### PR TITLE
Adjust event time constraints on each event handle

### DIFF
--- a/server/handlers/event.go
+++ b/server/handlers/event.go
@@ -79,6 +79,9 @@ func validateEventTimestamp(evt nostr.Event) bool {
 		return false
 	}
 
+	// Adjust event time constraints in the configuration
+	utils.AdjustEventTimeConstraints(cfg)
+
 	// Use current time for max and a fixed date for min if not specified
 	now := time.Now().Unix()
 	minCreatedAt := cfg.EventTimeConstraints.MinCreatedAt


### PR DESCRIPTION
Added line to update event time constraints on each `EVENT` handle to ensure `cfg.EventTimeConstraints.MaxCreatedAt` is updating to 5 minutes ahead of `now.Unix()` when event is handled, rather than relay start time as mentioned in https://github.com/0ceanSlim/grain/issues/28