### PR TITLE
fix: small bugs.

### DIFF
--- a/server/db/mongo/checkDuplicate.go
+++ b/server/db/mongo/checkDuplicate.go
@@ -2,10 +2,12 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	nostr "grain/server/types" // Adjust import path as needed
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // CheckDuplicateEvent checks if an event with the same ID already exists in the collection.
@@ -16,7 +18,7 @@ func CheckDuplicateEvent(ctx context.Context, evt nostr.Event) (bool, error) {
 	var existingEvent nostr.Event
 	err := collection.FindOne(ctx, filter).Decode(&existingEvent)
 	if err != nil {
-		if err.Error() == "mongo: no documents in result" {
+		if errors.Is(err, mongo.ErrNoDocuments) {
 			return false, nil // No duplicate found
 		}
 		return false, fmt.Errorf("error checking for duplicate event: %v", err)

--- a/server/db/mongo/kinds/addressable.go
+++ b/server/db/mongo/kinds/addressable.go
@@ -11,12 +11,12 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-// HandleParameterizedReplaceableKind handles parameterized replaceable events based on NIP-01 rules
-func HandleParameterizedReplaceableKind(ctx context.Context, evt relay.Event, collection *mongo.Collection, ws *websocket.Conn) error {
+// HandleAddressableKind handles parameterized replaceable events based on NIP-01 rules
+func HandleAddressableKind(ctx context.Context, evt relay.Event, collection *mongo.Collection, ws *websocket.Conn) error {
 	// Step 1: Extract the dTag from the event's tags
 	var dTag string
 	for _, tag := range evt.Tags {
-		if len(tag) > 0 && tag[0] == "d" {
+		if len(tag) >= 2 && tag[0] == "d" {
 			dTag = tag[1]
 			break
 		}

--- a/server/db/mongo/kinds/addressable.go
+++ b/server/db/mongo/kinds/addressable.go
@@ -22,6 +22,10 @@ func HandleAddressableKind(ctx context.Context, evt relay.Event, collection *mon
 		}
 	}
 
+	if dTag == "" {
+		return fmt.Errorf("no d tag is present in addressable event")
+	}
+
 	// Step 2: Create a filter to find the existing event based on pubkey, kind, and dTag
 	filter := bson.M{"pubkey": evt.PubKey, "kind": evt.Kind, "tags": bson.M{"$elemMatch": bson.M{"0": "d", "1": dTag}}}
 

--- a/server/db/mongo/storeMongo.go
+++ b/server/db/mongo/storeMongo.go
@@ -15,26 +15,20 @@ func StoreMongoEvent(ctx context.Context, evt nostr.Event, ws *websocket.Conn) {
 
 	var err error
 	switch {
-	case evt.Kind == 0:
-		err = kinds.HandleReplaceableKind(ctx, evt, collection, ws)
-	case evt.Kind == 1:
-		err = kinds.HandleRegularKind(ctx, evt, collection, ws)
 	case evt.Kind == 2:
 		err = kinds.HandleDeprecatedKind(ctx, evt, ws)
-	case evt.Kind == 3:
-		err = kinds.HandleReplaceableKind(ctx, evt, collection, ws)
 	case evt.Kind == 5:
 		err = kinds.HandleDeleteKind(ctx, evt, GetClient(), ws)
-	case evt.Kind >= 4 && evt.Kind < 45:
+	case (evt.Kind >= 1000 && evt.Kind < 10000) ||
+		(evt.Kind >= 4 && evt.Kind < 45) || evt.Kind == 1:
 		err = kinds.HandleRegularKind(ctx, evt, collection, ws)
-	case evt.Kind >= 1000 && evt.Kind < 10000:
-		err = kinds.HandleRegularKind(ctx, evt, collection, ws)
-	case evt.Kind >= 10000 && evt.Kind < 20000:
+	case (evt.Kind >= 10000 && evt.Kind < 20000) ||
+		evt.Kind == 0 || evt.Kind == 3:
 		err = kinds.HandleReplaceableKind(ctx, evt, collection, ws)
 	case evt.Kind >= 20000 && evt.Kind < 30000:
 		fmt.Println("Ephemeral event received and ignored:", evt.ID)
 	case evt.Kind >= 30000 && evt.Kind < 40000:
-		err = kinds.HandleParameterizedReplaceableKind(ctx, evt, collection, ws)
+		err = kinds.HandleAddressableKind(ctx, evt, collection, ws)
 	default:
 		err = kinds.HandleUnknownKind(ctx, evt, collection, ws)
 	}


### PR DESCRIPTION
1. better to check errors in a standard way. constant string is not a good approach.
2. the parameterized replaceable is gone. we have addressable.
3. checking d tag len is not safe. 

send this event:

```json
["EVENT",{"kind":30000,"id":"3814f2ec3cfd4395341d5b121bc59a29379fd8deaa6e53f6c5d6e94728cff377","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1736937513,"tags":[["d"]],"content":"","sig":"e347443a81c4e7b0e41594e63143ca5c9d9c27a5c155c6fa044c765be573cecc71d00323dc48993b4d666ca117fb9a0a81f549b373852687e88662404ec6c53d"}]
```

it closes the connection. i can guess it panic and then recover itself. using this change it returns a proper error tothe  user.

4. some cases on this switch case were duplicated.

also, you are reading config on some handlers each time. not a performant way. there are different ways to do it properly.

the last thing is checking duplicated events, don't make a mongo query for them. use a hash map or bloom filter. 

you can look at immortal as an example: https://github.com/dezh-tech/immortal

