### PR TITLE
v0.8.0 — client library, frontend reference, dashboard & relay management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,6 +361,10 @@ jobs:
         run: |
           set -euo pipefail
           go install github.com/swaggo/swag/cmd/swag@v1.16.4
+          # Seed a placeholder so `go list` (run by swag) can resolve the
+          # //go:embed of swagger.json before swag regenerates the real spec.
+          mkdir -p docs/openapi
+          printf '%s' '{"swagger":"2.0","info":{"title":"grain","version":"dev"},"paths":{}}' > docs/openapi/swagger.json
           "$(go env GOPATH)/bin/swag" init --parseDependency --parseInternal -g main.go -o docs/openapi -ot json
 
       - name: Build grain binary (Unix)
@@ -385,6 +389,10 @@ jobs:
         run: |
           set -euo pipefail
           go install github.com/swaggo/swag/cmd/swag@v1.16.4
+          # Seed a placeholder so `go list` (run by swag) can resolve the
+          # //go:embed of swagger.json before swag regenerates the real spec.
+          mkdir -p docs/openapi
+          printf '%s' '{"swagger":"2.0","info":{"title":"grain","version":"dev"},"paths":{}}' > docs/openapi/swagger.json
           "$(go env GOPATH)/bin/swag" init --parseDependency --parseInternal -g main.go -o docs/openapi -ot json
 
       - name: Build grain binary (Windows)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ DEV_COMPOSE = docker compose -f docs/docker/docker-compose.dev.yml
 # package directory and pull in swaggo/swag's API surface, which we
 # don't actually consume at runtime.
 generate:
+	mkdir -p docs/openapi
+	@[ -s docs/openapi/swagger.json ] || printf '%s' '{"swagger":"2.0","info":{"title":"grain","version":"dev"},"paths":{}}' > docs/openapi/swagger.json
 	swag init --parseDependency --parseInternal -g main.go -o docs/openapi -ot json
 
 # Bring up a single fresh dev relay built from the working tree.

--- a/client/admin.go
+++ b/client/admin.go
@@ -407,6 +407,7 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 			}},
 		{ID: "event_time_constraints", Title: "Event time constraints", Icon: "⏱️", Method: "grain_updateeventtimeconstraints", Config: cfg.EventTimeConstraints},
 		{ID: "backup_relay", Title: "Backup relay", Icon: "🪞", Method: "grain_updatebackuprelay", Config: cfg.BackupRelay},
+		{ID: "client", Title: "Client", Icon: "🧩", Method: "grain_updateclient", Config: cfg.Client},
 		{ID: "rate_limit", Title: "Rate limit", Icon: "🚦", Method: "grain_updateratelimit",
 			Config: RateLimitSectionData{
 				Config:              cfg.RateLimit,

--- a/client/admin.go
+++ b/client/admin.go
@@ -396,7 +396,7 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 
 	sections := []AdminSection{
 		{ID: "ops", Title: "Operations", Icon: "🛠️", Method: "", Config: nil},
-		{ID: "relay_info", Title: "Relay information", Icon: "📛", Method: "",
+		{ID: "relay_info", Title: "Relay information", Icon: "🪪", Method: "",
 			Config: func() OpsSectionData {
 				m := utils.GetRelayMetadataCopy()
 				return OpsSectionData{
@@ -486,6 +486,10 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 			}()},
 	}
 
+	// Operator-facing display order: the highest-traffic sections first; any not
+	// listed keep their definition order behind them.
+	sections = orderSections(sections, "ops", "relay_info", "server", "rate_limit", "resource_limits", "whitelist", "blacklist")
+
 	data := AdminPageData{
 		Title:      "🌾 grain — admin",
 		Owner:      owner,
@@ -493,6 +497,31 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 		KindLabels: KindLabels,
 	}
 	renderAdmin(w, data)
+}
+
+// orderSections returns sections with the given IDs first, in the order given;
+// any section not named keeps its original position behind them. Lets the
+// definition block stay grouped by concern while the display order is curated.
+func orderSections(sections []AdminSection, firstIDs ...string) []AdminSection {
+	listed := make(map[string]bool, len(firstIDs))
+	for _, id := range firstIDs {
+		listed[id] = true
+	}
+	out := make([]AdminSection, 0, len(sections))
+	for _, id := range firstIDs {
+		for _, s := range sections {
+			if s.ID == id {
+				out = append(out, s)
+				break
+			}
+		}
+	}
+	for _, s := range sections {
+		if !listed[s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // renderAdmin parses the admin template against the shared layout and

--- a/client/admin.go
+++ b/client/admin.go
@@ -395,6 +395,21 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 	wl := config.GetWhitelistConfig()
 
 	sections := []AdminSection{
+		{ID: "ops", Title: "Operations", Icon: "🛠️", Method: "", Config: nil},
+		{ID: "relay_info", Title: "Relay information", Icon: "📛", Method: "",
+			Config: func() OpsSectionData {
+				m := utils.GetRelayMetadataCopy()
+				return OpsSectionData{
+					RelayName:           m.Name,
+					RelayDescription:    m.Description,
+					RelayIcon:           m.Icon,
+					RelayBanner:         m.Banner,
+					RelayContact:        m.Contact,
+					RelayPrivacyPolicy:  m.PrivacyPolicy,
+					RelayTermsOfService: m.TermsOfService,
+					RelayPostingPolicy:  m.PostingPolicy,
+				}
+			}()},
 		{ID: "logging", Title: "Logging", Icon: "📜", Method: "grain_updatelogging",
 			Config: LoggingSectionData{Config: cfg.Logging, AllComponents: log.GetAllComponents()}},
 		{ID: "auth", Title: "Auth", Icon: "🔐", Method: "grain_updateauth", Config: cfg.Auth},
@@ -467,20 +482,6 @@ func HandleAdmin(w http.ResponseWriter, r *http.Request) {
 					OwnerMutelistCount:    ownerCount,
 					OwnerMutelistSynced:   ownerSynced,
 					OwnerMutelistPubkeys:  ownerMutes,
-				}
-			}()},
-		{ID: "ops", Title: "Operations", Icon: "🛠️", Method: "",
-			Config: func() OpsSectionData {
-				m := utils.GetRelayMetadataCopy()
-				return OpsSectionData{
-					RelayName:           m.Name,
-					RelayDescription:    m.Description,
-					RelayIcon:           m.Icon,
-					RelayBanner:         m.Banner,
-					RelayContact:        m.Contact,
-					RelayPrivacyPolicy:  m.PrivacyPolicy,
-					RelayTermsOfService: m.TermsOfService,
-					RelayPostingPolicy:  m.PostingPolicy,
 				}
 			}()},
 	}

--- a/client/api/appRelays.go
+++ b/client/api/appRelays.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// AppRelaysPayload is the session's locally-configured ("app") relay roles —
+// editable preferences seeded from the operator's config, not published Nostr
+// lists. Indexer drives discovery; Broadcast mirrors writes; Local/Trusted are
+// stored but inert until their wiring lands (Local routing; Trusted NIP-42 AUTH).
+type AppRelaysPayload struct {
+	Indexer   []string `json:"indexer"`
+	Broadcast []string `json:"broadcast"`
+	Local     []string `json:"local"`
+	Trusted   []string `json:"trusted"`
+}
+
+// AppRelaysHandler gets (GET) or replaces (POST) the session's app-relay
+// preferences. POST sets all four roles from the payload; an empty list clears
+// that role (Indexer then falls back to the configured default). Session-gated.
+//
+// @Summary      Get or set app-relay preferences
+// @Description  The session's locally-configured Indexer/Broadcast/Local/Trusted relays. GET returns them; POST replaces them.
+// @Tags         client
+// @Produce      json
+// @Success      200  {object}  AppRelaysPayload
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/client/app-relays [get]
+func AppRelaysHandler(w http.ResponseWriter, r *http.Request) {
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		var req AppRelaysPayload
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+		cc.SetAppRelays(core.RoleIndexer, req.Indexer)
+		cc.SetAppRelays(core.RoleBroadcast, req.Broadcast)
+		cc.SetAppRelays(core.RoleLocal, req.Local)
+		cc.SetAppRelays(core.RoleTrusted, req.Trusted)
+		log.ClientAPI().Info("App relays updated", "pubkey", sess.PublicKey)
+	}
+
+	resp := AppRelaysPayload{
+		Indexer:   cc.AppRelays(core.RoleIndexer),
+		Broadcast: cc.AppRelays(core.RoleBroadcast),
+		Local:     cc.AppRelays(core.RoleLocal),
+		Trusted:   cc.AppRelays(core.RoleTrusted),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.ClientAPI().Error("Failed to encode app relays", "error", err)
+	}
+}

--- a/client/api/clientStatus.go
+++ b/client/api/clientStatus.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// ClientStatusHandler returns the core client's relay-pool status — how many
+// relays are tracked versus currently connected — for the dashboard's relay
+// indicator.
+//
+// @Summary      Core client relay status
+// @Description  Relay pool counts (total, connected, pinned, leased) plus the index relay seed list.
+// @Tags         client
+// @Produce      json
+// @Success      200  {object}  map[string]interface{}
+// @Failure      405  {string}  string  "Method not allowed"
+// @Router       /api/v1/client/status [get]
+func ClientStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	status := connection.GetCoreClientStatus()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		log.ClientAPI().Error("Failed to encode client status", "error", err)
+	}
+}

--- a/client/api/clienttag.go
+++ b/client/api/clienttag.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/config"
+)
+
+// resolveClientTag decides whether grain stamps its `client` tag on an event it
+// builds, and under what name. The configured default (#80/#99) is overridden
+// per-build by the user's settings slider — `override` is nil when the request
+// carries no preference, in which case the default applies. Foreign `client`
+// tags are always stripped regardless (see core.ApplyClientTag).
+func resolveClientTag(override *bool) (enabled bool, name string) {
+	enabled, name = true, core.DefaultClientTagName
+	if cfg := config.GetConfig(); cfg != nil {
+		enabled = cfg.Client.ClientTag.Enabled
+		if cfg.Client.ClientTag.Name != "" {
+			name = cfg.Client.ClientTag.Name
+		}
+	}
+	if override != nil {
+		enabled = *override
+	}
+	return enabled, name
+}

--- a/client/api/events.go
+++ b/client/api/events.go
@@ -194,7 +194,7 @@ func GetUserProfileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch profile
-	profile, err := coreClient.GetUserProfile(pubkey, nil)
+	profile, err := coreClient.GetUserProfile(r.Context(), pubkey, nil)
 	if err != nil {
 		log.ClientAPI().Error("Failed to fetch user profile", "pubkey", pubkey, "error", err)
 		http.Error(w, "Profile not found", http.StatusNotFound)
@@ -308,7 +308,7 @@ func QueryEventsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create subscription to fetch events
-	sub, err := coreClient.Subscribe(filters, nil)
+	sub, err := coreClient.Subscribe(r.Context(), filters, nil)
 	if err != nil {
 		log.ClientAPI().Error("Failed to create subscription", "error", err)
 		http.Error(w, "Query failed", http.StatusInternalServerError)

--- a/client/api/events.go
+++ b/client/api/events.go
@@ -111,7 +111,7 @@ func PublishEventHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build, sign, and publish
-	event, results, err := core.PublishEvent(coreClient, signer, eventBuilder, req.Relays)
+	event, results, err := core.PublishEvent(r.Context(), coreClient, signer, eventBuilder, req.Relays)
 	if err != nil {
 		log.ClientAPI().Error("Failed to publish event", "error", err)
 		sendEventResponse(w, PublishEventResponse{

--- a/client/api/events.go
+++ b/client/api/events.go
@@ -320,6 +320,13 @@ func QueryEventsHandler(w http.ResponseWriter, r *http.Request) {
 	eventMap := make(map[string]*nostr.Event)
 	timeout := time.After(8 * time.Second)
 
+	// Track EOSE per relay so the query finishes the moment every relay has
+	// sent all its stored events, instead of always waiting out the 8s timeout.
+	// (sub.Done is only closed by sub.Close(); EOSE arrives on sub.EOSE — the
+	// same bug fixed for GetUserRelays in #77.)
+	eoseRelays := make(map[string]bool)
+	totalRelays := sub.GetRelayCount()
+
 	// Get the limit from the first filter (if any)
 	var requestedLimit int
 	if len(filters) > 0 && filters[0].Limit != nil {
@@ -356,10 +363,14 @@ func QueryEventsHandler(w http.ResponseWriter, r *http.Request) {
 					"unique_count", len(eventMap))
 			}
 
-		case <-sub.Done:
-			// Subscription completed (EOSE received from all relays)
-			log.ClientAPI().Debug("Subscription completed (EOSE)", "unique_count", len(eventMap))
-			goto sendResponse
+		case relayURL := <-sub.EOSE:
+			// A relay has sent all its stored events. Finish once they all have.
+			eoseRelays[relayURL] = true
+			if len(eoseRelays) >= totalRelays {
+				log.ClientAPI().Debug("All relays sent EOSE",
+					"unique_count", len(eventMap), "eose_relays", len(eoseRelays))
+				goto sendResponse
+			}
 
 		case <-timeout:
 			log.ClientAPI().Debug("Query timeout reached", "unique_count", len(eventMap))

--- a/client/api/knownRelays.go
+++ b/client/api/knownRelays.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// KnownRelaysHandler lists every relay the client is aware of (the "known" set:
+// config seeds + pooled + directory-resolved) with its live pool status, for the
+// relay manager's known-relays browser. Per-relay NIP-11 detail is fetched
+// lazily via /api/v1/relay-info. Session-gated.
+//
+// @Summary      List known relays
+// @Description  Every relay the client is aware of, with live pool status (connected/pinned/leased).
+// @Tags         client
+// @Produce      json
+// @Success      200  {array}   core.KnownRelayStatus
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/client/known-relays [get]
+func KnownRelaysHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(cc.KnownRelaysWithStatus()); err != nil {
+		log.ClientAPI().Error("Failed to encode known relays", "error", err)
+	}
+}
+
+// RelayInfoHandler returns a relay's NIP-11 document (TTL-cached) for the
+// known-relays browser's per-relay detail. Query: ?url=<relay url>. Returns an
+// empty object when the relay advertises no NIP-11. Session-gated.
+//
+// @Summary      Get a relay's NIP-11 info
+// @Description  A relay's NIP-11 document (name, software, supported NIPs, auth/payment flags), cached.
+// @Tags         client
+// @Produce      json
+// @Param        url  query     string  true  "Relay URL"
+// @Success      200  {object}  core.RelayInfo
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/relay-info [get]
+func RelayInfoHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	url := r.URL.Query().Get("url")
+	if url == "" {
+		http.Error(w, "url parameter required", http.StatusBadRequest)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	info := cc.FetchRelayInfo(url)
+	if info == nil {
+		_, _ = w.Write([]byte("{}")) // no NIP-11 advertised — empty, not an error
+		return
+	}
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		log.ClientAPI().Error("Failed to encode relay info", "error", err)
+	}
+}

--- a/client/api/mediaServers.go
+++ b/client/api/mediaServers.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// MediaServerEntry is a resolved media server annotated with grain's static
+// capability metadata (when the server is one grain knows).
+type MediaServerEntry struct {
+	URL       string `json:"url"`
+	Kind      string `json:"kind"`                // "blossom" | "nip96"
+	Primary   bool   `json:"primary"`             // first in its list (the upload default)
+	Name      string `json:"name,omitempty"`      // display name, when known
+	Cost      string `json:"cost,omitempty"`      // "free" | "paid" | "" (unknown)
+	Retention string `json:"retention,omitempty"` // "permanent" | "ephemeral" | "" (unknown)
+	Mirror    bool   `json:"mirror"`              // accepts BUD-04 /mirror
+	Note      string `json:"note,omitempty"`
+	CTA       string `json:"cta,omitempty"`
+	Known     bool   `json:"known"` // grain has capability metadata for this URL
+}
+
+// UserMediaServersResponse is a user's resolved Blossom + NIP-96 media-server
+// lists. HasAny drives the "set up media servers" prompt on upload.
+type UserMediaServersResponse struct {
+	Pubkey  string             `json:"pubkey"`
+	HasAny  bool               `json:"hasAny"`
+	Blossom []MediaServerEntry `json:"blossom"`
+	NIP96   []MediaServerEntry `json:"nip96"`
+}
+
+// GetUserMediaServersHandler resolves a user's Blossom (kind 10063) and NIP-96
+// (kind 10096) media-server lists and annotates each entry with grain's static
+// capability metadata. Defaults to the session user when no pubkey is given.
+//
+// @Summary      Get a user's media servers
+// @Description  Resolve a user's Blossom (kind 10063) and NIP-96 (kind 10096) media-server lists, annotated with grain's capability metadata. Defaults to the session user.
+// @Tags         client
+// @Produce      json
+// @Param        pubkey  query     string  false  "Hex pubkey (defaults to the session user)"
+// @Success      200     {object}  UserMediaServersResponse
+// @Failure      401     {string}  string  "Authentication required or pubkey parameter needed"
+// @Router       /api/v1/user/media-servers [get]
+func GetUserMediaServersHandler(w http.ResponseWriter, r *http.Request) {
+	pubkey := r.URL.Query().Get("pubkey")
+	if pubkey == "" {
+		sess := session.SessionMgr.GetCurrentUser(r)
+		if sess == nil {
+			http.Error(w, "Authentication required or pubkey parameter needed", http.StatusUnauthorized)
+			return
+		}
+		pubkey = sess.PublicKey
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	media := coreClient.ResolveMediaServers(pubkey)
+	resp := UserMediaServersResponse{
+		Pubkey:  pubkey,
+		HasAny:  media.HasAny(),
+		Blossom: annotateMediaServers(media.Blossom, core.MediaKindBlossom),
+		NIP96:   annotateMediaServers(media.NIP96, core.MediaKindNIP96),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.ClientAPI().Error("Failed to encode media servers response", "error", err)
+	}
+}
+
+// annotateMediaServers pairs each resolved URL with grain's capability metadata,
+// flagging the first entry as the primary (the default upload target).
+func annotateMediaServers(urls []string, kind string) []MediaServerEntry {
+	entries := make([]MediaServerEntry, 0, len(urls))
+	for i, u := range urls {
+		entry := MediaServerEntry{URL: u, Kind: kind, Primary: i == 0}
+		if info, ok := core.LookupMediaServerInfo(u); ok {
+			entry.Name = info.Name
+			entry.Cost = info.Cost
+			entry.Retention = info.Retention
+			entry.Mirror = info.Mirror
+			entry.Note = info.Note
+			entry.CTA = info.CTA
+			entry.Known = true
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// GetSuggestedMediaServersHandler returns grain's curated quick-add media-server
+// suggestions (Blossom preferred, NIP-96 legacy fallback) for the settings page.
+//
+// @Summary      Get suggested media servers
+// @Description  grain's curated quick-add media-server suggestions, Blossom preferred with NIP-96 as a legacy fallback.
+// @Tags         client
+// @Produce      json
+// @Success      200  {array}  core.MediaServerInfo
+// @Router       /api/v1/media-servers/suggested [get]
+func GetSuggestedMediaServersHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(core.SuggestedMediaServers()); err != nil {
+		log.ClientAPI().Error("Failed to encode suggested media servers", "error", err)
+	}
+}

--- a/client/api/mediaServers.go
+++ b/client/api/mediaServers.go
@@ -97,6 +97,65 @@ func annotateMediaServers(urls []string, kind string) []MediaServerEntry {
 	return entries
 }
 
+// MediaServersBuildRequest carries the desired ordered server list for one
+// media-server list kind.
+type MediaServersBuildRequest struct {
+	Kind    int      `json:"kind"`    // 10063 (Blossom) or 10096 (NIP-96)
+	Servers []string `json:"servers"` // ordered base URLs, primary first
+}
+
+// BuildMediaServersHandler assembles an UNSIGNED media-server list event for the
+// session user, preserving any non-server tags on their existing list, and
+// returns it for the browser to sign. Publish the signed event via
+// /api/v1/events/publish.
+//
+// @Summary      Build a media-server list event
+// @Description  Assemble an unsigned Blossom (10063) or NIP-96 (10096) server-list event for the session user, preserving non-server tags, and return it to sign client-side.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  nostr.Event
+// @Failure      400  {string}  string  "Invalid request"
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/user/media-servers/build [post]
+func BuildMediaServersHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req MediaServersBuildRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	// Fetch the user's existing list so non-server tags survive the rewrite.
+	existing := coreClient.FetchMediaServerList(sess.PublicKey, req.Kind)
+	unsigned, err := core.AssembleMediaServerEvent(existing, req.Kind, sess.PublicKey, req.Servers)
+	if err != nil {
+		log.ClientAPI().Warn("Media-server build failed", "pubkey", sess.PublicKey, "kind", req.Kind, "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(unsigned); err != nil {
+		log.ClientAPI().Error("Failed to encode built media-server event", "error", err)
+	}
+}
+
 // GetSuggestedMediaServersHandler returns grain's curated quick-add media-server
 // suggestions (Blossom preferred, NIP-96 legacy fallback) for the settings page.
 //

--- a/client/api/mediaServers.go
+++ b/client/api/mediaServers.go
@@ -63,6 +63,12 @@ func GetUserMediaServersHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ?refresh=1 drops any cached (possibly stale/negative) result first, so the
+	// "no media servers" prompt can recover from a transient empty resolve.
+	if r.URL.Query().Get("refresh") == "1" {
+		coreClient.InvalidateMediaServers(pubkey)
+	}
+
 	media := coreClient.ResolveMediaServers(pubkey)
 	resp := UserMediaServersResponse{
 		Pubkey:  pubkey,

--- a/client/api/mediaServers.go
+++ b/client/api/mediaServers.go
@@ -115,7 +115,7 @@ type MediaServersBuildRequest struct {
 // @Tags         client
 // @Accept       json
 // @Produce      json
-// @Success      200  {object}  nostr.Event
+// @Success      200  {object}  relay.Event
 // @Failure      400  {string}  string  "Invalid request"
 // @Failure      401  {string}  string  "Authentication required"
 // @Router       /api/v1/user/media-servers/build [post]

--- a/client/api/mediaServers.go
+++ b/client/api/mediaServers.go
@@ -100,8 +100,9 @@ func annotateMediaServers(urls []string, kind string) []MediaServerEntry {
 // MediaServersBuildRequest carries the desired ordered server list for one
 // media-server list kind.
 type MediaServersBuildRequest struct {
-	Kind    int      `json:"kind"`    // 10063 (Blossom) or 10096 (NIP-96)
-	Servers []string `json:"servers"` // ordered base URLs, primary first
+	Kind      int      `json:"kind"`                 // 10063 (Blossom) or 10096 (NIP-96)
+	Servers   []string `json:"servers"`              // ordered base URLs, primary first
+	ClientTag *bool    `json:"client_tag,omitempty"` // nil = config default; else per-user override (#99)
 }
 
 // BuildMediaServersHandler assembles an UNSIGNED media-server list event for the
@@ -149,6 +150,9 @@ func BuildMediaServersHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	en, nm := resolveClientTag(req.ClientTag)
+	core.ApplyClientTag(unsigned, en, nm)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(unsigned); err != nil {

--- a/client/api/nip42.go
+++ b/client/api/nip42.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/session"
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// AuthRequestsHandler lists the relays that have issued a NIP-42 AUTH challenge
+// this session, each with whether we've already authed. Session-gated.
+//
+// @Summary      List NIP-42 AUTH requests
+// @Description  Relays that have challenged the client for AUTH, with session authed status.
+// @Tags         client
+// @Produce      json
+// @Success      200  {array}   core.AuthState
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/client/auth-requests [get]
+func AuthRequestsHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(cc.AuthRequests()); err != nil {
+		log.ClientAPI().Error("Failed to encode auth requests", "error", err)
+	}
+}
+
+// SubmitAuthHandler relays a browser-signed kind-22242 event to a relay,
+// answering its NIP-42 challenge. The browser builds + signs the event (it holds
+// the key); grain only forwards it on the challenged connection. Session-gated.
+//
+// @Summary      Answer a NIP-42 AUTH challenge
+// @Description  Relay a browser-signed kind-22242 auth event to a relay.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Param        body  body      object{relay=string,event=object}  true  "Relay URL + signed kind-22242 event"
+// @Success      200   {object}  map[string]any
+// @Failure      400   {string}  string  "Invalid request"
+// @Failure      401   {string}  string  "Authentication required"
+// @Router       /api/v1/client/auth [post]
+func SubmitAuthHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Relay string       `json:"relay"`
+		Event *nostr.Event `json:"event"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request format", http.StatusBadRequest)
+		return
+	}
+	if req.Relay == "" || req.Event == nil {
+		http.Error(w, "relay and event are required", http.StatusBadRequest)
+		return
+	}
+	if req.Event.Kind != 22242 {
+		http.Error(w, "event must be kind 22242 (NIP-42)", http.StatusBadRequest)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	if err := cc.SendAuth(req.Relay, req.Event); err != nil {
+		log.ClientAPI().Warn("Failed to send AUTH", "relay", req.Relay, "error", err)
+		writeJSON(w, http.StatusOK, map[string]any{"success": false, "error": err.Error()})
+		return
+	}
+	log.ClientAPI().Info("Sent NIP-42 AUTH", "relay", req.Relay)
+	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+}
+
+// RemoveAuthHandler forgets a relay's session AUTH state (revoke trust).
+// Session-gated.
+//
+// @Summary      Revoke a relay's session AUTH
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Param        body  body      object{relay=string}  true  "Relay URL"
+// @Success      200   {object}  map[string]any
+// @Failure      401   {string}  string  "Authentication required"
+// @Router       /api/v1/client/auth/remove [post]
+func RemoveAuthHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Relay string `json:"relay"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Relay == "" {
+		http.Error(w, "relay is required", http.StatusBadRequest)
+		return
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	cc.RemoveAuth(req.Relay)
+	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+}
+
+// writeJSON writes v as a JSON response with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.ClientAPI().Error("Failed to encode JSON response", "error", err)
+	}
+}

--- a/client/api/pingRelays.go
+++ b/client/api/pingRelays.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// PingRelaysHandler measures TCP-connect latency for a set of relays, for the
+// known-relays browser's "fastest first" sort. The browser sends only the rows
+// currently in view (capped here too), so this never probes the whole known set.
+// Session-gated. Results are short-TTL-cached server-side.
+//
+// @Summary      Ping relays
+// @Description  TCP-connect latency (ms, -1 = unreachable) for a set of relays. Capped at 80 URLs per call.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Param        body  body      object{urls=[]string}  true  "Relay URLs to ping"
+// @Success      200   {object}  map[string]int
+// @Failure      401   {string}  string  "Authentication required"
+// @Router       /api/v1/relays/ping [post]
+func PingRelaysHandler(w http.ResponseWriter, r *http.Request) {
+	if session.SessionMgr.GetCurrentUser(r) == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		URLs []string `json:"urls"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request format", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if len(req.URLs) == 0 {
+		_, _ = w.Write([]byte("{}"))
+		return
+	}
+	const maxURLs = 80
+	if len(req.URLs) > maxURLs {
+		req.URLs = req.URLs[:maxURLs]
+	}
+	cc := connection.GetCoreClient()
+	if cc == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	if err := json.NewEncoder(w).Encode(cc.PingRelays(req.URLs)); err != nil {
+		log.ClientAPI().Error("Failed to encode relay pings", "error", err)
+	}
+}

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -171,3 +171,104 @@ func writeSignedResponse(w http.ResponseWriter, status int, resp PublishSignedRe
 		log.ClientAPI().Error("Failed to encode publish response", "error", err)
 	}
 }
+
+// publishStreamMsg is one NDJSON line of a streaming publish: a "start" line
+// carrying the target relay list, a "result" line per relay as it resolves, and
+// a final "done" line.
+type publishStreamMsg struct {
+	Type     string   `json:"type"`             // "start" | "result" | "done"
+	Relays   []string `json:"relays,omitempty"` // start: the target relays
+	RelayURL string   `json:"relayURL,omitempty"`
+	Sent     bool     `json:"sent"`     // the EVENT was delivered
+	Accepted bool     `json:"accepted"` // the relay's NIP-20 OK verdict
+	Reason   string   `json:"reason,omitempty"`
+	Message  string   `json:"message,omitempty"` // send-failure detail
+}
+
+// PublishSignedStreamHandler is the streaming counterpart of
+// PublishSignedHandler: it broadcasts a client-signed event and streams each
+// relay's result as NDJSON (one JSON object per line) the moment it resolves, so
+// the browser can show a live, count-up broadcast toast.
+//
+// @Summary      Publish a pre-signed event (streaming)
+// @Description  Verify a client-signed event belongs to the session user, broadcast it via the outbox model, and stream per-relay results as newline-delimited JSON.
+// @Tags         client-events
+// @Accept       json
+// @Produce      application/x-ndjson
+// @Success      200  {string}  string  "NDJSON stream of start/result/done lines"
+// @Failure      401  {string}  string  "Authentication required"
+// @Failure      403  {string}  string  "Pubkey mismatch"
+// @Router       /api/v1/events/publish/stream [post]
+func PublishSignedStreamHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req PublishSignedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Event == nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Event.PubKey != sess.PublicKey {
+		http.Error(w, "Event pubkey does not match the session", http.StatusForbidden)
+		return
+	}
+	if !core.VerifyEventSignature(req.Event) {
+		http.Error(w, "Invalid event signature", http.StatusBadRequest)
+		return
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	relays := coreClient.RoutePublish(req.Event)
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no") // tell any proxy not to buffer the stream
+	enc := json.NewEncoder(w)
+
+	_ = enc.Encode(publishStreamMsg{Type: "start", Relays: relays})
+	flusher.Flush()
+
+	for res := range coreClient.PublishEventStream(req.Event, relays) {
+		msg := publishStreamMsg{
+			Type:     "result",
+			RelayURL: res.RelayURL,
+			Sent:     res.Success,
+			Accepted: res.Accepted,
+			Reason:   res.Reason,
+		}
+		if !res.Success {
+			msg.Message = res.Message
+		}
+		_ = enc.Encode(msg)
+		flusher.Flush()
+	}
+
+	_ = enc.Encode(publishStreamMsg{Type: "done"})
+	flusher.Flush()
+
+	// Same cache invalidation as the non-streaming handler.
+	if req.Event.Kind == 10063 || req.Event.Kind == 10096 {
+		coreClient.InvalidateMediaServers(req.Event.PubKey)
+	}
+	if req.Event.Kind == 10002 || req.Event.Kind == 10050 {
+		coreClient.InvalidateUserRelays(req.Event.PubKey)
+	}
+	log.ClientAPI().Info("Streamed signed event publish", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))
+}

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -145,7 +145,7 @@ func PublishSignedHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	relays := coreClient.RoutePublish(req.Event)
-	results, err := coreClient.PublishEvent(req.Event, relays)
+	results, err := coreClient.PublishEvent(r.Context(), req.Event, relays)
 	if err != nil {
 		writeSignedResponse(w, http.StatusInternalServerError, PublishSignedResponse{Error: err.Error(), Relays: relays})
 		return
@@ -264,7 +264,7 @@ func PublishSignedStreamHandler(w http.ResponseWriter, r *http.Request) {
 	_ = enc.Encode(publishStreamMsg{Type: "start", Relays: relays})
 	flusher.Flush()
 
-	for res := range coreClient.PublishEventStream(req.Event, relays) {
+	for res := range coreClient.PublishEventStream(r.Context(), req.Event, relays) {
 		msg := publishStreamMsg{
 			Type:     "result",
 			RelayURL: res.RelayURL,

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -31,7 +31,7 @@ type ProfileBuildRequest struct {
 // @Tags         client
 // @Accept       json
 // @Produce      json
-// @Success      200  {object}  nostr.Event
+// @Success      200  {object}  relay.Event
 // @Failure      400  {string}  string  "Invalid request"
 // @Failure      401  {string}  string  "Authentication required"
 // @Failure      403  {string}  string  "Pubkey mismatch"

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/session"
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// ProfileBuildRequest carries the user's existing kind-0 event and the field
+// edits to apply.
+type ProfileBuildRequest struct {
+	Event *nostr.Event      `json:"event"` // existing kind-0 (may be null for a first profile)
+	Edits map[string]string `json:"edits"`
+}
+
+// BuildProfileHandler merges the supplied field edits over the user's existing
+// kind-0 metadata and returns the UNSIGNED result for the browser to sign. The
+// merge preserves every existing content field and tag — only edited fields are
+// changed, and each is dual-written to content and a tag (see
+// core.AssembleProfileEvent).
+//
+// @Summary      Build an updated profile event
+// @Description  Merge field edits over an existing kind-0 (preserving all other fields/tags) and return the unsigned event to sign client-side.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  nostr.Event
+// @Failure      400  {string}  string  "Invalid request"
+// @Failure      401  {string}  string  "Authentication required"
+// @Failure      403  {string}  string  "Pubkey mismatch"
+// @Router       /api/v1/user/profile/build [post]
+func BuildProfileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req ProfileBuildRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Edits) == 0 {
+		http.Error(w, "No edits provided", http.StatusBadRequest)
+		return
+	}
+
+	existing := req.Event
+	if existing == nil {
+		existing = &nostr.Event{}
+	}
+	// You can only build your OWN profile.
+	if existing.PubKey != "" && existing.PubKey != sess.PublicKey {
+		http.Error(w, "Existing event pubkey does not match the session", http.StatusForbidden)
+		return
+	}
+	existing.PubKey = sess.PublicKey
+
+	unsigned, err := core.AssembleProfileEvent(existing, req.Edits)
+	if err != nil {
+		log.ClientAPI().Warn("Profile build failed", "pubkey", sess.PublicKey, "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(unsigned); err != nil {
+		log.ClientAPI().Error("Failed to encode built profile event", "error", err)
+	}
+}
+
+// PublishSignedRequest carries a fully-signed event to broadcast.
+type PublishSignedRequest struct {
+	Event *nostr.Event `json:"event"`
+}
+
+// PublishSignedResponse reports where a signed event was published.
+type PublishSignedResponse struct {
+	Success bool                   `json:"success"`
+	EventID string                 `json:"eventId,omitempty"`
+	Relays  []string               `json:"relays"`
+	Results []core.BroadcastResult `json:"results"`
+	Error   string                 `json:"error,omitempty"`
+}
+
+// PublishSignedHandler broadcasts a client-signed event via the outbox model.
+// Unlike /api/v1/publish (which signs server-side from a private key), this
+// accepts an already-signed event — the dashboard signs with the user's
+// NIP-07 / NIP-46 / Amber signer in the browser.
+//
+// @Summary      Publish a pre-signed event
+// @Description  Verify a client-signed event belongs to the session user, then broadcast it to the outbox-routed relays.
+// @Tags         client-events
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  PublishSignedResponse
+// @Failure      400  {object}  PublishSignedResponse
+// @Failure      401  {string}  string  "Authentication required"
+// @Failure      403  {object}  PublishSignedResponse
+// @Router       /api/v1/events/publish [post]
+func PublishSignedHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req PublishSignedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Event == nil {
+		writeSignedResponse(w, http.StatusBadRequest, PublishSignedResponse{Error: "Invalid request body"})
+		return
+	}
+	if req.Event.PubKey != sess.PublicKey {
+		writeSignedResponse(w, http.StatusForbidden, PublishSignedResponse{Error: "Event pubkey does not match the session"})
+		return
+	}
+	if !core.VerifyEventSignature(req.Event) {
+		writeSignedResponse(w, http.StatusBadRequest, PublishSignedResponse{Error: "Invalid event signature"})
+		return
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		writeSignedResponse(w, http.StatusInternalServerError, PublishSignedResponse{Error: "Client not available"})
+		return
+	}
+
+	relays := coreClient.RoutePublish(req.Event)
+	results, err := coreClient.PublishEvent(req.Event, relays)
+	if err != nil {
+		writeSignedResponse(w, http.StatusInternalServerError, PublishSignedResponse{Error: err.Error(), Relays: relays})
+		return
+	}
+
+	log.ClientAPI().Info("Published signed event", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))
+	writeSignedResponse(w, http.StatusOK, PublishSignedResponse{
+		Success: true,
+		EventID: req.Event.ID,
+		Relays:  relays,
+		Results: results,
+	})
+}
+
+func writeSignedResponse(w http.ResponseWriter, status int, resp PublishSignedResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.ClientAPI().Error("Failed to encode publish response", "error", err)
+	}
+}

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -154,6 +154,10 @@ func PublishSignedHandler(w http.ResponseWriter, r *http.Request) {
 	if req.Event.Kind == 10002 || req.Event.Kind == 10050 {
 		coreClient.InvalidateUserRelays(req.Event.PubKey)
 	}
+	switch req.Event.Kind {
+	case 10002, 10050, 10006, 10007, 10012:
+		coreClient.InvalidateUserRelayLists(req.Event.PubKey)
+	}
 
 	log.ClientAPI().Info("Published signed event", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))
 	writeSignedResponse(w, http.StatusOK, PublishSignedResponse{
@@ -269,6 +273,10 @@ func PublishSignedStreamHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Event.Kind == 10002 || req.Event.Kind == 10050 {
 		coreClient.InvalidateUserRelays(req.Event.PubKey)
+	}
+	switch req.Event.Kind {
+	case 10002, 10050, 10006, 10007, 10012:
+		coreClient.InvalidateUserRelayLists(req.Event.PubKey)
 	}
 	log.ClientAPI().Info("Streamed signed event publish", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))
 }

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -146,6 +146,12 @@ func PublishSignedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A republished media-server list must show immediately — drop the cached
+	// resolution so the next lookup re-fetches the new list.
+	if req.Event.Kind == 10063 || req.Event.Kind == 10096 {
+		coreClient.InvalidateMediaServers(req.Event.PubKey)
+	}
+
 	log.ClientAPI().Info("Published signed event", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))
 	writeSignedResponse(w, http.StatusOK, PublishSignedResponse{
 		Success: true,

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -146,10 +146,13 @@ func PublishSignedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// A republished media-server list must show immediately — drop the cached
-	// resolution so the next lookup re-fetches the new list.
+	// A republished media-server or relay list must show immediately — drop the
+	// cached resolution so the next lookup re-fetches it.
 	if req.Event.Kind == 10063 || req.Event.Kind == 10096 {
 		coreClient.InvalidateMediaServers(req.Event.PubKey)
+	}
+	if req.Event.Kind == 10002 || req.Event.Kind == 10050 {
+		coreClient.InvalidateUserRelays(req.Event.PubKey)
 	}
 
 	log.ClientAPI().Info("Published signed event", "kind", req.Event.Kind, "event_id", req.Event.ID, "relay_count", len(relays))

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -15,8 +15,9 @@ import (
 // ProfileBuildRequest carries the user's existing kind-0 event and the field
 // edits to apply.
 type ProfileBuildRequest struct {
-	Event *nostr.Event      `json:"event"` // existing kind-0 (may be null for a first profile)
-	Edits map[string]string `json:"edits"`
+	Event     *nostr.Event      `json:"event"` // existing kind-0 (may be null for a first profile)
+	Edits     map[string]string `json:"edits"`
+	ClientTag *bool             `json:"client_tag,omitempty"` // nil = config default; else per-user override (#99)
 }
 
 // BuildProfileHandler merges the supplied field edits over the user's existing
@@ -73,6 +74,9 @@ func BuildProfileHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	en, nm := resolveClientTag(req.ClientTag)
+	core.ApplyClientTag(unsigned, en, nm)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(unsigned); err != nil {

--- a/client/api/profile.go
+++ b/client/api/profile.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/0ceanslim/grain/client/connection"
 	"github.com/0ceanslim/grain/client/core"
@@ -237,6 +238,16 @@ func PublishSignedStreamHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
 		return
+	}
+
+	// Opt out of the server's WriteTimeout: a broadcast to slow relays can run
+	// longer than the (few-second) deadline, which would otherwise cut the
+	// NDJSON stream and truncate the live toast's per-relay results. Same fix
+	// as StreamHandler.
+	if rc := http.NewResponseController(w); rc != nil {
+		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			log.ClientAPI().Debug("publish stream: could not clear write deadline", "error", err)
+		}
 	}
 
 	relays := coreClient.RoutePublish(req.Event)

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/0ceanslim/grain/client/connection"
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// RelayListBuildRequest carries the desired relay list for one kind.
+type RelayListBuildRequest struct {
+	Kind    int                   `json:"kind"`    // 10002 | 10050 | 10006 | 10007 | 10012
+	Entries []core.RelayListEntry `json:"entries"` // ordered; Read/Write apply to 10002 only
+}
+
+// BuildRelayListHandler assembles an UNSIGNED relay-list event for the session
+// user, preserving any non-relay tags on their existing list, and returns it for
+// the browser to sign. Publish the signed event via /api/v1/events/publish.
+//
+// @Summary      Build a relay-list event
+// @Description  Assemble an unsigned NIP-65 (10002) / NIP-17 (10050) / NIP-51 (10006/10007/10012) relay-list event for the session user, preserving non-relay tags, and return it to sign client-side.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  nostr.Event
+// @Failure      400  {string}  string  "Invalid request"
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/user/relay-list/build [post]
+func BuildRelayListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req RelayListBuildRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	existing := coreClient.FetchRelayList(sess.PublicKey, req.Kind)
+	unsigned, err := core.AssembleRelayListEvent(existing, req.Kind, sess.PublicKey, req.Entries)
+	if err != nil {
+		log.ClientAPI().Warn("Relay-list build failed", "pubkey", sess.PublicKey, "kind", req.Kind, "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(unsigned); err != nil {
+		log.ClientAPI().Error("Failed to encode built relay-list event", "error", err)
+	}
+}
+
+// FixedRelaysRequest sets or clears the fixed-relay override.
+type FixedRelaysRequest struct {
+	Enabled bool     `json:"enabled"`
+	Read    []string `json:"read"`
+	Write   []string `json:"write"`
+}
+
+// FixedRelaysResponse reports the override state after the change.
+type FixedRelaysResponse struct {
+	Enabled bool `json:"enabled"`
+}
+
+// FixedRelaysHandler enables or disables the fixed-relay override — the advanced
+// opt-out that bypasses the outbox model and uses a fixed read/write set (the
+// "proxy" / aggregator override). Off by default and discouraged.
+//
+// @Summary      Set the fixed-relay override
+// @Description  Enable (with read/write sets) or disable the fixed-relay override that bypasses outbox routing. Session-gated.
+// @Tags         client
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  FixedRelaysResponse
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/client/fixed-relays [post]
+func FixedRelaysHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var req FixedRelaysRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	if req.Enabled {
+		coreClient.SetFixedRelays(req.Read, req.Write)
+	} else {
+		coreClient.ClearFixedRelays()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(FixedRelaysResponse{Enabled: coreClient.FixedRelaysEnabled()}); err != nil {
+		log.ClientAPI().Error("Failed to encode fixed-relays response", "error", err)
+	}
+}

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -12,8 +12,9 @@ import (
 
 // RelayListBuildRequest carries the desired relay list for one kind.
 type RelayListBuildRequest struct {
-	Kind    int                   `json:"kind"`    // 10002 | 10050 | 10006 | 10007 | 10012
-	Entries []core.RelayListEntry `json:"entries"` // ordered; Read/Write apply to 10002 only
+	Kind      int                   `json:"kind"`                 // 10002 | 10050 | 10006 | 10007 | 10012
+	Entries   []core.RelayListEntry `json:"entries"`              // ordered; Read/Write apply to 10002 only
+	ClientTag *bool                 `json:"client_tag,omitempty"` // nil = config default; else per-user override (#99)
 }
 
 // BuildRelayListHandler assembles an UNSIGNED relay-list event for the session
@@ -59,6 +60,9 @@ func BuildRelayListHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	en, nm := resolveClientTag(req.ClientTag)
+	core.ApplyClientTag(unsigned, en, nm)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(unsigned); err != nil {

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -26,7 +26,7 @@ type RelayListBuildRequest struct {
 // @Tags         client
 // @Accept       json
 // @Produce      json
-// @Success      200  {object}  nostr.Event
+// @Success      200  {object}  relay.Event
 // @Failure      400  {string}  string  "Invalid request"
 // @Failure      401  {string}  string  "Authentication required"
 // @Router       /api/v1/user/relay-list/build [post]

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -66,6 +66,62 @@ func BuildRelayListHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// UserRelayListsResponse is a user's resolved relay lists across the kinds the
+// relay manager edits.
+type UserRelayListsResponse struct {
+	Pubkey    string                `json:"pubkey"`
+	NIP65     []core.RelayListEntry `json:"nip65"`     // 10002, with read/write flags
+	DM        []string              `json:"dm"`        // 10050
+	Blocked   []string              `json:"blocked"`   // 10006
+	Search    []string              `json:"search"`    // 10007
+	Favorites []string              `json:"favorites"` // 10012
+}
+
+// GetUserRelayListsHandler resolves a user's relay lists (NIP-65 10002, NIP-17
+// 10050, NIP-51 10006/10007/10012) for the relay manager. Defaults to the
+// session user when no pubkey is given.
+//
+// @Summary      Get a user's relay lists
+// @Description  Resolve a user's NIP-65 / NIP-17 / NIP-51 relay lists for the relay manager. Defaults to the session user.
+// @Tags         client
+// @Produce      json
+// @Param        pubkey  query     string  false  "Hex pubkey (defaults to the session user)"
+// @Success      200     {object}  UserRelayListsResponse
+// @Failure      401     {string}  string  "Authentication required or pubkey parameter needed"
+// @Router       /api/v1/user/relay-lists [get]
+func GetUserRelayListsHandler(w http.ResponseWriter, r *http.Request) {
+	pubkey := r.URL.Query().Get("pubkey")
+	if pubkey == "" {
+		sess := session.SessionMgr.GetCurrentUser(r)
+		if sess == nil {
+			http.Error(w, "Authentication required or pubkey parameter needed", http.StatusUnauthorized)
+			return
+		}
+		pubkey = sess.PublicKey
+	}
+
+	coreClient := connection.GetCoreClient()
+	if coreClient == nil {
+		http.Error(w, "Client not available", http.StatusInternalServerError)
+		return
+	}
+
+	lists := coreClient.FetchUserRelayLists(pubkey)
+	resp := UserRelayListsResponse{
+		Pubkey:    pubkey,
+		NIP65:     lists.NIP65,
+		DM:        lists.DM,
+		Blocked:   lists.Blocked,
+		Search:    lists.Search,
+		Favorites: lists.Favorites,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.ClientAPI().Error("Failed to encode relay lists response", "error", err)
+	}
+}
+
 // FixedRelaysRequest sets or clears the fixed-relay override.
 type FixedRelaysRequest struct {
 	Enabled bool     `json:"enabled"`

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -107,7 +107,7 @@ func GetUserRelayListsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lists := coreClient.FetchUserRelayLists(pubkey)
+	lists := coreClient.ResolveUserRelayLists(pubkey)
 	resp := UserRelayListsResponse{
 		Pubkey:    pubkey,
 		NIP65:     lists.NIP65,

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -75,7 +75,8 @@ type UserRelayListsResponse struct {
 	Blocked   []string              `json:"blocked"`   // 10006
 	Search    []string              `json:"search"`    // 10007
 	Favorites []string              `json:"favorites"` // 10012
-	Encrypted core.EncryptedFlags   `json:"encrypted"` // NIP-51 lists with private (encrypted) entries
+	Private   []string              `json:"private"`   // 10013 (NIP-37) — usually empty; entries are encrypted
+	Encrypted core.EncryptedFlags   `json:"encrypted"` // NIP-51/37 lists with private (encrypted) entries
 	// EncryptedContent is the raw encrypted blob per list so the browser can
 	// decrypt it with the user's signer on demand (#100). grain never decrypts.
 	EncryptedContent core.EncryptedContent `json:"encrypted_content"`
@@ -118,6 +119,7 @@ func GetUserRelayListsHandler(w http.ResponseWriter, r *http.Request) {
 		Blocked:          lists.Blocked,
 		Search:           lists.Search,
 		Favorites:        lists.Favorites,
+		Private:          lists.Private,
 		Encrypted:        lists.Encrypted,
 		EncryptedContent: lists.EncryptedContent,
 	}

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -76,6 +76,9 @@ type UserRelayListsResponse struct {
 	Search    []string              `json:"search"`    // 10007
 	Favorites []string              `json:"favorites"` // 10012
 	Encrypted core.EncryptedFlags   `json:"encrypted"` // NIP-51 lists with private (encrypted) entries
+	// EncryptedContent is the raw encrypted blob per list so the browser can
+	// decrypt it with the user's signer on demand (#100). grain never decrypts.
+	EncryptedContent core.EncryptedContent `json:"encrypted_content"`
 }
 
 // GetUserRelayListsHandler resolves a user's relay lists (NIP-65 10002, NIP-17
@@ -109,13 +112,14 @@ func GetUserRelayListsHandler(w http.ResponseWriter, r *http.Request) {
 
 	lists := coreClient.ResolveUserRelayLists(pubkey)
 	resp := UserRelayListsResponse{
-		Pubkey:    pubkey,
-		NIP65:     lists.NIP65,
-		DM:        lists.DM,
-		Blocked:   lists.Blocked,
-		Search:    lists.Search,
-		Favorites: lists.Favorites,
-		Encrypted: lists.Encrypted,
+		Pubkey:           pubkey,
+		NIP65:            lists.NIP65,
+		DM:               lists.DM,
+		Blocked:          lists.Blocked,
+		Search:           lists.Search,
+		Favorites:        lists.Favorites,
+		Encrypted:        lists.Encrypted,
+		EncryptedContent: lists.EncryptedContent,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/client/api/relayList.go
+++ b/client/api/relayList.go
@@ -75,6 +75,7 @@ type UserRelayListsResponse struct {
 	Blocked   []string              `json:"blocked"`   // 10006
 	Search    []string              `json:"search"`    // 10007
 	Favorites []string              `json:"favorites"` // 10012
+	Encrypted core.EncryptedFlags   `json:"encrypted"` // NIP-51 lists with private (encrypted) entries
 }
 
 // GetUserRelayListsHandler resolves a user's relay lists (NIP-65 10002, NIP-17
@@ -114,6 +115,7 @@ func GetUserRelayListsHandler(w http.ResponseWriter, r *http.Request) {
 		Blocked:   lists.Blocked,
 		Search:    lists.Search,
 		Favorites: lists.Favorites,
+		Encrypted: lists.Encrypted,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/client/api/stream.go
+++ b/client/api/stream.go
@@ -35,6 +35,18 @@ func StreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Clear the server's write deadline for this connection. The shared
+	// http.Server sets WriteTimeout (a few seconds) to bound normal request
+	// handlers, but that deadline caps the ENTIRE response — for a long-lived
+	// SSE stream it kills the connection mid-flight (heartbeats don't help; the
+	// deadline is absolute, not idle-based), so the browser reconnects in a
+	// tight loop and live-sync thrashes. Streaming handlers must opt out.
+	if rc := http.NewResponseController(w); rc != nil {
+		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			log.ClientAPI().Debug("SSE: could not clear write deadline", "error", err)
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")

--- a/client/api/stream.go
+++ b/client/api/stream.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/0ceanslim/grain/client/session"
+	"github.com/0ceanslim/grain/client/stream"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// StreamHandler is the per-session SSE channel grain pushes live updates to (the
+// login-hydration live-sync #87 and the streaming fetch path #77). The browser
+// connects once via EventSource; grain streams JSON messages — one per `data:`
+// line — until the client disconnects. A heartbeat comment keeps the connection
+// (and any intermediary) alive.
+//
+// @Summary      Live update stream (SSE)
+// @Description  Per-session Server-Sent Events channel for live updates. Connect with EventSource.
+// @Tags         client
+// @Produce      text/event-stream
+// @Success      200  {string}  string  "SSE stream"
+// @Failure      401  {string}  string  "Authentication required"
+// @Router       /api/v1/stream [get]
+func StreamHandler(w http.ResponseWriter, r *http.Request) {
+	sess := session.SessionMgr.GetCurrentUser(r)
+	if sess == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // tell any proxy not to buffer
+
+	ch, unregister := stream.Default().Register(sess.PublicKey)
+	defer unregister()
+
+	// Opening comment so EventSource fires `onopen` right away.
+	_, _ = w.Write([]byte(": connected\n\n"))
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(25 * time.Second)
+	defer heartbeat.Stop()
+	enc := json.NewEncoder(w)
+
+	log.ClientAPI().Debug("SSE stream opened", "pubkey", sess.PublicKey)
+
+	for {
+		select {
+		case <-r.Context().Done():
+			log.ClientAPI().Debug("SSE stream closed", "pubkey", sess.PublicKey)
+			return
+		case <-heartbeat.C:
+			_, _ = w.Write([]byte(": ping\n\n"))
+			flusher.Flush()
+		case msg, open := <-ch:
+			if !open {
+				return
+			}
+			_, _ = w.Write([]byte("data: "))
+			_ = enc.Encode(msg) // JSON + trailing newline
+			_, _ = w.Write([]byte("\n"))
+			flusher.Flush()
+		}
+	}
+}

--- a/client/connection/helpers.go
+++ b/client/connection/helpers.go
@@ -109,6 +109,7 @@ func GetCoreClientStatus() map[string]interface{} {
 		"connected_relays": connectedRelays,
 		"connected_count":  len(connectedRelays),
 		"index_relays":     indexRelays,
+		"pool_known":       stats.Known,     // relays the client is aware of
 		"pool_total":       stats.Total,     // relays tracked in the pool
 		"pool_connected":   stats.Connected, // currently connected
 		"pool_pinned":      stats.Pinned,    // index/seed relays

--- a/client/connection/helpers.go
+++ b/client/connection/helpers.go
@@ -111,6 +111,19 @@ func GetCoreClientStatus() map[string]interface{} {
 	}
 }
 
+// StartRelayEvictionSweeper starts the core client's idle-connection sweeper,
+// bounded to ctx so it doesn't outlive the server instance (#93). Companion to
+// StartRelayHealthCheck: the health check keeps the pinned index relays up,
+// while the sweeper reclaims the per-user connections the outbox pool dials on
+// demand once they go idle.
+func StartRelayEvictionSweeper(ctx context.Context, interval time.Duration) {
+	if coreClient == nil {
+		log.ClientConnection().Warn("Core client not initialized; eviction sweeper not started")
+		return
+	}
+	coreClient.StartEvictionSweeper(ctx, interval)
+}
+
 // StartRelayHealthCheck starts a background goroutine to maintain relay
 // connections. It exits when ctx is cancelled so it doesn't outlive the
 // server instance that started it (#93).

--- a/client/connection/helpers.go
+++ b/client/connection/helpers.go
@@ -102,12 +102,17 @@ func GetCoreClientStatus() map[string]interface{} {
 	}
 
 	connectedRelays := coreClient.GetConnectedRelays()
+	stats := coreClient.PoolStats()
 
 	return map[string]interface{}{
 		"initialized":      true,
 		"connected_relays": connectedRelays,
 		"connected_count":  len(connectedRelays),
 		"index_relays":     indexRelays,
+		"pool_total":       stats.Total,     // relays tracked in the pool
+		"pool_connected":   stats.Connected, // currently connected
+		"pool_pinned":      stats.Pinned,    // index/seed relays
+		"pool_leased":      stats.Leased,    // in active use
 	}
 }
 

--- a/client/connection/livesync.go
+++ b/client/connection/livesync.go
@@ -1,0 +1,101 @@
+package connection
+
+import (
+	"sync"
+	"time"
+
+	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/stream"
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// ownEventKinds are the logged-in user's replaceable kinds grain live-syncs, so
+// a change made in another client shows up here without a reload.
+var ownEventKinds = []int{0, 10002, 10050, 10063, 10096, 10006, 10007, 10012}
+
+var (
+	liveSyncMu   sync.Mutex
+	liveSyncSubs = map[string]*core.Subscription{}
+)
+
+// StartLiveSync opens a subscription to a user's own replaceable events created
+// from now on; for each, it drops the cached resolution that event supersedes
+// and pushes a live update to the user's open pages. Wired to the SSE hub's
+// first-connection hook, so it runs only while a page is open.
+func StartLiveSync(pubkey string) {
+	cc := GetCoreClient()
+	if cc == nil {
+		return
+	}
+
+	liveSyncMu.Lock()
+	if _, running := liveSyncSubs[pubkey]; running {
+		liveSyncMu.Unlock()
+		return
+	}
+	liveSyncMu.Unlock()
+
+	since := time.Now()
+	relays := cc.OwnListRelays(pubkey)
+	sub, err := cc.Subscribe([]nostr.Filter{{
+		Authors: []string{pubkey},
+		Kinds:   ownEventKinds,
+		Since:   &since,
+	}}, relays)
+	if err != nil {
+		log.ClientConnection().Warn("Live-sync subscribe failed", "pubkey", pubkey, "error", err)
+		return
+	}
+
+	liveSyncMu.Lock()
+	// Lost a race with another first-connection — keep the existing sub.
+	if _, running := liveSyncSubs[pubkey]; running {
+		liveSyncMu.Unlock()
+		sub.Close()
+		return
+	}
+	liveSyncSubs[pubkey] = sub
+	liveSyncMu.Unlock()
+
+	log.ClientConnection().Info("Live-sync started", "pubkey", pubkey, "relay_count", len(relays))
+
+	go func() {
+		// range ends when StopLiveSync closes the subscription (Close closes Events).
+		for ev := range sub.Events {
+			if ev != nil {
+				handleOwnEvent(cc, pubkey, ev)
+			}
+		}
+	}()
+}
+
+// StopLiveSync closes a user's live-sync subscription — wired to the SSE hub's
+// last-connection hook.
+func StopLiveSync(pubkey string) {
+	liveSyncMu.Lock()
+	sub := liveSyncSubs[pubkey]
+	delete(liveSyncSubs, pubkey)
+	liveSyncMu.Unlock()
+	if sub != nil {
+		sub.Close()
+		log.ClientConnection().Info("Live-sync stopped", "pubkey", pubkey)
+	}
+}
+
+// handleOwnEvent drops the cache the event supersedes and notifies the user's
+// open pages which kind changed so they can re-render.
+func handleOwnEvent(cc *core.Client, pubkey string, ev *nostr.Event) {
+	switch ev.Kind {
+	case 10063, 10096:
+		cc.InvalidateMediaServers(pubkey)
+	case 10002, 10050:
+		cc.InvalidateUserRelays(pubkey)
+	}
+	switch ev.Kind {
+	case 10002, 10050, 10006, 10007, 10012:
+		cc.InvalidateUserRelayLists(pubkey)
+	}
+	log.ClientConnection().Debug("Live-sync own-event update", "pubkey", pubkey, "kind", ev.Kind)
+	stream.Default().Push(pubkey, stream.Message{Type: "list-updated", Kind: ev.Kind})
+}

--- a/client/connection/livesync.go
+++ b/client/connection/livesync.go
@@ -13,7 +13,7 @@ import (
 
 // ownEventKinds are the logged-in user's replaceable kinds grain live-syncs, so
 // a change made in another client shows up here without a reload.
-var ownEventKinds = []int{0, 10002, 10050, 10063, 10096, 10006, 10007, 10012}
+var ownEventKinds = []int{0, 10002, 10050, 10063, 10096, 10006, 10007, 10012, 10013}
 
 var (
 	liveSyncMu   sync.Mutex
@@ -94,7 +94,7 @@ func handleOwnEvent(cc *core.Client, pubkey string, ev *nostr.Event) {
 		cc.InvalidateUserRelays(pubkey)
 	}
 	switch ev.Kind {
-	case 10002, 10050, 10006, 10007, 10012:
+	case 10002, 10050, 10006, 10007, 10012, 10013:
 		cc.InvalidateUserRelayLists(pubkey)
 	}
 	log.ClientConnection().Debug("Live-sync own-event update", "pubkey", pubkey, "kind", ev.Kind)

--- a/client/connection/livesync.go
+++ b/client/connection/livesync.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -38,7 +39,7 @@ func StartLiveSync(pubkey string) {
 
 	since := time.Now()
 	relays := cc.OwnListRelays(pubkey)
-	sub, err := cc.Subscribe([]nostr.Filter{{
+	sub, err := cc.Subscribe(context.Background(), []nostr.Filter{{
 		Authors: []string{pubkey},
 		Kinds:   ownEventKinds,
 		Since:   &since,

--- a/client/connection/manager.go
+++ b/client/connection/manager.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"github.com/0ceanslim/grain/client/core"
+	"github.com/0ceanslim/grain/client/stream"
 	cfgType "github.com/0ceanslim/grain/config/types"
 	"github.com/0ceanslim/grain/server/utils/log"
 )
@@ -40,6 +41,10 @@ func InitializeCoreClient(serverCfg *cfgType.ServerConfig) error {
 	// Pin index/seed relays so the idle sweeper never evicts them — they must
 	// stay connected to resolve relay lists and metadata for arbitrary users.
 	coreClient.PinRelays(config.IndexRelays...)
+
+	// Live-sync (#87): start a user's own-event subscription when their first
+	// page opens the SSE channel, and stop it when the last one disconnects.
+	stream.Default().SetLifecycle(StartLiveSync, StopLiveSync)
 
 	// Connect to index relays asynchronously. Relay startup must never
 	// block on outbound network — when index relays are unreachable, the

--- a/client/connection/manager.go
+++ b/client/connection/manager.go
@@ -37,6 +37,10 @@ func InitializeCoreClient(serverCfg *cfgType.ServerConfig) error {
 	// Store relays for later use
 	indexRelays = config.IndexRelays
 
+	// Pin index/seed relays so the idle sweeper never evicts them — they must
+	// stay connected to resolve relay lists and metadata for arbitrary users.
+	coreClient.PinRelays(config.IndexRelays...)
+
 	// Connect to index relays asynchronously. Relay startup must never
 	// block on outbound network — when index relays are unreachable, the
 	// retry loop can take 30+ seconds and leave the HTTP server unable

--- a/client/connection/manager.go
+++ b/client/connection/manager.go
@@ -53,10 +53,14 @@ func InitializeCoreClient(serverCfg *cfgType.ServerConfig) error {
 			log.ClientConnection().Warn("Failed to connect to index relays during initialization - relay will operate in offline mode",
 				"error", err,
 				"relay_count", len(config.IndexRelays))
-		} else {
-			log.ClientConnection().Info("Core client connected to index relays",
-				"relay_count", len(config.IndexRelays))
+			return
 		}
+		log.ClientConnection().Info("Core client connected to index relays",
+			"relay_count", len(config.IndexRelays))
+
+		// Seed the known-relays set broadly from the indexers so it starts large
+		// instead of growing only as users get browsed.
+		coreClient.SeedKnownRelays()
 	}()
 
 	log.ClientConnection().Info("Core client initialized successfully",

--- a/client/core/approles.go
+++ b/client/core/approles.go
@@ -1,0 +1,45 @@
+package core
+
+// Locally-configured ("app") relay roles are session preferences a downstream
+// app edits — seeded from the operator's config, overridable per session, and
+// NOT published as Nostr lists (unlike the per-target/self-only event-derived
+// roles). Today the routing-affecting ones are RoleIndexer (resolution seeds)
+// and RoleBroadcast (writes mirror there); RoleLocal and RoleTrusted are stored
+// but inert until their wiring lands (Local routing preference; Trusted needs
+// NIP-42 AUTH, see #101).
+
+// AppRelays returns the session relays for a locally-configured role. RoleIndexer
+// falls back to the configured index relays when the user hasn't overridden it;
+// the other roles return nil when unset.
+func (c *Client) AppRelays(role Role) []string {
+	c.appRelaysMu.Lock()
+	v, ok := c.appRelays[role]
+	c.appRelaysMu.Unlock()
+	if ok {
+		return append([]string(nil), v...)
+	}
+	if role == RoleIndexer {
+		return append([]string(nil), c.config.IndexRelays...)
+	}
+	return nil
+}
+
+// SetAppRelays sets (or clears, when urls is empty) the session override for a
+// locally-configured role. Clearing RoleIndexer restores the configured default.
+func (c *Client) SetAppRelays(role Role, urls []string) {
+	urls = normalizeRelayURLs(urls)
+	c.appRelaysMu.Lock()
+	if len(urls) == 0 {
+		delete(c.appRelays, role)
+	} else {
+		c.appRelays[role] = urls
+	}
+	c.appRelaysMu.Unlock()
+}
+
+// indexRelays is the effective index-relay set for routing and resolution: the
+// session's RoleIndexer override if set, else the configured defaults. Used in
+// place of c.config.IndexRelays everywhere routing/discovery reads the seeds.
+func (c *Client) indexRelays() []string {
+	return c.AppRelays(RoleIndexer)
+}

--- a/client/core/broadcast_test.go
+++ b/client/core/broadcast_test.go
@@ -1,0 +1,46 @@
+package core
+
+import "testing"
+
+func TestMessageRouterOKWaiter(t *testing.T) {
+	mr := NewMessageRouter()
+	ch := mr.RegisterOKWaiter("evt1", 2)
+
+	mr.RouteOK("evt1", OKResult{Relay: "wss://a", Accepted: true})
+	select {
+	case ok := <-ch:
+		if ok.Relay != "wss://a" || !ok.Accepted {
+			t.Errorf("routed OK = %+v", ok)
+		}
+	default:
+		t.Fatal("expected OK to be routed to the waiter")
+	}
+
+	// Unknown event id and post-unregister routing must be safe no-ops.
+	mr.RouteOK("nonexistent", OKResult{Relay: "x"})
+	mr.UnregisterOKWaiter("evt1")
+	mr.RouteOK("evt1", OKResult{Relay: "y"})
+}
+
+func TestCollectOKResponses(t *testing.T) {
+	results := []BroadcastResult{
+		{RelayURL: "wss://a", Success: true},
+		{RelayURL: "wss://b", Success: true},
+		{RelayURL: "wss://c", Success: false}, // send failed — no OK expected
+	}
+	okCh := make(chan OKResult, 3)
+	okCh <- OKResult{Relay: "wss://a", Accepted: true}
+	okCh <- OKResult{Relay: "wss://b", Accepted: false, Reason: "blocked: spam"}
+
+	collectOKResponses(okCh, results)
+
+	if !results[0].Accepted {
+		t.Error("relay a should be accepted")
+	}
+	if results[1].Accepted || results[1].Reason != "blocked: spam" {
+		t.Errorf("relay b should be rejected with reason, got %+v", results[1])
+	}
+	if results[2].Accepted {
+		t.Error("relay c (send failed) should not be marked accepted")
+	}
+}

--- a/client/core/broadcast_test.go
+++ b/client/core/broadcast_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestMessageRouterOKWaiter(t *testing.T) {
 	mr := NewMessageRouter()
@@ -32,7 +35,7 @@ func TestCollectOKResponses(t *testing.T) {
 	okCh <- OKResult{Relay: "wss://a", Accepted: true}
 	okCh <- OKResult{Relay: "wss://b", Accepted: false, Reason: "blocked: spam"}
 
-	collectOKResponses(okCh, results)
+	collectOKResponses(context.Background(), okCh, results)
 
 	if !results[0].Accepted {
 		t.Error("relay a should be accepted")

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -29,6 +29,10 @@ type Client struct {
 	// (outbox / inbox / DM inbox) for outbox routing.
 	directory *RelayDirectory
 
+	// mediaDir resolves and caches per-user media-server lists (Blossom kind
+	// 10063 / NIP-96 kind 10096) for the upload flow.
+	mediaDir *MediaDirectory
+
 	// Fixed-relay override (opt-out, default OFF). When enabled, every read uses
 	// fixedRead and every write uses fixedWrite, bypassing outbox routing
 	// entirely — replies stop reaching other users' inboxes. Only for users who
@@ -51,6 +55,7 @@ func NewClient(config *Config) *Client {
 		config:        config,
 	}
 	c.directory = newRelayDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserRelaysFromNetwork)
+	c.mediaDir = newMediaDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserMediaServersFromNetwork)
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -302,13 +302,14 @@ func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Even
 		Limit:   &[]int{1}[0], // Get latest only
 	}
 
-	// Use relay hints if provided, otherwise route to the author's outbox
-	// relays (falling back to index relays) per the outbox model, rather than
-	// blasting every connected relay.
+	// Use relay hints if provided, otherwise query the index/profile-indexer
+	// relays plus the author's outbox when already cached (RouteMetadata) —
+	// metadata lives on the indexers, and resolving the outbox synchronously on
+	// every profile view is what made the dashboard crawl.
 	targetRelays := relayHints
 	if len(targetRelays) == 0 {
-		targetRelays = c.RouteFetch(pubkey)
-		log.ClientCore().Debug("No relay hints provided, routing to author outbox",
+		targetRelays = c.RouteMetadata(pubkey)
+		log.ClientCore().Debug("No relay hints provided, routing metadata fetch",
 			"pubkey", pubkey, "relays", targetRelays)
 	}
 
@@ -329,41 +330,41 @@ func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Even
 	return event, nil
 }
 
-// GetUserRelays retrieves user relay list (kind 10002)
+// GetUserRelays retrieves a user's relay list (NIP-65), resolved through the
+// directory — an index-relay query that is TTL-cached and single-flighted —
+// rather than fanning a REQ out to every connected relay. That fan-out is what
+// melted the dashboard during a mutelist sync once the outbox pool had grown to
+// dozens of connections: each author's lookup blasted all of them. Returns
+// empty mailboxes (not an error) when the user has published no relay list.
 func (c *Client) GetUserRelays(pubkey string) (*Mailboxes, error) {
-	log.ClientCore().Debug("Fetching user relays", "pubkey", pubkey)
+	ur := c.ResolveRelays(pubkey)
 
-	filter := nostr.Filter{
-		Authors: []string{pubkey},
-		Kinds:   []int{10002},
-		Limit:   &[]int{1}[0],
+	// Reconstruct the read/write/both split callers expect from the directory's
+	// outbox (write+both) / inbox (read+both) view: a relay in both is "both",
+	// outbox-only is "write", inbox-only is "read".
+	inbox := make(map[string]bool, len(ur.Inbox))
+	for _, r := range ur.Inbox {
+		inbox[r] = true
+	}
+	outbox := make(map[string]bool, len(ur.Outbox))
+	for _, r := range ur.Outbox {
+		outbox[r] = true
 	}
 
-	// Use connected relays for relay list queries
-	connectedRelays := c.relayPool.GetConnectedRelays()
-	if len(connectedRelays) == 0 {
-		return nil, &ClientError{Message: "no connected relays available"}
+	mb := &Mailboxes{}
+	for _, r := range ur.Outbox {
+		if inbox[r] {
+			mb.Both = append(mb.Both, r)
+		} else {
+			mb.Write = append(mb.Write, r)
+		}
 	}
-
-	sub, err := c.Subscribe([]nostr.Filter{filter}, connectedRelays)
-	if err != nil {
-		return nil, err
+	for _, r := range ur.Inbox {
+		if !outbox[r] {
+			mb.Read = append(mb.Read, r)
+		}
 	}
-	defer sub.Close()
-
-	event := collectLatestReplaceable(sub, len(connectedRelays), 5*time.Second)
-	if event == nil {
-		// Not an error: the user may simply not have published a kind-10002.
-		log.ClientCore().Debug("No relay list found for user", "pubkey", pubkey)
-		return &Mailboxes{}, nil
-	}
-
-	mailboxes := parseMailboxEvent(event)
-	log.ClientCore().Debug("Parsed user relays", "pubkey", pubkey,
-		"read_count", len(mailboxes.Read),
-		"write_count", len(mailboxes.Write),
-		"both_count", len(mailboxes.Both))
-	return mailboxes, nil
+	return mb, nil
 }
 
 // PublishEvent publishes an event to specified relays

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
@@ -223,6 +224,54 @@ func (c *Client) ConnectToRelaysWithRetry(urls []string, maxRetries int) error {
 	return fmt.Errorf("failed to connect after %d attempts: %w", maxRetries, lastErr)
 }
 
+// collectLatestReplaceable drains a subscription and returns the newest event
+// (by created_at) as soon as any relay signals EOSE, once every target relay
+// has, or on timeout — whichever comes first. It returns nil when no matching
+// event arrived; callers decide what that means (a hard error for a required
+// profile, an empty result for an optional relay list).
+//
+// This is the shared core of GetUserProfile and GetUserRelays, and the fix for
+// the GetUserRelays latency bug (#77): that method used to wait on sub.Done —
+// which EOSE never closes — so every mailbox fetch burned the full timeout
+// instead of returning the moment a relay reported EOSE.
+func collectLatestReplaceable(sub *Subscription, totalRelays int, timeout time.Duration) *nostr.Event {
+	deadline := time.After(timeout)
+	eoseRelays := make(map[string]bool)
+	var latest *nostr.Event
+
+	for {
+		select {
+		case event := <-sub.Events:
+			if event == nil {
+				continue
+			}
+			// Keep the newest by created_at (these are replaceable events).
+			if latest == nil || event.CreatedAt > latest.CreatedAt {
+				latest = event
+			}
+
+		case relayURL := <-sub.EOSE:
+			eoseRelays[relayURL] = true
+			// Newest event in hand and a relay has nothing more to send.
+			if latest != nil {
+				return latest
+			}
+			// Every target relay reported end-of-stored-events; none had it.
+			if len(eoseRelays) >= totalRelays {
+				return nil
+			}
+
+		case err := <-sub.Errors:
+			// One relay failing isn't fatal — others may still answer.
+			log.ClientCore().Debug("Subscription error while collecting event",
+				"sub_id", sub.ID, "error", err)
+
+		case <-deadline:
+			return latest
+		}
+	}
+}
+
 func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Event, error) {
 	log.ClientCore().Debug("Fetching user profile", "pubkey", pubkey, "relay_hints", relayHints)
 
@@ -238,83 +287,24 @@ func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Even
 	if len(targetRelays) == 0 {
 		targetRelays = c.GetConnectedRelays()
 		log.ClientCore().Debug("No relay hints provided, using connected relays",
-			"pubkey", pubkey,
-			"connected_relays", targetRelays)
+			"pubkey", pubkey, "connected_relays", targetRelays)
 	}
 
-	// Subscribe with the specific relays
 	sub, err := c.Subscribe([]nostr.Filter{filter}, targetRelays)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create subscription: %w", err)
 	}
 	defer sub.Close()
 
-	// Wait for events with timeout
-	timeout := time.After(5 * time.Second)
-
-	// Track which relays have sent EOSE
-	eoseRelays := make(map[string]bool)
-	totalRelays := len(targetRelays)
-
-	// We might receive multiple events, keep the latest
-	var latestEvent *nostr.Event
-
-	for {
-		select {
-		case event := <-sub.Events:
-			log.ClientCore().Debug("Received profile event",
-				"pubkey", pubkey,
-				"event_id", event.ID,
-				"created_at", event.CreatedAt)
-			// Keep the latest event (highest created_at)
-			if latestEvent == nil || event.CreatedAt > latestEvent.CreatedAt {
-				latestEvent = event
-			}
-
-		case relayURL := <-sub.EOSE:
-			// Track EOSE from this relay
-			eoseRelays[relayURL] = true
-			log.ClientCore().Debug("EOSE received from relay",
-				"pubkey", pubkey,
-				"relay", relayURL,
-				"eose_count", len(eoseRelays),
-				"total_relays", totalRelays)
-
-			// If we have an event and at least one EOSE, we can return early
-			if latestEvent != nil {
-				log.ClientCore().Debug("Returning profile after EOSE",
-					"pubkey", pubkey,
-					"event_id", latestEvent.ID,
-					"eose_count", len(eoseRelays))
-				return latestEvent, nil
-			}
-
-			// If all relays have sent EOSE and no event found
-			if len(eoseRelays) >= totalRelays {
-				log.ClientCore().Debug("All relays sent EOSE, no profile found",
-					"pubkey", pubkey)
-				return nil, &ClientError{Message: "profile not found"}
-			}
-
-			// Continue waiting for events from other relays
-
-		case err := <-sub.Errors:
-			log.ClientCore().Error("Subscription error", "pubkey", pubkey, "error", err)
-			// Don't fail immediately on error, other relays might succeed
-
-		case <-timeout:
-			log.ClientCore().Warn("Timeout waiting for profile",
-				"pubkey", pubkey,
-				"eose_count", len(eoseRelays),
-				"total_relays", totalRelays,
-				"has_event", latestEvent != nil)
-			// If we got any event before timeout, return it
-			if latestEvent != nil {
-				return latestEvent, nil
-			}
-			return nil, &ClientError{Message: "timeout waiting for profile"}
-		}
+	event := collectLatestReplaceable(sub, len(targetRelays), 5*time.Second)
+	if event == nil {
+		log.ClientCore().Warn("No profile found", "pubkey", pubkey)
+		return nil, &ClientError{Message: "profile not found"}
 	}
+
+	log.ClientCore().Debug("Fetched user profile",
+		"pubkey", pubkey, "event_id", event.ID, "created_at", event.CreatedAt)
+	return event, nil
 }
 
 // GetUserRelays retrieves user relay list (kind 10002)
@@ -339,53 +329,19 @@ func (c *Client) GetUserRelays(pubkey string) (*Mailboxes, error) {
 	}
 	defer sub.Close()
 
-	timeout := time.After(5 * time.Second)
-
-	// Keep track of the latest relay list event
-	var latestEvent *nostr.Event
-
-	for {
-		select {
-		case event := <-sub.Events:
-			log.ClientCore().Debug("Received relay list event",
-				"pubkey", pubkey,
-				"event_id", event.ID,
-				"created_at", event.CreatedAt)
-			// Keep the latest event (highest created_at)
-			if latestEvent == nil || event.CreatedAt > latestEvent.CreatedAt {
-				latestEvent = event
-			}
-
-		case <-sub.Done:
-			// EOSE received - all stored events have been sent
-			log.ClientCore().Debug("EOSE received for relay list request", "pubkey", pubkey)
-			if latestEvent != nil {
-				mailboxes := parseMailboxEvent(latestEvent)
-				log.ClientCore().Debug("Parsed user relays", "pubkey", pubkey,
-					"read_count", len(mailboxes.Read),
-					"write_count", len(mailboxes.Write),
-					"both_count", len(mailboxes.Both))
-				return mailboxes, nil
-			}
-			// No relay list found (user might not have published one)
-			log.ClientCore().Debug("No relay list found for user", "pubkey", pubkey)
-			return &Mailboxes{}, nil
-
-		case err := <-sub.Errors:
-			log.ClientCore().Error("Subscription error", "pubkey", pubkey, "error", err)
-			return nil, err
-
-		case <-timeout:
-			log.ClientCore().Warn("Timeout waiting for relay list", "pubkey", pubkey)
-			// If we got any event before timeout, use it
-			if latestEvent != nil {
-				mailboxes := parseMailboxEvent(latestEvent)
-				return mailboxes, nil
-			}
-			// Return empty mailboxes on timeout (not an error - user might not have relay list)
-			return &Mailboxes{}, nil
-		}
+	event := collectLatestReplaceable(sub, len(connectedRelays), 5*time.Second)
+	if event == nil {
+		// Not an error: the user may simply not have published a kind-10002.
+		log.ClientCore().Debug("No relay list found for user", "pubkey", pubkey)
+		return &Mailboxes{}, nil
 	}
+
+	mailboxes := parseMailboxEvent(event)
+	log.ClientCore().Debug("Parsed user relays", "pubkey", pubkey,
+		"read_count", len(mailboxes.Read),
+		"write_count", len(mailboxes.Write),
+		"both_count", len(mailboxes.Both))
+	return mailboxes, nil
 }
 
 // PublishEvent publishes an event to specified relays
@@ -453,10 +409,15 @@ func (e *ClientError) Error() string {
 	return e.Message
 }
 
+// subSeq guarantees subscription IDs are unique even when two subscriptions are
+// created within the same microsecond — which happens now that login fetches
+// mailboxes and metadata concurrently (#77). A collision would cross-wire the
+// two subscriptions' events in the message router.
+var subSeq atomic.Uint64
+
 // generateSubscriptionID creates a unique subscription identifier
 func generateSubscriptionID() string {
-	// Simple time-based ID for now
-	return "sub_" + time.Now().Format("20060102150405.000000")
+	return fmt.Sprintf("sub_%s_%d", time.Now().Format("20060102150405.000000"), subSeq.Add(1))
 }
 
 // parseMailboxEvent parses a kind 10002 event into a Mailboxes struct

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -294,12 +294,14 @@ func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Even
 		Limit:   &[]int{1}[0], // Get latest only
 	}
 
-	// Use relay hints if provided, otherwise use connected relays
+	// Use relay hints if provided, otherwise route to the author's outbox
+	// relays (falling back to index relays) per the outbox model, rather than
+	// blasting every connected relay.
 	targetRelays := relayHints
 	if len(targetRelays) == 0 {
-		targetRelays = c.GetConnectedRelays()
-		log.ClientCore().Debug("No relay hints provided, using connected relays",
-			"pubkey", pubkey, "connected_relays", targetRelays)
+		targetRelays = c.RouteFetch(pubkey)
+		log.ClientCore().Debug("No relay hints provided, routing to author outbox",
+			"pubkey", pubkey, "relays", targetRelays)
 	}
 
 	sub, err := c.Subscribe([]nostr.Filter{filter}, targetRelays)

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -417,7 +417,7 @@ func (c *Client) GetUserRelays(pubkey string) (*Mailboxes, error) {
 }
 
 // PublishEvent publishes an event to specified relays
-func (c *Client) PublishEvent(event *nostr.Event, targetRelays []string) ([]BroadcastResult, error) {
+func (c *Client) PublishEvent(ctx context.Context, event *nostr.Event, targetRelays []string) ([]BroadcastResult, error) {
 	if event == nil {
 		return nil, &ClientError{Message: "event cannot be nil"}
 	}
@@ -434,11 +434,11 @@ func (c *Client) PublishEvent(event *nostr.Event, targetRelays []string) ([]Broa
 
 	log.ClientCore().Info("Publishing event", "event_id", event.ID, "relay_count", len(relays))
 
-	return BroadcastEvent(event, relays, c.relayPool), nil
+	return BroadcastEvent(ctx, event, relays, c.relayPool), nil
 }
 
 // PublishEventWithRetry publishes an event with retry logic
-func (c *Client) PublishEventWithRetry(event *nostr.Event, targetRelays []string, maxRetries int) ([]BroadcastResult, error) {
+func (c *Client) PublishEventWithRetry(ctx context.Context, event *nostr.Event, targetRelays []string, maxRetries int) ([]BroadcastResult, error) {
 	if event == nil {
 		return nil, &ClientError{Message: "event cannot be nil"}
 	}
@@ -455,7 +455,7 @@ func (c *Client) PublishEventWithRetry(event *nostr.Event, targetRelays []string
 
 	log.ClientCore().Info("Publishing event with retry", "event_id", event.ID, "relay_count", len(relays), "max_retries", maxRetries)
 
-	return BroadcastWithRetry(event, relays, c.relayPool, maxRetries), nil
+	return BroadcastWithRetry(ctx, event, relays, c.relayPool, maxRetries), nil
 }
 func (c *Client) Close() error {
 	log.ClientCore().Info("Shutting down client")

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -43,6 +43,7 @@ func NewClient(config *Config) *Client {
 	if config == nil {
 		config = DefaultConfig()
 	}
+	config.IndexRelays = normalizeRelayURLs(config.IndexRelays)
 
 	c := &Client{
 		relayPool:     NewRelayPool(config),
@@ -460,7 +461,10 @@ func parseMailboxEvent(event *nostr.Event) *Mailboxes {
 	// Parse relay tags
 	for _, tag := range event.Tags {
 		if len(tag) >= 2 && tag[0] == "r" {
-			relayURL := tag[1]
+			relayURL, ok := normalizeRelayURL(tag[1])
+			if !ok {
+				continue
+			}
 			if len(tag) >= 3 {
 				switch tag[2] {
 				case "read":

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -24,6 +24,10 @@ type Client struct {
 	// released when the session switches relays or ends, so they can be
 	// idle-evicted — the outbox pool stays additive rather than torn down.
 	sessionRelays []string
+
+	// directory resolves and caches per-target users' event-derived relay roles
+	// (outbox / inbox / DM inbox) for outbox routing.
+	directory *RelayDirectory
 }
 
 // NewClient creates a new Nostr client instance
@@ -32,12 +36,13 @@ func NewClient(config *Config) *Client {
 		config = DefaultConfig()
 	}
 
-	return &Client{
+	c := &Client{
 		relayPool:     NewRelayPool(config),
 		subscriptions: make(map[string]*Subscription),
 		config:        config,
-		mu:            sync.RWMutex{},
 	}
+	c.directory = newRelayDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserRelaysFromNetwork)
+	return c
 }
 
 // ConnectToRelays establishes connections to multiple relay URLs

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -62,6 +62,12 @@ type Client struct {
 	// browser (#98). A plain HTTP GET per relay, not a pool connection.
 	relayInfoMu    sync.Mutex
 	relayInfoCache map[string]relayInfoEntry
+
+	// relayPingCache short-TTL-caches TCP-connect latency per relay for the
+	// known-relays "fastest first" sort (#98). A cheap reachability probe, not a
+	// pool/WebSocket round-trip.
+	relayPingMu    sync.Mutex
+	relayPingCache map[string]relayPingEntry
 }
 
 // NewClient creates a new Nostr client instance
@@ -82,6 +88,7 @@ func NewClient(config *Config) *Client {
 	c.relayListsInflight = make(map[string]chan struct{})
 	c.appRelays = make(map[Role][]string)
 	c.relayInfoCache = make(map[string]relayInfoEntry)
+	c.relayPingCache = make(map[string]relayPingEntry)
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // Client represents the main Nostr client with connection pooling
@@ -76,6 +75,9 @@ func NewClient(config *Config) *Client {
 		config = DefaultConfig()
 	}
 	config.IndexRelays = normalizeRelayURLs(config.IndexRelays)
+	if config.Logger != nil {
+		SetLogger(config.Logger)
+	}
 
 	c := &Client{
 		relayPool:     NewRelayPool(config),
@@ -94,7 +96,7 @@ func NewClient(config *Config) *Client {
 
 // ConnectToRelays establishes connections to multiple relay URLs
 func (c *Client) ConnectToRelays(urls []string) error {
-	log.ClientCore().Info("Connecting to relays", "relay_count", len(urls), "relays", urls)
+	clog().Info("Connecting to relays", "relay_count", len(urls), "relays", urls)
 
 	if len(urls) == 0 {
 		return fmt.Errorf("no relay URLs provided")
@@ -107,31 +109,31 @@ func (c *Client) ConnectToRelays(urls []string) error {
 	for _, url := range urls {
 		// Validate URL format
 		if url == "" || (!strings.HasPrefix(url, "ws://") && !strings.HasPrefix(url, "wss://")) {
-			log.ClientCore().Warn("Invalid relay URL format", "relay", url)
+			clog().Warn("Invalid relay URL format", "relay", url)
 			failed = append(failed, url)
 			lastErr = fmt.Errorf("invalid URL format: %s", url)
 			continue
 		}
 
 		if err := c.relayPool.Connect(url); err != nil {
-			log.ClientCore().Warn("Failed to connect to relay", "relay", url, "error", err)
+			clog().Warn("Failed to connect to relay", "relay", url, "error", err)
 			failed = append(failed, url)
 			lastErr = err
 			continue
 		}
 		connected++
-		log.ClientCore().Debug("Successfully connected to relay", "relay", url)
+		clog().Debug("Successfully connected to relay", "relay", url)
 	}
 
 	if connected == 0 && lastErr != nil {
-		log.ClientCore().Error("Failed to connect to any relays",
+		clog().Error("Failed to connect to any relays",
 			"attempted", len(urls),
 			"failed_relays", failed,
 			"last_error", lastErr)
 		return fmt.Errorf("failed to connect to any relays: %w", lastErr)
 	}
 
-	log.ClientCore().Info("Connected to relays",
+	clog().Info("Connected to relays",
 		"connected", connected,
 		"failed", len(failed),
 		"total", len(urls))
@@ -141,7 +143,7 @@ func (c *Client) ConnectToRelays(urls []string) error {
 
 	// Verify connections are actually established
 	actuallyConnected := c.GetConnectedRelays()
-	log.ClientCore().Info("Relay connection verification",
+	clog().Info("Relay connection verification",
 		"reported_connected", connected,
 		"actually_connected", len(actuallyConnected),
 		"connected_relays", actuallyConnected)
@@ -151,15 +153,15 @@ func (c *Client) ConnectToRelays(urls []string) error {
 
 // DisconnectFromRelay closes a specific relay connection
 func (c *Client) DisconnectFromRelay(relayURL string) error {
-	log.ClientCore().Info("Disconnecting from relay", "relay", relayURL)
+	clog().Info("Disconnecting from relay", "relay", relayURL)
 
 	// Use the relay pool's existing CloseConnection method
 	if err := c.relayPool.CloseConnection(relayURL); err != nil {
-		log.ClientCore().Error("Failed to close relay connection", "relay", relayURL, "error", err)
+		clog().Error("Failed to close relay connection", "relay", relayURL, "error", err)
 		return err
 	}
 
-	log.ClientCore().Info("Successfully disconnected from relay", "relay", relayURL)
+	clog().Info("Successfully disconnected from relay", "relay", relayURL)
 	return nil
 }
 
@@ -168,18 +170,18 @@ func (c *Client) DisconnectFromRelays(relayURLs []string) error {
 	var lastErr error
 	disconnected := 0
 
-	log.ClientCore().Info("Disconnecting from multiple relays", "relay_count", len(relayURLs))
+	clog().Info("Disconnecting from multiple relays", "relay_count", len(relayURLs))
 
 	for _, relayURL := range relayURLs {
 		if err := c.DisconnectFromRelay(relayURL); err != nil {
-			log.ClientCore().Warn("Failed to disconnect from relay", "relay", relayURL, "error", err)
+			clog().Warn("Failed to disconnect from relay", "relay", relayURL, "error", err)
 			lastErr = err
 		} else {
 			disconnected++
 		}
 	}
 
-	log.ClientCore().Info("Relay disconnection complete", "requested", len(relayURLs), "disconnected", disconnected)
+	clog().Info("Relay disconnection complete", "requested", len(relayURLs), "disconnected", disconnected)
 
 	if disconnected == 0 && lastErr != nil {
 		return fmt.Errorf("failed to disconnect from any relays: %w", lastErr)
@@ -211,7 +213,7 @@ func (c *Client) Subscribe(ctx context.Context, filters []nostr.Filter, relayHin
 	c.subscriptions[subID] = sub
 	c.mu.Unlock()
 
-	log.ClientCore().Debug("Created subscription", "sub_id", subID, "relay_count", len(targetRelays))
+	clog().Debug("Created subscription", "sub_id", subID, "relay_count", len(targetRelays))
 
 	if err := sub.Start(); err != nil {
 		c.mu.Lock()
@@ -260,7 +262,7 @@ func (c *Client) ConnectToRelaysWithRetry(urls []string, maxRetries int) error {
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		log.ClientCore().Debug("Connection attempt", "attempt", attempt, "max_retries", maxRetries)
+		clog().Debug("Connection attempt", "attempt", attempt, "max_retries", maxRetries)
 
 		err := c.ConnectToRelays(urls)
 		if err == nil {
@@ -272,13 +274,13 @@ func (c *Client) ConnectToRelaysWithRetry(urls []string, maxRetries int) error {
 		// Check if any relays are connected
 		connected := c.relayPool.GetConnectedRelays()
 		if len(connected) > 0 {
-			log.ClientCore().Info("Partial connection success", "connected_relays", len(connected))
+			clog().Info("Partial connection success", "connected_relays", len(connected))
 			return nil // Partial success is acceptable
 		}
 
 		if attempt < maxRetries {
 			delay := time.Duration(attempt) * c.config.RetryDelay
-			log.ClientCore().Info("Retrying connection", "attempt", attempt, "delay", delay)
+			clog().Info("Retrying connection", "attempt", attempt, "delay", delay)
 			time.Sleep(delay)
 		}
 	}
@@ -325,7 +327,7 @@ func collectLatestReplaceable(ctx context.Context, sub *Subscription, totalRelay
 
 		case err := <-sub.Errors:
 			// One relay failing isn't fatal — others may still answer.
-			log.ClientCore().Debug("Subscription error while collecting event",
+			clog().Debug("Subscription error while collecting event",
 				"sub_id", sub.ID, "error", err)
 
 		case <-ctx.Done():
@@ -337,7 +339,7 @@ func collectLatestReplaceable(ctx context.Context, sub *Subscription, totalRelay
 }
 
 func (c *Client) GetUserProfile(ctx context.Context, pubkey string, relayHints []string) (*nostr.Event, error) {
-	log.ClientCore().Debug("Fetching user profile", "pubkey", pubkey, "relay_hints", relayHints)
+	clog().Debug("Fetching user profile", "pubkey", pubkey, "relay_hints", relayHints)
 
 	// Background-warm this user's mailbox relays into the directory (and thus
 	// the "known" set), without blocking this fetch. Resolution only queries the
@@ -358,7 +360,7 @@ func (c *Client) GetUserProfile(ctx context.Context, pubkey string, relayHints [
 	targetRelays := relayHints
 	if len(targetRelays) == 0 {
 		targetRelays = c.RouteMetadata(pubkey)
-		log.ClientCore().Debug("No relay hints provided, routing metadata fetch",
+		clog().Debug("No relay hints provided, routing metadata fetch",
 			"pubkey", pubkey, "relays", targetRelays)
 	}
 
@@ -370,11 +372,11 @@ func (c *Client) GetUserProfile(ctx context.Context, pubkey string, relayHints [
 
 	event := collectLatestReplaceable(ctx, sub, len(targetRelays), 5*time.Second)
 	if event == nil {
-		log.ClientCore().Warn("No profile found", "pubkey", pubkey)
+		clog().Warn("No profile found", "pubkey", pubkey)
 		return nil, &ClientError{Message: "profile not found"}
 	}
 
-	log.ClientCore().Debug("Fetched user profile",
+	clog().Debug("Fetched user profile",
 		"pubkey", pubkey, "event_id", event.ID, "created_at", event.CreatedAt)
 	return event, nil
 }
@@ -432,7 +434,7 @@ func (c *Client) PublishEvent(ctx context.Context, event *nostr.Event, targetRel
 		return nil, &ClientError{Message: "no relays available for publishing"}
 	}
 
-	log.ClientCore().Info("Publishing event", "event_id", event.ID, "relay_count", len(relays))
+	clog().Info("Publishing event", "event_id", event.ID, "relay_count", len(relays))
 
 	return BroadcastEvent(ctx, event, relays, c.relayPool), nil
 }
@@ -453,12 +455,12 @@ func (c *Client) PublishEventWithRetry(ctx context.Context, event *nostr.Event, 
 		return nil, &ClientError{Message: "no relays available for publishing"}
 	}
 
-	log.ClientCore().Info("Publishing event with retry", "event_id", event.ID, "relay_count", len(relays), "max_retries", maxRetries)
+	clog().Info("Publishing event with retry", "event_id", event.ID, "relay_count", len(relays), "max_retries", maxRetries)
 
 	return BroadcastWithRetry(ctx, event, relays, c.relayPool, maxRetries), nil
 }
 func (c *Client) Close() error {
-	log.ClientCore().Info("Shutting down client")
+	clog().Info("Shutting down client")
 
 	// Close all subscriptions
 	c.mu.Lock()
@@ -495,7 +497,7 @@ func generateSubscriptionID() string {
 // parseMailboxEvent parses a kind 10002 event into a Mailboxes struct
 func parseMailboxEvent(event *nostr.Event) *Mailboxes {
 	if event.Kind != 10002 {
-		log.ClientCore().Warn("Event is not a mailbox event", "kind", event.Kind, "expected", 10002)
+		clog().Warn("Event is not a mailbox event", "kind", event.Kind, "expected", 10002)
 		return &Mailboxes{}
 	}
 
@@ -522,7 +524,7 @@ func parseMailboxEvent(event *nostr.Event) *Mailboxes {
 		}
 	}
 
-	log.ClientCore().Debug("Parsed mailbox event", "event_id", event.ID,
+	clog().Debug("Parsed mailbox event", "event_id", event.ID,
 		"read_count", len(mailboxes.Read),
 		"write_count", len(mailboxes.Write),
 		"both_count", len(mailboxes.Both))
@@ -563,7 +565,7 @@ func (c *Client) ReplaceRelayConnections(newRelays []RelayConfig) error {
 	acquired := make([]string, 0, len(urls))
 	for _, u := range urls {
 		if _, err := c.relayPool.Acquire(u); err != nil {
-			log.ClientCore().Debug("Failed to acquire session relay", "relay", u, "error", err)
+			clog().Debug("Failed to acquire session relay", "relay", u, "error", err)
 			continue
 		}
 		acquired = append(acquired, u)
@@ -577,7 +579,7 @@ func (c *Client) ReplaceRelayConnections(newRelays []RelayConfig) error {
 		return fmt.Errorf("failed to connect to any of the %d requested relays", len(urls))
 	}
 
-	log.ClientCore().Info("Switched session relays (additive)",
+	clog().Info("Switched session relays (additive)",
 		"requested", len(urls), "acquired", len(acquired))
 	return nil
 }
@@ -586,10 +588,10 @@ func (c *Client) ReplaceRelayConnections(newRelays []RelayConfig) error {
 // ReplaceRelayConnections). Index relays stay connected alongside them.
 func (c *Client) SwitchToUserRelays(userRelays []RelayConfig) error {
 	if len(userRelays) == 0 {
-		log.ClientCore().Warn("No user relays provided, keeping current session relays")
+		clog().Warn("No user relays provided, keeping current session relays")
 		return nil
 	}
-	log.ClientCore().Info("Switching to user relays", "relay_count", len(userRelays))
+	clog().Info("Switching to user relays", "relay_count", len(userRelays))
 	return c.ReplaceRelayConnections(userRelays)
 }
 
@@ -604,7 +606,7 @@ func (c *Client) SwitchToIndexRelays() error {
 	for _, u := range previous {
 		c.relayPool.Release(u)
 	}
-	log.ClientCore().Info("Released session relays; pinned index relays remain", "released", len(previous))
+	clog().Info("Released session relays; pinned index relays remain", "released", len(previous))
 	return nil
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -50,6 +50,13 @@ type Client struct {
 	fixedMode  bool
 	fixedRead  []string
 	fixedWrite []string
+
+	// appRelays holds the session's editable overrides for the locally-configured
+	// roles (Indexer/Broadcast/Local/Trusted), seeded from config. An unset role
+	// falls back to config (the index relays) or has no effect. Guarded by
+	// appRelaysMu. These are session preferences, not published Nostr lists.
+	appRelaysMu sync.Mutex
+	appRelays   map[Role][]string
 }
 
 // NewClient creates a new Nostr client instance
@@ -68,6 +75,7 @@ func NewClient(config *Config) *Client {
 	c.mediaDir = newMediaDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserMediaServersFromNetwork)
 	c.relayListsCache = make(map[string]relayListsEntry)
 	c.relayListsInflight = make(map[string]chan struct{})
+	c.appRelays = make(map[Role][]string)
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -33,6 +33,11 @@ type Client struct {
 	// 10063 / NIP-96 kind 10096) for the upload flow.
 	mediaDir *MediaDirectory
 
+	// relayListsCache caches a user's resolved relay lists (all kinds) so the
+	// settings page renders from cache once login-hydration has warmed it.
+	relayListsMu    sync.Mutex
+	relayListsCache map[string]relayListsEntry
+
 	// Fixed-relay override (opt-out, default OFF). When enabled, every read uses
 	// fixedRead and every write uses fixedWrite, bypassing outbox routing
 	// entirely — replies stop reaching other users' inboxes. Only for users who
@@ -56,6 +61,7 @@ func NewClient(config *Config) *Client {
 	}
 	c.directory = newRelayDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserRelaysFromNetwork)
 	c.mediaDir = newMediaDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserMediaServersFromNetwork)
+	c.relayListsCache = make(map[string]relayListsEntry)
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -57,6 +57,11 @@ type Client struct {
 	// appRelaysMu. These are session preferences, not published Nostr lists.
 	appRelaysMu sync.Mutex
 	appRelays   map[Role][]string
+
+	// relayInfoCache TTL-caches relays' NIP-11 documents for the known-relays
+	// browser (#98). A plain HTTP GET per relay, not a pool connection.
+	relayInfoMu    sync.Mutex
+	relayInfoCache map[string]relayInfoEntry
 }
 
 // NewClient creates a new Nostr client instance
@@ -76,6 +81,7 @@ func NewClient(config *Config) *Client {
 	c.relayListsCache = make(map[string]relayListsEntry)
 	c.relayListsInflight = make(map[string]chan struct{})
 	c.appRelays = make(map[Role][]string)
+	c.relayInfoCache = make(map[string]relayInfoEntry)
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -17,6 +18,12 @@ type Client struct {
 	subscriptions map[string]*Subscription
 	config        *Config
 	mu            sync.RWMutex
+
+	// sessionRelays are the urls Acquired for the currently logged-in session
+	// (a lease held on each for the session's lifetime). Guarded by mu. They're
+	// released when the session switches relays or ends, so they can be
+	// idle-evicted — the outbox pool stays additive rather than torn down.
+	sessionRelays []string
 }
 
 // NewClient creates a new Nostr client instance
@@ -462,97 +469,85 @@ type RelayConfig struct {
 	Write bool   `json:"write"`
 }
 
-// ReplaceRelayConnections replaces current relay connections with a new set
+// ReplaceRelayConnections swaps the relays held for the current session.
+//
+// In the outbox model this is ADDITIVE: it does not tear the shared pool down.
+// It releases the previous session's leases (so those connections become
+// idle-evictable once nothing else needs them) and acquires the new set,
+// holding one lease on each for the session's lifetime. Index/seed relays are
+// pinned separately and are never affected by a session switch.
 func (c *Client) ReplaceRelayConnections(newRelays []RelayConfig) error {
-	log.ClientCore().Info("Replacing relay connections", "new_relay_count", len(newRelays))
-
-	// Extract URLs for connection
-	var relayURLs []string
+	urls := make([]string, 0, len(newRelays))
 	for _, relay := range newRelays {
-		relayURLs = append(relayURLs, relay.URL)
+		urls = append(urls, relay.URL)
 	}
 
-	// Close existing connections (need to do this with lock)
+	// Drop the previous session's holds first.
 	c.mu.Lock()
-	if err := c.relayPool.Close(); err != nil {
-		log.ClientCore().Warn("Error closing existing relay pool", "error", err)
+	previous := c.sessionRelays
+	c.sessionRelays = nil
+	c.mu.Unlock()
+	for _, u := range previous {
+		c.relayPool.Release(u)
 	}
 
-	// Create new relay pool with current config
-	c.relayPool = NewRelayPool(c.config)
-	c.mu.Unlock() // IMPORTANT: Unlock before trying to connect to avoid deadlock
-
-	// Connect to new relays (this needs to happen without the lock)
-	if err := c.ConnectToRelaysWithRetry(relayURLs, 2); err != nil {
-		log.ClientCore().Error("Failed to connect to new relay set", "error", err)
-		// Try to recover by connecting to index relays
-		c.mu.Lock()
-		c.relayPool = NewRelayPool(c.config)
-		c.mu.Unlock()
-
-		// Try index relays as fallback
-		if len(c.config.IndexRelays) > 0 {
-			log.ClientCore().Info("Attempting to reconnect to index relays as fallback")
-			if fallbackErr := c.ConnectToRelaysWithRetry(c.config.IndexRelays, 1); fallbackErr != nil {
-				log.ClientCore().Error("Failed to connect to index relays as fallback", "error", fallbackErr)
-			}
+	// Acquire the new set, holding one lease each for the session duration.
+	acquired := make([]string, 0, len(urls))
+	for _, u := range urls {
+		if _, err := c.relayPool.Acquire(u); err != nil {
+			log.ClientCore().Debug("Failed to acquire session relay", "relay", u, "error", err)
+			continue
 		}
-
-		return fmt.Errorf("failed to connect to new relay set: %w", err)
+		acquired = append(acquired, u)
 	}
 
-	// Log relay permissions
-	for _, relay := range newRelays {
-		permissions := []string{}
-		if relay.Read {
-			permissions = append(permissions, "read")
-		}
-		if relay.Write {
-			permissions = append(permissions, "write")
-		}
-		log.ClientCore().Debug("Relay permissions set",
-			"relay", relay.URL,
-			"permissions", permissions)
+	c.mu.Lock()
+	c.sessionRelays = acquired
+	c.mu.Unlock()
+
+	if len(acquired) == 0 && len(urls) > 0 {
+		return fmt.Errorf("failed to connect to any of the %d requested relays", len(urls))
 	}
 
-	connectedRelays := c.GetConnectedRelays()
-	log.ClientCore().Info("Successfully replaced relay connections",
-		"requested_count", len(newRelays),
-		"connected_count", len(connectedRelays),
-		"connected_relays", connectedRelays)
-
+	log.ClientCore().Info("Switched session relays (additive)",
+		"requested", len(urls), "acquired", len(acquired))
 	return nil
 }
 
-// SwitchToUserRelays switches the client to use user's cached relays
+// SwitchToUserRelays holds the user's relays for the session (additive — see
+// ReplaceRelayConnections). Index relays stay connected alongside them.
 func (c *Client) SwitchToUserRelays(userRelays []RelayConfig) error {
-	log.ClientCore().Info("Switching to user relays", "relay_count", len(userRelays))
-
 	if len(userRelays) == 0 {
-		log.ClientCore().Warn("No user relays found, keeping current connections")
+		log.ClientCore().Warn("No user relays provided, keeping current session relays")
 		return nil
 	}
-
-	// Replace connections with user's relays
+	log.ClientCore().Info("Switching to user relays", "relay_count", len(userRelays))
 	return c.ReplaceRelayConnections(userRelays)
 }
 
-// SwitchToIndexRelays switches the client back to the configured index
-// (seed/discovery) relays — used when a session ends or when no per-user
-// mailbox set is known.
+// SwitchToIndexRelays releases the current session's relay leases. There is
+// nothing to "switch back" to in the additive model: the index/seed relays are
+// pinned and kept up by the health check, so they remain connected regardless.
 func (c *Client) SwitchToIndexRelays() error {
-	log.ClientCore().Info("Switching to index relays")
-
-	// Convert index relays to RelayConfig format (both read and write)
-	var indexRelayConfigs []RelayConfig
-	for _, url := range c.config.IndexRelays {
-		indexRelayConfigs = append(indexRelayConfigs, RelayConfig{
-			URL:   url,
-			Read:  true,
-			Write: true,
-		})
+	c.mu.Lock()
+	previous := c.sessionRelays
+	c.sessionRelays = nil
+	c.mu.Unlock()
+	for _, u := range previous {
+		c.relayPool.Release(u)
 	}
+	log.ClientCore().Info("Released session relays; pinned index relays remain", "released", len(previous))
+	return nil
+}
 
-	// Replace connections with index relays
-	return c.ReplaceRelayConnections(indexRelayConfigs)
+// PinRelays marks relays so the idle sweeper never evicts them — used for the
+// index/seed relays. Pinning does not dial; the connection is still established
+// on demand by Acquire or the startup connect.
+func (c *Client) PinRelays(urls ...string) {
+	c.relayPool.Pin(urls...)
+}
+
+// StartEvictionSweeper starts the pool's idle-connection sweeper, bounded to ctx.
+func (c *Client) StartEvictionSweeper(ctx context.Context, interval time.Duration) {
+	c.relayPool.StartEvictionSweeper(ctx, interval)
 }

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -295,6 +295,11 @@ func collectLatestReplaceable(sub *Subscription, totalRelays int, timeout time.D
 func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Event, error) {
 	log.ClientCore().Debug("Fetching user profile", "pubkey", pubkey, "relay_hints", relayHints)
 
+	// Background-warm this user's mailbox relays into the directory (and thus
+	// the "known" set), without blocking this fetch. Resolution only queries the
+	// already-connected index relays, so it adds no new dials.
+	c.WarmRelays(pubkey)
+
 	// Create filter for metadata (kind 0)
 	filter := nostr.Filter{
 		Authors: []string{pubkey},

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -84,7 +84,7 @@ func NewClient(config *Config) *Client {
 		subscriptions: make(map[string]*Subscription),
 		config:        config,
 	}
-	c.directory = newRelayDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserRelaysFromNetwork)
+	c.directory = newRelayDirectoryWithStore(config.RelayListTTL, config.RelayListNegTTL, config.RelayListStore, c.fetchUserRelaysFromNetwork)
 	c.mediaDir = newMediaDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserMediaServersFromNetwork)
 	c.relayListsCache = make(map[string]relayListsEntry)
 	c.relayListsInflight = make(map[string]chan struct{})

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -28,6 +28,14 @@ type Client struct {
 	// directory resolves and caches per-target users' event-derived relay roles
 	// (outbox / inbox / DM inbox) for outbox routing.
 	directory *RelayDirectory
+
+	// Fixed-relay override (opt-out, default OFF). When enabled, every read uses
+	// fixedRead and every write uses fixedWrite, bypassing outbox routing
+	// entirely — replies stop reaching other users' inboxes. Only for users who
+	// explicitly want a fixed-/single-relay client. Guarded by mu.
+	fixedMode  bool
+	fixedRead  []string
+	fixedWrite []string
 }
 
 // NewClient creates a new Nostr client instance

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -35,8 +35,13 @@ type Client struct {
 
 	// relayListsCache caches a user's resolved relay lists (all kinds) so the
 	// settings page renders from cache once login-hydration has warmed it.
-	relayListsMu    sync.Mutex
-	relayListsCache map[string]relayListsEntry
+	// relayListsInflight collapses concurrent resolves for the same pubkey onto
+	// one network fetch (e.g. the relay-pool dropdown's warm prefetch and the
+	// relay manager's own load), so the second caller waits for the first
+	// instead of duplicating a multi-second cold resolve.
+	relayListsMu       sync.Mutex
+	relayListsCache    map[string]relayListsEntry
+	relayListsInflight map[string]chan struct{}
 
 	// Fixed-relay override (opt-out, default OFF). When enabled, every read uses
 	// fixedRead and every write uses fixedWrite, bypassing outbox routing
@@ -62,6 +67,7 @@ func NewClient(config *Config) *Client {
 	c.directory = newRelayDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserRelaysFromNetwork)
 	c.mediaDir = newMediaDirectory(config.RelayListTTL, config.RelayListNegTTL, c.fetchUserMediaServersFromNetwork)
 	c.relayListsCache = make(map[string]relayListsEntry)
+	c.relayListsInflight = make(map[string]chan struct{})
 	return c
 }
 

--- a/client/core/client.go
+++ b/client/core/client.go
@@ -168,7 +168,10 @@ func (c *Client) DisconnectFromRelays(relayURLs []string) error {
 }
 
 // Subscribe creates a new subscription with filters and relay hints
-func (c *Client) Subscribe(filters []nostr.Filter, relayHints []string) (*Subscription, error) {
+func (c *Client) Subscribe(ctx context.Context, filters []nostr.Filter, relayHints []string) (*Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err // already cancelled / past deadline
+	}
 	subID := generateSubscriptionID()
 
 	// Use all connected relays if no hints provided
@@ -272,7 +275,7 @@ func (c *Client) ConnectToRelaysWithRetry(urls []string, maxRetries int) error {
 // the GetUserRelays latency bug (#77): that method used to wait on sub.Done —
 // which EOSE never closes — so every mailbox fetch burned the full timeout
 // instead of returning the moment a relay reported EOSE.
-func collectLatestReplaceable(sub *Subscription, totalRelays int, timeout time.Duration) *nostr.Event {
+func collectLatestReplaceable(ctx context.Context, sub *Subscription, totalRelays int, timeout time.Duration) *nostr.Event {
 	deadline := time.After(timeout)
 	eoseRelays := make(map[string]bool)
 	var latest *nostr.Event
@@ -304,13 +307,15 @@ func collectLatestReplaceable(sub *Subscription, totalRelays int, timeout time.D
 			log.ClientCore().Debug("Subscription error while collecting event",
 				"sub_id", sub.ID, "error", err)
 
+		case <-ctx.Done():
+			return latest
 		case <-deadline:
 			return latest
 		}
 	}
 }
 
-func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Event, error) {
+func (c *Client) GetUserProfile(ctx context.Context, pubkey string, relayHints []string) (*nostr.Event, error) {
 	log.ClientCore().Debug("Fetching user profile", "pubkey", pubkey, "relay_hints", relayHints)
 
 	// Background-warm this user's mailbox relays into the directory (and thus
@@ -336,13 +341,13 @@ func (c *Client) GetUserProfile(pubkey string, relayHints []string) (*nostr.Even
 			"pubkey", pubkey, "relays", targetRelays)
 	}
 
-	sub, err := c.Subscribe([]nostr.Filter{filter}, targetRelays)
+	sub, err := c.Subscribe(ctx, []nostr.Filter{filter}, targetRelays)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create subscription: %w", err)
 	}
 	defer sub.Close()
 
-	event := collectLatestReplaceable(sub, len(targetRelays), 5*time.Second)
+	event := collectLatestReplaceable(ctx, sub, len(targetRelays), 5*time.Second)
 	if event == nil {
 		log.ClientCore().Warn("No profile found", "pubkey", pubkey)
 		return nil, &ClientError{Message: "profile not found"}

--- a/client/core/client_session_test.go
+++ b/client/core/client_session_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+func assertHasRelay(t *testing.T, urls []string, want string) {
+	t.Helper()
+	for _, u := range urls {
+		if u == want {
+			return
+		}
+	}
+	t.Fatalf("expected %q in connected relays %v", want, urls)
+}
+
+// Logging in / switching users must be ADDITIVE: the shared pool (and the
+// pinned index relays) survive a session switch, the previous user's relays
+// are released, and the new user's relays are leased for the session. This is
+// the core behavior change of Phase A2 — the old code tore the whole pool down.
+func TestSessionRelaySwitchIsAdditive(t *testing.T) {
+	c := NewClient(DefaultConfig())
+	c.relayPool.dialFn = func(string, time.Duration) (*websocket.Conn, error) { return nil, nil }
+	c.relayPool.startReader = func(*RelayConnection) {}
+
+	// A pinned, connected index relay (as the manager sets up at startup).
+	c.PinRelays("wss://index")
+	if _, err := c.relayPool.Acquire("wss://index"); err != nil {
+		t.Fatalf("acquire index: %v", err)
+	}
+	c.relayPool.Release("wss://index") // pinned ⇒ stays connected at lease 0
+
+	// Login as user A.
+	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://userA", Read: true, Write: true}}); err != nil {
+		t.Fatalf("switch to user A: %v", err)
+	}
+	conns := c.GetConnectedRelays()
+	assertHasRelay(t, conns, "wss://index") // index NOT torn down
+	assertHasRelay(t, conns, "wss://userA")
+	if l := leasesOf(c.relayPool, "wss://userA"); l != 1 {
+		t.Fatalf("userA leases = %d, want 1 (held for the session)", l)
+	}
+
+	// Switch to user B: A's session lease released, B acquired.
+	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://userB"}}); err != nil {
+		t.Fatalf("switch to user B: %v", err)
+	}
+	if l := leasesOf(c.relayPool, "wss://userA"); l != 0 {
+		t.Fatalf("userA leases after switch = %d, want 0 (released)", l)
+	}
+	if l := leasesOf(c.relayPool, "wss://userB"); l != 1 {
+		t.Fatalf("userB leases = %d, want 1", l)
+	}
+
+	// Logout: session relays released, pinned index relay remains.
+	if err := c.SwitchToIndexRelays(); err != nil {
+		t.Fatalf("switch to index: %v", err)
+	}
+	if l := leasesOf(c.relayPool, "wss://userB"); l != 0 {
+		t.Fatalf("userB leases after logout = %d, want 0", l)
+	}
+	assertHasRelay(t, c.GetConnectedRelays(), "wss://index")
+}

--- a/client/core/client_session_test.go
+++ b/client/core/client_session_test.go
@@ -34,24 +34,24 @@ func TestSessionRelaySwitchIsAdditive(t *testing.T) {
 	c.relayPool.Release("wss://index") // pinned ⇒ stays connected at lease 0
 
 	// Login as user A.
-	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://userA", Read: true, Write: true}}); err != nil {
+	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://user-a", Read: true, Write: true}}); err != nil {
 		t.Fatalf("switch to user A: %v", err)
 	}
 	conns := c.GetConnectedRelays()
 	assertHasRelay(t, conns, "wss://index") // index NOT torn down
-	assertHasRelay(t, conns, "wss://userA")
-	if l := leasesOf(c.relayPool, "wss://userA"); l != 1 {
+	assertHasRelay(t, conns, "wss://user-a")
+	if l := leasesOf(c.relayPool, "wss://user-a"); l != 1 {
 		t.Fatalf("userA leases = %d, want 1 (held for the session)", l)
 	}
 
 	// Switch to user B: A's session lease released, B acquired.
-	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://userB"}}); err != nil {
+	if err := c.SwitchToUserRelays([]RelayConfig{{URL: "wss://user-b"}}); err != nil {
 		t.Fatalf("switch to user B: %v", err)
 	}
-	if l := leasesOf(c.relayPool, "wss://userA"); l != 0 {
+	if l := leasesOf(c.relayPool, "wss://user-a"); l != 0 {
 		t.Fatalf("userA leases after switch = %d, want 0 (released)", l)
 	}
-	if l := leasesOf(c.relayPool, "wss://userB"); l != 1 {
+	if l := leasesOf(c.relayPool, "wss://user-b"); l != 1 {
 		t.Fatalf("userB leases = %d, want 1", l)
 	}
 
@@ -59,7 +59,7 @@ func TestSessionRelaySwitchIsAdditive(t *testing.T) {
 	if err := c.SwitchToIndexRelays(); err != nil {
 		t.Fatalf("switch to index: %v", err)
 	}
-	if l := leasesOf(c.relayPool, "wss://userB"); l != 0 {
+	if l := leasesOf(c.relayPool, "wss://user-b"); l != 0 {
 		t.Fatalf("userB leases after logout = %d, want 0", l)
 	}
 	assertHasRelay(t, c.GetConnectedRelays(), "wss://index")

--- a/client/core/clienttag.go
+++ b/client/core/clienttag.go
@@ -1,0 +1,38 @@
+package core
+
+import nostr "github.com/0ceanslim/grain/server/types"
+
+// DefaultClientTagName is grain's client-tag value when none is configured. The
+// "on by default" semantics live in the resolving handler + config loader; this
+// is just the fallback name.
+const DefaultClientTagName = "grain"
+
+// applyClientTag strips every foreign `client` tag from tags and, when enabled,
+// appends grain's own ["client", name]. Always strips; conditionally adds.
+// Returns a new slice — the input is not mutated.
+func applyClientTag(tags [][]string, enabled bool, name string) [][]string {
+	out := make([][]string, 0, len(tags)+1)
+	for _, t := range tags {
+		if len(t) >= 1 && t[0] == "client" {
+			continue // drop foreign client tags (e.g. a carried-over client:amethyst)
+		}
+		out = append(out, t)
+	}
+	if enabled {
+		if name == "" {
+			name = DefaultClientTagName
+		}
+		out = append(out, []string{"client", name})
+	}
+	return out
+}
+
+// ApplyClientTag rewrites an event's client tag in place per grain's policy:
+// strip any foreign `client` tag always, add grain's own when enabled. Safe on a
+// nil event. Build handlers call this after assembling an event grain authors.
+func ApplyClientTag(event *nostr.Event, enabled bool, name string) {
+	if event == nil {
+		return
+	}
+	event.Tags = applyClientTag(event.Tags, enabled, name)
+}

--- a/client/core/clienttag_test.go
+++ b/client/core/clienttag_test.go
@@ -1,0 +1,58 @@
+package core
+
+import "testing"
+
+func hasTag(tags [][]string, key, val string) bool {
+	for _, t := range tags {
+		if len(t) >= 2 && t[0] == key && t[1] == val {
+			return true
+		}
+	}
+	return false
+}
+
+func countTag(tags [][]string, key string) int {
+	n := 0
+	for _, t := range tags {
+		if len(t) >= 1 && t[0] == key {
+			n++
+		}
+	}
+	return n
+}
+
+func TestApplyClientTag(t *testing.T) {
+	base := [][]string{{"d", "x"}, {"client", "amethyst"}, {"r", "wss://relay.example"}}
+
+	// Enabled: foreign stripped, grain's own added exactly once, others kept.
+	on := applyClientTag(base, true, "grain")
+	if hasTag(on, "client", "amethyst") {
+		t.Error("foreign client tag should be stripped")
+	}
+	if !hasTag(on, "client", "grain") {
+		t.Error("grain client tag should be added")
+	}
+	if countTag(on, "client") != 1 {
+		t.Errorf("expected exactly one client tag, got %d", countTag(on, "client"))
+	}
+	if !hasTag(on, "d", "x") || !hasTag(on, "r", "wss://relay.example") {
+		t.Error("non-client tags must be preserved")
+	}
+
+	// Disabled: foreign stripped, none added.
+	off := applyClientTag(base, false, "grain")
+	if countTag(off, "client") != 0 {
+		t.Errorf("disabled should leave no client tag, got %d", countTag(off, "client"))
+	}
+
+	// Empty name falls back to the default.
+	def := applyClientTag(nil, true, "")
+	if !hasTag(def, "client", DefaultClientTagName) {
+		t.Errorf("empty name should default to %q", DefaultClientTagName)
+	}
+
+	// Input slice is not mutated.
+	if !hasTag(base, "client", "amethyst") {
+		t.Error("input slice must not be mutated")
+	}
+}

--- a/client/core/collect_test.go
+++ b/client/core/collect_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ func TestCollectReturnsEventOnEOSE(t *testing.T) {
 	sub.Events <- &nostr.Event{ID: "e1", CreatedAt: 100}
 	sub.EOSE <- "wss://a"
 
-	got := collectLatestReplaceable(sub, 2, 300*time.Millisecond)
+	got := collectLatestReplaceable(context.Background(), sub, 2, 300*time.Millisecond)
 	if got == nil || got.ID != "e1" {
 		t.Fatalf("want event e1, got %+v", got)
 	}
@@ -40,7 +41,7 @@ func TestCollectPicksHighestCreatedAt(t *testing.T) {
 	sub.Events <- &nostr.Event{ID: "old", CreatedAt: 100}
 	sub.Events <- &nostr.Event{ID: "new", CreatedAt: 200}
 
-	got := collectLatestReplaceable(sub, 2, 150*time.Millisecond)
+	got := collectLatestReplaceable(context.Background(), sub, 2, 150*time.Millisecond)
 	if got == nil || got.ID != "new" {
 		t.Fatalf("want newest event 'new', got %+v", got)
 	}
@@ -56,7 +57,7 @@ func TestCollectAllEOSEReturnsNilPromptly(t *testing.T) {
 	sub.EOSE <- "wss://b"
 
 	start := time.Now()
-	got := collectLatestReplaceable(sub, 2, 2*time.Second)
+	got := collectLatestReplaceable(context.Background(), sub, 2, 2*time.Second)
 	elapsed := time.Since(start)
 
 	if got != nil {
@@ -70,7 +71,7 @@ func TestCollectAllEOSEReturnsNilPromptly(t *testing.T) {
 // Nothing arrives: nil at the deadline (offline / not-found case).
 func TestCollectTimeoutReturnsNil(t *testing.T) {
 	sub := newTestSub("t4", 1)
-	if got := collectLatestReplaceable(sub, 1, 150*time.Millisecond); got != nil {
+	if got := collectLatestReplaceable(context.Background(), sub, 1, 150*time.Millisecond); got != nil {
 		t.Fatalf("want nil on timeout, got %+v", got)
 	}
 }
@@ -79,7 +80,7 @@ func TestCollectTimeoutReturnsNil(t *testing.T) {
 func TestCollectTimeoutReturnsLatest(t *testing.T) {
 	sub := newTestSub("t5", 2)
 	sub.Events <- &nostr.Event{ID: "e", CreatedAt: 100}
-	if got := collectLatestReplaceable(sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
+	if got := collectLatestReplaceable(context.Background(), sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
 		t.Fatalf("want event e at timeout, got %+v", got)
 	}
 }
@@ -90,7 +91,7 @@ func TestCollectErrorIsNonFatal(t *testing.T) {
 	sub.Errors <- errors.New("relay blew up")
 	sub.Events <- &nostr.Event{ID: "e", CreatedAt: 100}
 
-	if got := collectLatestReplaceable(sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
+	if got := collectLatestReplaceable(context.Background(), sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
 		t.Fatalf("want event e despite a relay error, got %+v", got)
 	}
 }

--- a/client/core/collect_test.go
+++ b/client/core/collect_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// newTestSub builds a Subscription with just the channels collectLatestReplaceable
+// reads. No live websocket or relay pool is needed — the helper only consumes
+// Events / EOSE / Errors, which lets us drive it deterministically.
+func newTestSub(id string, relays int) *Subscription {
+	return &Subscription{
+		ID:     id,
+		Events: make(chan *nostr.Event, 10),
+		Errors: make(chan error, 10),
+		EOSE:   make(chan string, relays),
+	}
+}
+
+// An event in hand plus a relay EOSE must return that event (never nil). The
+// relay count is 2 so a single EOSE can't trip the all-EOSE→nil path.
+func TestCollectReturnsEventOnEOSE(t *testing.T) {
+	sub := newTestSub("t1", 2)
+	sub.Events <- &nostr.Event{ID: "e1", CreatedAt: 100}
+	sub.EOSE <- "wss://a"
+
+	got := collectLatestReplaceable(sub, 2, 300*time.Millisecond)
+	if got == nil || got.ID != "e1" {
+		t.Fatalf("want event e1, got %+v", got)
+	}
+}
+
+// Newest-by-created_at wins. No EOSE is sent, so both buffered events are
+// drained before the deadline returns the latest — order-independent.
+func TestCollectPicksHighestCreatedAt(t *testing.T) {
+	sub := newTestSub("t2", 2)
+	sub.Events <- &nostr.Event{ID: "old", CreatedAt: 100}
+	sub.Events <- &nostr.Event{ID: "new", CreatedAt: 200}
+
+	got := collectLatestReplaceable(sub, 2, 150*time.Millisecond)
+	if got == nil || got.ID != "new" {
+		t.Fatalf("want newest event 'new', got %+v", got)
+	}
+}
+
+// This is the #77 regression guard: every relay reporting EOSE with no event
+// must return nil *promptly*, not after waiting out the full deadline. If the
+// old sub.Done bug ever returns, EOSE is never consumed and this blocks until
+// the 2s deadline, failing the elapsed check.
+func TestCollectAllEOSEReturnsNilPromptly(t *testing.T) {
+	sub := newTestSub("t3", 2)
+	sub.EOSE <- "wss://a"
+	sub.EOSE <- "wss://b"
+
+	start := time.Now()
+	got := collectLatestReplaceable(sub, 2, 2*time.Second)
+	elapsed := time.Since(start)
+
+	if got != nil {
+		t.Fatalf("want nil when all relays EOSE with no event, got %+v", got)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("all-EOSE should short-circuit, took %s (did it wait for the deadline?)", elapsed)
+	}
+}
+
+// Nothing arrives: nil at the deadline (offline / not-found case).
+func TestCollectTimeoutReturnsNil(t *testing.T) {
+	sub := newTestSub("t4", 1)
+	if got := collectLatestReplaceable(sub, 1, 150*time.Millisecond); got != nil {
+		t.Fatalf("want nil on timeout, got %+v", got)
+	}
+}
+
+// An event with no EOSE is still returned once the deadline hits.
+func TestCollectTimeoutReturnsLatest(t *testing.T) {
+	sub := newTestSub("t5", 2)
+	sub.Events <- &nostr.Event{ID: "e", CreatedAt: 100}
+	if got := collectLatestReplaceable(sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
+		t.Fatalf("want event e at timeout, got %+v", got)
+	}
+}
+
+// A relay error is non-fatal: a later event still resolves the call.
+func TestCollectErrorIsNonFatal(t *testing.T) {
+	sub := newTestSub("t6", 2)
+	sub.Errors <- errors.New("relay blew up")
+	sub.Events <- &nostr.Event{ID: "e", CreatedAt: 100}
+
+	if got := collectLatestReplaceable(sub, 2, 150*time.Millisecond); got == nil || got.ID != "e" {
+		t.Fatalf("want event e despite a relay error, got %+v", got)
+	}
+}

--- a/client/core/config.go
+++ b/client/core/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	// NewClient time (see [SetLogger]). Not serialized; defaults to grain's
 	// client-core logging so behaviour is unchanged when unset.
 	Logger Logger `json:"-"`
+
+	// RelayListStore, when non-nil, backs the relay directory's per-user
+	// resolutions with a custom store (see [RelayListStore]) — e.g. a database
+	// for persistence across restarts. Not serialized; defaults to in-memory.
+	RelayListStore RelayListStore `json:"-"`
 }
 
 // DefaultConfig returns a sensible default configuration. The IndexRelays

--- a/client/core/config.go
+++ b/client/core/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	BackoffMax      time.Duration `json:"backoff_max"`        // dial-retry backoff ceiling
 	RelayListTTL    time.Duration `json:"relay_list_ttl"`     // per-user relay-list directory cache TTL
 	RelayListNegTTL time.Duration `json:"relay_list_neg_ttl"` // shorter TTL for "no list published"
+	OpenTimeout     time.Duration `json:"open_timeout"`       // per-dial cap for on-demand outbox dials (< ConnectionTimeout)
 }
 
 // DefaultConfig returns a sensible default configuration. The IndexRelays
@@ -58,6 +59,7 @@ func DefaultConfig() *Config {
 		BackoffMax:        60 * time.Second,
 		RelayListTTL:      time.Hour,
 		RelayListNegTTL:   time.Minute,
+		OpenTimeout:       4 * time.Second,
 	}
 }
 

--- a/client/core/config.go
+++ b/client/core/config.go
@@ -30,6 +30,11 @@ type Config struct {
 	RelayListTTL    time.Duration `json:"relay_list_ttl"`     // per-user relay-list directory cache TTL
 	RelayListNegTTL time.Duration `json:"relay_list_neg_ttl"` // shorter TTL for "no list published"
 	OpenTimeout     time.Duration `json:"open_timeout"`       // per-dial cap for on-demand outbox dials (< ConnectionTimeout)
+
+	// Logger, when non-nil, replaces the process-wide client-library logger at
+	// NewClient time (see [SetLogger]). Not serialized; defaults to grain's
+	// client-core logging so behaviour is unchanged when unset.
+	Logger Logger `json:"-"`
 }
 
 // DefaultConfig returns a sensible default configuration. The IndexRelays

--- a/client/core/config.go
+++ b/client/core/config.go
@@ -19,6 +19,14 @@ type Config struct {
 	RetryDelay        time.Duration `json:"retry_delay"`
 	KeepAlive         bool          `json:"keep_alive"`
 	UserAgent         string        `json:"user_agent"`
+
+	// Outbox-pool lifecycle (#56). Zero values fall back to built-in defaults
+	// in NewRelayPool / the lease methods, so older callers that build a Config
+	// by hand keep working.
+	DialConcurrency int           `json:"dial_concurrency"` // max simultaneous dials
+	IdleTTL         time.Duration `json:"idle_ttl"`         // evict a 0-lease conn after this idle span
+	BackoffBase     time.Duration `json:"backoff_base"`     // first dial-retry backoff
+	BackoffMax      time.Duration `json:"backoff_max"`      // dial-retry backoff ceiling
 }
 
 // DefaultConfig returns a sensible default configuration. The IndexRelays
@@ -37,11 +45,15 @@ func DefaultConfig() *Config {
 		ConnectionTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      10 * time.Second,
-		MaxConnections:    10,
+		MaxConnections:    256, // soft cap; the outbox pool holds many users' relays
 		RetryAttempts:     3,
 		RetryDelay:        2 * time.Second,
 		KeepAlive:         true,
 		UserAgent:         "grain-client/1.0",
+		DialConcurrency:   16,
+		IdleTTL:           120 * time.Second,
+		BackoffBase:       2 * time.Second,
+		BackoffMax:        60 * time.Second,
 	}
 }
 

--- a/client/core/config.go
+++ b/client/core/config.go
@@ -23,10 +23,12 @@ type Config struct {
 	// Outbox-pool lifecycle (#56). Zero values fall back to built-in defaults
 	// in NewRelayPool / the lease methods, so older callers that build a Config
 	// by hand keep working.
-	DialConcurrency int           `json:"dial_concurrency"` // max simultaneous dials
-	IdleTTL         time.Duration `json:"idle_ttl"`         // evict a 0-lease conn after this idle span
-	BackoffBase     time.Duration `json:"backoff_base"`     // first dial-retry backoff
-	BackoffMax      time.Duration `json:"backoff_max"`      // dial-retry backoff ceiling
+	DialConcurrency int           `json:"dial_concurrency"`   // max simultaneous dials
+	IdleTTL         time.Duration `json:"idle_ttl"`           // evict a 0-lease conn after this idle span
+	BackoffBase     time.Duration `json:"backoff_base"`       // first dial-retry backoff
+	BackoffMax      time.Duration `json:"backoff_max"`        // dial-retry backoff ceiling
+	RelayListTTL    time.Duration `json:"relay_list_ttl"`     // per-user relay-list directory cache TTL
+	RelayListNegTTL time.Duration `json:"relay_list_neg_ttl"` // shorter TTL for "no list published"
 }
 
 // DefaultConfig returns a sensible default configuration. The IndexRelays
@@ -54,6 +56,8 @@ func DefaultConfig() *Config {
 		IdleTTL:           120 * time.Second,
 		BackoffBase:       2 * time.Second,
 		BackoffMax:        60 * time.Second,
+		RelayListTTL:      time.Hour,
+		RelayListNegTTL:   time.Minute,
 	}
 }
 

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -83,8 +83,11 @@ func (d *RelayDirectory) Lookup(pubkey string) *UserRelays {
 
 		ur := d.resolve(pubkey)
 		if ur == nil {
-			ur = &UserRelays{FetchedAt: time.Now(), Negative: true}
+			ur = &UserRelays{Negative: true}
 		}
+		// Stamp the fetch time here, not in the resolver, so a resolver that
+		// forgets can't silently disable caching (entry never reads as fresh).
+		ur.FetchedAt = time.Now()
 
 		d.mu.Lock()
 		d.entries[pubkey] = ur
@@ -101,6 +104,18 @@ func (d *RelayDirectory) Invalidate(pubkey string) {
 	d.mu.Lock()
 	delete(d.entries, pubkey)
 	d.mu.Unlock()
+}
+
+// Cached returns a user's resolved relays only if a fresh entry is already in
+// the cache, WITHOUT triggering a network resolve. For latency-sensitive paths
+// (e.g. rendering a profile) that must not block on resolution.
+func (d *RelayDirectory) Cached(pubkey string) (*UserRelays, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if ur, ok := d.entries[pubkey]; ok && d.fresh(ur) {
+		return ur, true
+	}
+	return nil, false
 }
 
 // ResolveRelays returns a target user's per-target relay roles (outbox / inbox /

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -25,7 +25,7 @@ type UserRelays struct {
 // concurrent lookups for the same pubkey into a single network fetch.
 type RelayDirectory struct {
 	mu       sync.Mutex
-	entries  map[string]*UserRelays
+	store    RelayListStore
 	inflight map[string]chan struct{}
 	ttl      time.Duration
 	negTTL   time.Duration
@@ -33,14 +33,23 @@ type RelayDirectory struct {
 }
 
 func newRelayDirectory(ttl, negTTL time.Duration, resolve func(string) *UserRelays) *RelayDirectory {
+	return newRelayDirectoryWithStore(ttl, negTTL, nil, resolve)
+}
+
+// newRelayDirectoryWithStore is newRelayDirectory with an explicit persistence
+// store; a nil store falls back to the default in-memory one.
+func newRelayDirectoryWithStore(ttl, negTTL time.Duration, store RelayListStore, resolve func(string) *UserRelays) *RelayDirectory {
 	if ttl <= 0 {
 		ttl = time.Hour
 	}
 	if negTTL <= 0 {
 		negTTL = time.Minute
 	}
+	if store == nil {
+		store = newMemRelayListStore()
+	}
 	return &RelayDirectory{
-		entries:  make(map[string]*UserRelays),
+		store:    store,
 		inflight: make(map[string]chan struct{}),
 		ttl:      ttl,
 		negTTL:   negTTL,
@@ -67,7 +76,7 @@ func (d *RelayDirectory) fresh(ur *UserRelays) bool {
 func (d *RelayDirectory) Lookup(pubkey string) *UserRelays {
 	for {
 		d.mu.Lock()
-		if ur, ok := d.entries[pubkey]; ok && d.fresh(ur) {
+		if ur, ok := d.store.Get(pubkey); ok && d.fresh(ur) {
 			d.mu.Unlock()
 			return ur
 		}
@@ -90,7 +99,7 @@ func (d *RelayDirectory) Lookup(pubkey string) *UserRelays {
 		ur.FetchedAt = time.Now()
 
 		d.mu.Lock()
-		d.entries[pubkey] = ur
+		d.store.Set(pubkey, ur)
 		delete(d.inflight, pubkey)
 		close(ch)
 		d.mu.Unlock()
@@ -102,7 +111,7 @@ func (d *RelayDirectory) Lookup(pubkey string) *UserRelays {
 // observing a newer relay-list event for the user.
 func (d *RelayDirectory) Invalidate(pubkey string) {
 	d.mu.Lock()
-	delete(d.entries, pubkey)
+	d.store.Delete(pubkey)
 	d.mu.Unlock()
 }
 
@@ -117,11 +126,11 @@ func (d *RelayDirectory) Store(pubkey string, ur *UserRelays) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	existing, ok := d.entries[pubkey]
+	existing, ok := d.store.Get(pubkey)
 	if !ok {
 		ur.FetchedAt = time.Now()
 		ur.Negative = false
-		d.entries[pubkey] = ur
+		d.store.Set(pubkey, ur)
 		return
 	}
 	if len(ur.Outbox) > 0 {
@@ -135,6 +144,7 @@ func (d *RelayDirectory) Store(pubkey string, ur *UserRelays) {
 	}
 	existing.FetchedAt = time.Now()
 	existing.Negative = false
+	d.store.Set(pubkey, existing) // persist the merge (no-op for the in-memory store, required for a persistent one)
 }
 
 // KnownRelays returns the distinct relay URLs across every resolved entry —
@@ -145,7 +155,7 @@ func (d *RelayDirectory) KnownRelays() []string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	set := make(map[string]struct{})
-	for _, ur := range d.entries {
+	d.store.Range(func(_ string, ur *UserRelays) bool {
 		for _, r := range ur.Outbox {
 			set[r] = struct{}{}
 		}
@@ -155,7 +165,8 @@ func (d *RelayDirectory) KnownRelays() []string {
 		for _, r := range ur.DMInbox {
 			set[r] = struct{}{}
 		}
-	}
+		return true
+	})
 	out := make([]string, 0, len(set))
 	for r := range set {
 		out = append(out, r)
@@ -169,7 +180,7 @@ func (d *RelayDirectory) KnownRelays() []string {
 func (d *RelayDirectory) Cached(pubkey string) (*UserRelays, bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if ur, ok := d.entries[pubkey]; ok && d.fresh(ur) {
+	if ur, ok := d.store.Get(pubkey); ok && d.fresh(ur) {
 		return ur, true
 	}
 	return nil, false

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -106,6 +106,32 @@ func (d *RelayDirectory) Invalidate(pubkey string) {
 	d.mu.Unlock()
 }
 
+// KnownRelays returns the distinct relay URLs across every resolved entry —
+// the union of all users' outbox / inbox / DM relays the directory has seen.
+// This is the bulk of the client's "known relays" set: relays we're aware of
+// from indexer-seeded mailbox lists, whether or not we're connected to them.
+func (d *RelayDirectory) KnownRelays() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	set := make(map[string]struct{})
+	for _, ur := range d.entries {
+		for _, r := range ur.Outbox {
+			set[r] = struct{}{}
+		}
+		for _, r := range ur.Inbox {
+			set[r] = struct{}{}
+		}
+		for _, r := range ur.DMInbox {
+			set[r] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for r := range set {
+		out = append(out, r)
+	}
+	return out
+}
+
 // Cached returns a user's resolved relays only if a fresh entry is already in
 // the cache, WITHOUT triggering a network resolve. For latency-sensitive paths
 // (e.g. rendering a profile) that must not block on resolution.
@@ -123,6 +149,17 @@ func (d *RelayDirectory) Cached(pubkey string) (*UserRelays, bool) {
 // TTL. Safe for concurrent use; the logged-in user is just another pubkey.
 func (c *Client) ResolveRelays(pubkey string) *UserRelays {
 	return c.directory.Lookup(pubkey)
+}
+
+// WarmRelays kicks an asynchronous resolution of a user's relay lists into the
+// directory if not already cached, so their mailbox relays join the "known" set
+// and the cache is ready for outbox-routed fetches next time — without blocking
+// the caller and without dialing (resolution queries the index relays only).
+func (c *Client) WarmRelays(pubkey string) {
+	if _, ok := c.directory.Cached(pubkey); ok {
+		return
+	}
+	go c.directory.Lookup(pubkey)
 }
 
 // fetchUserRelaysFromNetwork is the RelayDirectory's resolver: it queries the

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -210,11 +211,11 @@ func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		nip65 = c.fetchLatestEvent(pubkey, 10002, relays)
+		nip65 = c.fetchLatestEvent(context.Background(), pubkey, 10002, relays)
 	}()
 	go func() {
 		defer wg.Done()
-		nip17 = c.fetchLatestEvent(pubkey, 10050, relays)
+		nip17 = c.fetchLatestEvent(context.Background(), pubkey, 10050, relays)
 	}()
 	wg.Wait()
 
@@ -236,8 +237,8 @@ func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
 
 // fetchLatestEvent returns the newest event of kind for pubkey from relays, or
 // nil if none arrives. Shared by the directory resolver.
-func (c *Client) fetchLatestEvent(pubkey string, kind int, relays []string) *nostr.Event {
-	return c.fetchLatestEventWithin(pubkey, kind, relays, 5*time.Second)
+func (c *Client) fetchLatestEvent(ctx context.Context, pubkey string, kind int, relays []string) *nostr.Event {
+	return c.fetchLatestEventWithin(ctx, pubkey, kind, relays, 5*time.Second)
 }
 
 // fetchLatestEventWithin is fetchLatestEvent with a caller-chosen deadline. A
@@ -246,7 +247,7 @@ func (c *Client) fetchLatestEvent(pubkey string, kind int, relays []string) *nos
 // case. Callers resolving "does the user have this list at all?" (media servers,
 // relay lists) pass a shorter deadline so a cold miss doesn't stall the UI for
 // the full 5s.
-func (c *Client) fetchLatestEventWithin(pubkey string, kind int, relays []string, timeout time.Duration) *nostr.Event {
+func (c *Client) fetchLatestEventWithin(ctx context.Context, pubkey string, kind int, relays []string, timeout time.Duration) *nostr.Event {
 	if len(relays) == 0 {
 		return nil
 	}
@@ -256,13 +257,13 @@ func (c *Client) fetchLatestEventWithin(pubkey string, kind int, relays []string
 		Kinds:   []int{kind},
 		Limit:   &limit,
 	}
-	sub, err := c.Subscribe([]nostr.Filter{filter}, relays)
+	sub, err := c.Subscribe(ctx, []nostr.Filter{filter}, relays)
 	if err != nil {
 		log.ClientCore().Debug("Subscribe failed during relay resolution", "pubkey", pubkey, "kind", kind, "error", err)
 		return nil
 	}
 	defer sub.Close()
-	return collectLatestReplaceable(sub, len(relays), timeout)
+	return collectLatestReplaceable(ctx, sub, len(relays), timeout)
 }
 
 // parseDMRelays extracts relay URLs from a NIP-17 kind 10050 event's relay tags.

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // UserRelays holds a target user's per-target event-derived relay roles,
@@ -230,7 +229,7 @@ func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
 	}
 	ur.Negative = len(ur.Outbox) == 0 && len(ur.Inbox) == 0 && len(ur.DMInbox) == 0
 
-	log.ClientCore().Debug("Resolved user relays", "pubkey", pubkey,
+	clog().Debug("Resolved user relays", "pubkey", pubkey,
 		"outbox", len(ur.Outbox), "inbox", len(ur.Inbox), "dm", len(ur.DMInbox), "negative", ur.Negative)
 	return ur
 }
@@ -259,7 +258,7 @@ func (c *Client) fetchLatestEventWithin(ctx context.Context, pubkey string, kind
 	}
 	sub, err := c.Subscribe(ctx, []nostr.Filter{filter}, relays)
 	if err != nil {
-		log.ClientCore().Debug("Subscribe failed during relay resolution", "pubkey", pubkey, "kind", kind, "error", err)
+		clog().Debug("Subscribe failed during relay resolution", "pubkey", pubkey, "kind", kind, "error", err)
 		return nil
 	}
 	defer sub.Close()

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -1,0 +1,200 @@
+package core
+
+import (
+	"sync"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// UserRelays holds a target user's per-target event-derived relay roles,
+// resolved from their published NIP-65 (kind 10002) and NIP-17 (kind 10050)
+// events. These are the only roles the directory resolves for arbitrary users;
+// the richer self-only roles (search / blocked / favorite / private) load into
+// the logged-in user's own session config, not here.
+type UserRelays struct {
+	Outbox    []string  // NIP-65 write relays — publish / fetch their notes
+	Inbox     []string  // NIP-65 read relays — deliver replies / zaps here
+	DMInbox   []string  // NIP-17 kind 10050 DM relays
+	FetchedAt time.Time // when this was resolved
+	Negative  bool      // user has no published lists — cached briefly
+}
+
+// RelayDirectory caches per-user relay-role resolutions with a TTL, collapsing
+// concurrent lookups for the same pubkey into a single network fetch.
+type RelayDirectory struct {
+	mu       sync.Mutex
+	entries  map[string]*UserRelays
+	inflight map[string]chan struct{}
+	ttl      time.Duration
+	negTTL   time.Duration
+	resolve  func(pubkey string) *UserRelays
+}
+
+func newRelayDirectory(ttl, negTTL time.Duration, resolve func(string) *UserRelays) *RelayDirectory {
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	if negTTL <= 0 {
+		negTTL = time.Minute
+	}
+	return &RelayDirectory{
+		entries:  make(map[string]*UserRelays),
+		inflight: make(map[string]chan struct{}),
+		ttl:      ttl,
+		negTTL:   negTTL,
+		resolve:  resolve,
+	}
+}
+
+// fresh reports whether a cached entry is still within its TTL. Negative
+// results use the shorter TTL so a user who later publishes a list is picked up
+// soon instead of being treated as relay-less for an hour.
+func (d *RelayDirectory) fresh(ur *UserRelays) bool {
+	if ur == nil {
+		return false
+	}
+	ttl := d.ttl
+	if ur.Negative {
+		ttl = d.negTTL
+	}
+	return time.Since(ur.FetchedAt) < ttl
+}
+
+// Lookup returns the user's relay roles, resolving and caching on a miss or
+// stale entry. Concurrent lookups for the same pubkey share one resolution.
+func (d *RelayDirectory) Lookup(pubkey string) *UserRelays {
+	for {
+		d.mu.Lock()
+		if ur, ok := d.entries[pubkey]; ok && d.fresh(ur) {
+			d.mu.Unlock()
+			return ur
+		}
+		if ch, ok := d.inflight[pubkey]; ok {
+			// A resolution is in progress — wait for it, then re-check.
+			d.mu.Unlock()
+			<-ch
+			continue
+		}
+		ch := make(chan struct{})
+		d.inflight[pubkey] = ch
+		d.mu.Unlock()
+
+		ur := d.resolve(pubkey)
+		if ur == nil {
+			ur = &UserRelays{FetchedAt: time.Now(), Negative: true}
+		}
+
+		d.mu.Lock()
+		d.entries[pubkey] = ur
+		delete(d.inflight, pubkey)
+		close(ch)
+		d.mu.Unlock()
+		return ur
+	}
+}
+
+// Invalidate drops a cached entry so the next Lookup re-resolves — e.g. after
+// observing a newer relay-list event for the user.
+func (d *RelayDirectory) Invalidate(pubkey string) {
+	d.mu.Lock()
+	delete(d.entries, pubkey)
+	d.mu.Unlock()
+}
+
+// ResolveRelays returns a target user's per-target relay roles (outbox / inbox /
+// DM inbox), resolved from their published relay-list events and cached with a
+// TTL. Safe for concurrent use; the logged-in user is just another pubkey.
+func (c *Client) ResolveRelays(pubkey string) *UserRelays {
+	return c.directory.Lookup(pubkey)
+}
+
+// fetchUserRelaysFromNetwork is the RelayDirectory's resolver: it queries the
+// index/seed relays for a user's latest kind 10002 (NIP-65) and 10050 (NIP-17)
+// events concurrently and maps them to relay roles.
+func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
+	relays := c.config.IndexRelays
+	if len(relays) == 0 {
+		relays = c.GetConnectedRelays()
+	}
+
+	var (
+		nip65 *nostr.Event
+		nip17 *nostr.Event
+		wg    sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		nip65 = c.fetchLatestEvent(pubkey, 10002, relays)
+	}()
+	go func() {
+		defer wg.Done()
+		nip17 = c.fetchLatestEvent(pubkey, 10050, relays)
+	}()
+	wg.Wait()
+
+	ur := &UserRelays{FetchedAt: time.Now()}
+	if nip65 != nil {
+		mb := parseMailboxEvent(nip65)
+		ur.Outbox = appendUnique(mb.Write, mb.Both)
+		ur.Inbox = appendUnique(mb.Read, mb.Both)
+	}
+	if nip17 != nil {
+		ur.DMInbox = parseDMRelays(nip17)
+	}
+	ur.Negative = len(ur.Outbox) == 0 && len(ur.Inbox) == 0 && len(ur.DMInbox) == 0
+
+	log.ClientCore().Debug("Resolved user relays", "pubkey", pubkey,
+		"outbox", len(ur.Outbox), "inbox", len(ur.Inbox), "dm", len(ur.DMInbox), "negative", ur.Negative)
+	return ur
+}
+
+// fetchLatestEvent returns the newest event of kind for pubkey from relays, or
+// nil if none arrives. Shared by the directory resolver.
+func (c *Client) fetchLatestEvent(pubkey string, kind int, relays []string) *nostr.Event {
+	if len(relays) == 0 {
+		return nil
+	}
+	limit := 1
+	filter := nostr.Filter{
+		Authors: []string{pubkey},
+		Kinds:   []int{kind},
+		Limit:   &limit,
+	}
+	sub, err := c.Subscribe([]nostr.Filter{filter}, relays)
+	if err != nil {
+		log.ClientCore().Debug("Subscribe failed during relay resolution", "pubkey", pubkey, "kind", kind, "error", err)
+		return nil
+	}
+	defer sub.Close()
+	return collectLatestReplaceable(sub, len(relays), 5*time.Second)
+}
+
+// parseDMRelays extracts relay URLs from a NIP-17 kind 10050 event's relay tags.
+func parseDMRelays(event *nostr.Event) []string {
+	var relays []string
+	for _, tag := range event.Tags {
+		if len(tag) >= 2 && tag[0] == "relay" {
+			relays = append(relays, tag[1])
+		}
+	}
+	return relays
+}
+
+// appendUnique concatenates lists, dropping duplicates while preserving order.
+func appendUnique(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, l := range lists {
+		for _, s := range l {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -198,7 +198,7 @@ func (c *Client) WarmRelays(pubkey string) {
 // index/seed relays for a user's latest kind 10002 (NIP-65) and 10050 (NIP-17)
 // events concurrently and maps them to relay roles.
 func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
-	relays := c.config.IndexRelays
+	relays := c.indexRelays()
 	if len(relays) == 0 {
 		relays = c.GetConnectedRelays()
 	}

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -237,6 +237,16 @@ func (c *Client) fetchUserRelaysFromNetwork(pubkey string) *UserRelays {
 // fetchLatestEvent returns the newest event of kind for pubkey from relays, or
 // nil if none arrives. Shared by the directory resolver.
 func (c *Client) fetchLatestEvent(pubkey string, kind int, relays []string) *nostr.Event {
+	return c.fetchLatestEventWithin(pubkey, kind, relays, 5*time.Second)
+}
+
+// fetchLatestEventWithin is fetchLatestEvent with a caller-chosen deadline. A
+// replaceable event, when it exists, comes back well under a second; the full
+// deadline is only ever spent waiting on unresponsive relays in the negative
+// case. Callers resolving "does the user have this list at all?" (media servers,
+// relay lists) pass a shorter deadline so a cold miss doesn't stall the UI for
+// the full 5s.
+func (c *Client) fetchLatestEventWithin(pubkey string, kind int, relays []string, timeout time.Duration) *nostr.Event {
 	if len(relays) == 0 {
 		return nil
 	}
@@ -252,7 +262,7 @@ func (c *Client) fetchLatestEvent(pubkey string, kind int, relays []string) *nos
 		return nil
 	}
 	defer sub.Close()
-	return collectLatestReplaceable(sub, len(relays), 5*time.Second)
+	return collectLatestReplaceable(sub, len(relays), timeout)
 }
 
 // parseDMRelays extracts relay URLs from a NIP-17 kind 10050 event's relay tags.

--- a/client/core/directory.go
+++ b/client/core/directory.go
@@ -106,6 +106,37 @@ func (d *RelayDirectory) Invalidate(pubkey string) {
 	d.mu.Unlock()
 }
 
+// Store inserts or merges a resolved relay set for a pubkey directly, without a
+// network resolve — used by bulk seeding. A NIP-65 (10002) and a NIP-17 (10050)
+// event for the same author arrive separately, so non-empty fields merge rather
+// than clobber.
+func (d *RelayDirectory) Store(pubkey string, ur *UserRelays) {
+	if pubkey == "" || ur == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	existing, ok := d.entries[pubkey]
+	if !ok {
+		ur.FetchedAt = time.Now()
+		ur.Negative = false
+		d.entries[pubkey] = ur
+		return
+	}
+	if len(ur.Outbox) > 0 {
+		existing.Outbox = ur.Outbox
+	}
+	if len(ur.Inbox) > 0 {
+		existing.Inbox = ur.Inbox
+	}
+	if len(ur.DMInbox) > 0 {
+		existing.DMInbox = ur.DMInbox
+	}
+	existing.FetchedAt = time.Now()
+	existing.Negative = false
+}
+
 // KnownRelays returns the distinct relay URLs across every resolved entry —
 // the union of all users' outbox / inbox / DM relays the directory has seen.
 // This is the bulk of the client's "known relays" set: relays we're aware of
@@ -229,7 +260,9 @@ func parseDMRelays(event *nostr.Event) []string {
 	var relays []string
 	for _, tag := range event.Tags {
 		if len(tag) >= 2 && tag[0] == "relay" {
-			relays = append(relays, tag[1])
+			if n, ok := normalizeRelayURL(tag[1]); ok {
+				relays = append(relays, n)
+			}
 		}
 	}
 	return relays

--- a/client/core/directory_test.go
+++ b/client/core/directory_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+func TestParseDMRelays(t *testing.T) {
+	ev := &nostr.Event{Kind: 10050, Tags: [][]string{
+		{"relay", "wss://a"},
+		{"relay", "wss://b"},
+		{"other", "ignored"},
+		{"relay"}, // malformed (no url) — skipped
+	}}
+	got := parseDMRelays(ev)
+	if len(got) != 2 || got[0] != "wss://a" || got[1] != "wss://b" {
+		t.Fatalf("parseDMRelays = %v, want [wss://a wss://b]", got)
+	}
+}
+
+func TestAppendUniqueDedupsPreservingOrder(t *testing.T) {
+	got := appendUnique([]string{"a", "b"}, []string{"b", "c", "a"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("appendUnique = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("appendUnique = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestDirectoryCachesAndSingleFlights(t *testing.T) {
+	var calls int32
+	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays {
+		atomic.AddInt32(&calls, 1)
+		time.Sleep(10 * time.Millisecond) // widen the single-flight window
+		return &UserRelays{Outbox: []string{"wss://o"}, FetchedAt: time.Now()}
+	})
+
+	const n = 6
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); d.Lookup("pk") }()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("single-flight: resolved %d times, want 1", got)
+	}
+
+	// A subsequent lookup is served from cache.
+	d.Lookup("pk")
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("cache hit: resolved %d times, want 1", got)
+	}
+}
+
+func TestDirectoryReresolvesAfterTTL(t *testing.T) {
+	var calls int32
+	d := newRelayDirectory(20*time.Millisecond, 20*time.Millisecond, func(string) *UserRelays {
+		atomic.AddInt32(&calls, 1)
+		return &UserRelays{Outbox: []string{"wss://o"}, FetchedAt: time.Now()}
+	})
+	d.Lookup("pk")
+	time.Sleep(40 * time.Millisecond) // exceed the TTL
+	d.Lookup("pk")
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("want 2 resolves after TTL expiry, got %d", got)
+	}
+}
+
+func TestDirectoryNegativeCachedBriefly(t *testing.T) {
+	var calls int32
+	// Positive TTL long, negative TTL short: a "no list" answer must re-resolve
+	// soon (the user may publish one) without hammering on every lookup.
+	d := newRelayDirectory(time.Hour, 40*time.Millisecond, func(string) *UserRelays {
+		atomic.AddInt32(&calls, 1)
+		return nil // nothing found
+	})
+
+	ur := d.Lookup("pk")
+	if !ur.Negative {
+		t.Fatal("nil resolve should produce a Negative entry")
+	}
+	d.Lookup("pk") // within negTTL — cached
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("negative cache: resolved %d times, want 1", got)
+	}
+
+	time.Sleep(70 * time.Millisecond) // exceed negTTL
+	d.Lookup("pk")
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("want re-resolve after negTTL, got %d", got)
+	}
+}

--- a/client/core/directory_test.go
+++ b/client/core/directory_test.go
@@ -37,8 +37,8 @@ func TestAppendUniqueDedupsPreservingOrder(t *testing.T) {
 
 func TestKnownRelays(t *testing.T) {
 	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays { return nil })
-	d.entries["a"] = &UserRelays{Outbox: []string{"wss://o1"}, Inbox: []string{"wss://i1"}}
-	d.entries["b"] = &UserRelays{Outbox: []string{"wss://o1", "wss://o2"}, DMInbox: []string{"wss://dm"}}
+	d.store.Set("a", &UserRelays{Outbox: []string{"wss://o1"}, Inbox: []string{"wss://i1"}})
+	d.store.Set("b", &UserRelays{Outbox: []string{"wss://o1", "wss://o2"}, DMInbox: []string{"wss://dm"}})
 
 	// Distinct across both entries: o1, i1, o2, dm = 4.
 	if got := d.KnownRelays(); len(got) != 4 {

--- a/client/core/directory_test.go
+++ b/client/core/directory_test.go
@@ -35,6 +35,31 @@ func TestAppendUniqueDedupsPreservingOrder(t *testing.T) {
 	}
 }
 
+func TestKnownRelays(t *testing.T) {
+	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays { return nil })
+	d.entries["a"] = &UserRelays{Outbox: []string{"wss://o1"}, Inbox: []string{"wss://i1"}}
+	d.entries["b"] = &UserRelays{Outbox: []string{"wss://o1", "wss://o2"}, DMInbox: []string{"wss://dm"}}
+
+	// Distinct across both entries: o1, i1, o2, dm = 4.
+	if got := d.KnownRelays(); len(got) != 4 {
+		t.Fatalf("KnownRelays = %v, want 4 distinct", got)
+	}
+}
+
+func TestPoolStatsKnownCountsDefaultsAndDirectory(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"a": {Outbox: []string{"wss://o1"}, Inbox: []string{"wss://i1"}},
+		"b": {Outbox: []string{"wss://o2"}},
+	})
+	c.directory.Lookup("a")
+	c.directory.Lookup("b")
+
+	// 5 default index relays + 3 distinct resolved (o1, i1, o2) = 8.
+	if s := c.PoolStats(); s.Known != 8 {
+		t.Fatalf("Known = %d, want 8 (5 index + 3 resolved)", s.Known)
+	}
+}
+
 func TestDirectoryCachesAndSingleFlights(t *testing.T) {
 	var calls int32
 	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays {

--- a/client/core/directory_test.go
+++ b/client/core/directory_test.go
@@ -60,6 +60,21 @@ func TestPoolStatsKnownCountsDefaultsAndDirectory(t *testing.T) {
 	}
 }
 
+func TestDirectoryStoreMergesAndCountsKnown(t *testing.T) {
+	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays { return nil })
+	// A 10002 then a 10050 for the same author must merge, not clobber.
+	d.Store("a", &UserRelays{Outbox: []string{"wss://o1"}, Inbox: []string{"wss://i1"}})
+	d.Store("a", &UserRelays{DMInbox: []string{"wss://dm1"}})
+
+	if known := d.KnownRelays(); len(known) != 3 {
+		t.Fatalf("KnownRelays = %v, want 3 (o1,i1,dm1 merged)", known)
+	}
+	cached, ok := d.Cached("a")
+	if !ok || len(cached.Outbox) != 1 || len(cached.Inbox) != 1 || len(cached.DMInbox) != 1 {
+		t.Fatalf("Store merge clobbered fields: %+v ok=%v", cached, ok)
+	}
+}
+
 func TestDirectoryCachesAndSingleFlights(t *testing.T) {
 	var calls int32
 	d := newRelayDirectory(time.Hour, time.Minute, func(string) *UserRelays {

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -22,8 +23,27 @@ type BroadcastResult struct {
 	Duration time.Duration
 }
 
-// BroadcastEvent sends an event to multiple relays using the relay pool
-func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []BroadcastResult {
+// effectiveTimeout returns max, shortened to the caller's context deadline when
+// that deadline is sooner — so a caller-set deadline actually bounds the per-relay
+// connect rather than being ignored in favour of the fixed publish timeout.
+func effectiveTimeout(ctx context.Context, max time.Duration) time.Duration {
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return max
+	}
+	if d := time.Until(dl); d < max {
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return max
+}
+
+// BroadcastEvent sends an event to multiple relays using the relay pool. The
+// context bounds the per-relay connect and the NIP-20 OK-collection wait, so a
+// caller can cancel or deadline the whole publish.
+func BroadcastEvent(ctx context.Context, event *nostr.Event, relays []string, pool *RelayPool) []BroadcastResult {
 	if event == nil {
 		return []BroadcastResult{{
 			Success: false,
@@ -60,7 +80,7 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 			defer wg.Done()
 
 			start := time.Now()
-			results[index] = broadcastToSingleRelay(relay, eventMessage, pool)
+			results[index] = broadcastToSingleRelay(ctx, relay, eventMessage, pool)
 			results[index].RelayURL = relay
 			results[index].Duration = time.Since(start)
 		}(i, relayURL)
@@ -71,7 +91,7 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 	// Collect OK responses for the relays we successfully sent to, matched by
 	// relay URL, within a short window. A relay that never answers is left as
 	// Accepted=false (sent but unconfirmed).
-	collectOKResponses(okCh, results)
+	collectOKResponses(ctx, okCh, results)
 
 	// Log summary
 	successful := 0
@@ -96,8 +116,8 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 // collectOKResponses waits on okCh for NIP-20 OK responses and fills the
 // Accepted/Reason fields of the matching results, for up to a short window. It
 // only waits for relays we successfully sent to; a relay that never answers is
-// left Accepted=false (sent but unconfirmed).
-func collectOKResponses(okCh <-chan OKResult, results []BroadcastResult) {
+// left Accepted=false (sent but unconfirmed). Returns early if ctx is cancelled.
+func collectOKResponses(ctx context.Context, okCh <-chan OKResult, results []BroadcastResult) {
 	relayIndex := make(map[string]int, len(results))
 	pending := 0
 	for i := range results {
@@ -124,6 +144,8 @@ func collectOKResponses(okCh <-chan OKResult, results []BroadcastResult) {
 				results[idx].Reason = ok.Reason
 			}
 			pending--
+		case <-ctx.Done():
+			return
 		case <-deadline:
 			return
 		}
@@ -133,9 +155,10 @@ func collectOKResponses(okCh <-chan OKResult, results []BroadcastResult) {
 // broadcastEventStream broadcasts like BroadcastEvent but emits each relay's
 // result on the returned channel the moment it resolves: a send failure right
 // away, an accept/reject when that relay's NIP-20 OK arrives, and a "sent but no
-// response" at the collect deadline. The channel is closed once every relay has
-// resolved. This powers the live, count-up publish toast.
-func broadcastEventStream(event *nostr.Event, relays []string, pool *RelayPool) <-chan BroadcastResult {
+// response" at the collect deadline (or on ctx cancellation). The channel is
+// closed once every relay has resolved. This powers the live, count-up publish
+// toast.
+func broadcastEventStream(ctx context.Context, event *nostr.Event, relays []string, pool *RelayPool) <-chan BroadcastResult {
 	out := make(chan BroadcastResult, len(relays)) // buffered to the relay count: each relay emits exactly once, so sends never block
 
 	go func() {
@@ -165,7 +188,7 @@ func broadcastEventStream(event *nostr.Event, relays []string, pool *RelayPool) 
 			go func(index int, relay string) {
 				defer wg.Done()
 				start := time.Now()
-				r := broadcastToSingleRelay(relay, eventMessage, pool)
+				r := broadcastToSingleRelay(ctx, relay, eventMessage, pool)
 				r.RelayURL = relay
 				r.Duration = time.Since(start)
 				mu.Lock()
@@ -205,6 +228,14 @@ func broadcastEventStream(event *nostr.Event, relays []string, pool *RelayPool) 
 				sent[idx].Reason = ok.Reason
 				out <- sent[idx]
 				pending--
+			case <-ctx.Done():
+				// Cancelled: flush the sent-but-unanswered relays and stop.
+				for i := range sent {
+					if sent[i].Success && !received[sent[i].RelayURL] {
+						out <- sent[i]
+					}
+				}
+				return
 			case <-deadline:
 				// Emit the relays that were sent but never answered.
 				for i := range sent {
@@ -224,8 +255,8 @@ func broadcastEventStream(event *nostr.Event, relays []string, pool *RelayPool) 
 // returns a channel that emits each relay's result as it resolves. The caller
 // ranges the channel until it closes. Used by the streaming publish endpoint to
 // drive the live broadcast toast.
-func (c *Client) PublishEventStream(event *nostr.Event, relays []string) <-chan BroadcastResult {
-	return broadcastEventStream(event, relays, c.relayPool)
+func (c *Client) PublishEventStream(ctx context.Context, event *nostr.Event, relays []string) <-chan BroadcastResult {
+	return broadcastEventStream(ctx, event, relays, c.relayPool)
 }
 
 // broadcastToSingleRelay broadcasts to a single relay
@@ -233,12 +264,22 @@ func (c *Client) PublishEventStream(event *nostr.Event, relays []string) <-chan 
 // broadcast gives up on it with a server-timeout result.
 const publishConnectTimeout = 10 * time.Second
 
-func broadcastToSingleRelay(relayURL string, message []interface{}, pool *RelayPool) BroadcastResult {
+func broadcastToSingleRelay(ctx context.Context, relayURL string, message []interface{}, pool *RelayPool) BroadcastResult {
+	// Honour a cancelled/expired context before doing any work.
+	if err := ctx.Err(); err != nil {
+		return BroadcastResult{
+			Success: false,
+			Error:   err,
+			Message: "cancelled",
+		}
+	}
+
 	// Make sure the target relay is connected before sending. A publish target
 	// that has dropped would otherwise fail instantly with "not connected";
 	// redial it (an explicit publish ignores dial backoff), bounded by
-	// publishConnectTimeout, and report a server timeout if it won't come up.
-	if err := pool.EnsureConnectedForSend(relayURL, publishConnectTimeout); err != nil {
+	// publishConnectTimeout or the caller's deadline if sooner, and report a
+	// server timeout if it won't come up.
+	if err := pool.EnsureConnectedForSend(relayURL, effectiveTimeout(ctx, publishConnectTimeout)); err != nil {
 		log.ClientCore().Warn("Couldn't connect to relay to broadcast", "relay", relayURL, "error", err)
 		return BroadcastResult{
 			Success: false,
@@ -265,7 +306,7 @@ func broadcastToSingleRelay(relayURL string, message []interface{}, pool *RelayP
 }
 
 // BroadcastToUserRelays broadcasts an event to a user's preferred relays
-func BroadcastToUserRelays(event *nostr.Event, pubkey string, client *Client) []BroadcastResult {
+func BroadcastToUserRelays(ctx context.Context, event *nostr.Event, pubkey string, client *Client) []BroadcastResult {
 	if client == nil {
 		return []BroadcastResult{{
 			Success: false,
@@ -280,7 +321,7 @@ func BroadcastToUserRelays(event *nostr.Event, pubkey string, client *Client) []
 	mailboxes, err := client.GetUserRelays(pubkey)
 	if err != nil {
 		log.ClientCore().Warn("Failed to get user relays, using index relays", "pubkey", pubkey, "error", err)
-		return BroadcastEvent(event, client.indexRelays(), client.relayPool)
+		return BroadcastEvent(ctx, event, client.indexRelays(), client.relayPool)
 	}
 
 	// Use write relays for broadcasting
@@ -297,11 +338,11 @@ func BroadcastToUserRelays(event *nostr.Event, pubkey string, client *Client) []
 	}
 
 	log.ClientCore().Info("Broadcasting to user relays", "pubkey", pubkey, "relay_count", len(relays))
-	return BroadcastEvent(event, relays, client.relayPool)
+	return BroadcastEvent(ctx, event, relays, client.relayPool)
 }
 
 // BroadcastWithRetry broadcasts an event with retry logic
-func BroadcastWithRetry(event *nostr.Event, relays []string, pool *RelayPool, maxRetries int) []BroadcastResult {
+func BroadcastWithRetry(ctx context.Context, event *nostr.Event, relays []string, pool *RelayPool, maxRetries int) []BroadcastResult {
 	if maxRetries < 1 {
 		maxRetries = 1
 	}
@@ -312,7 +353,7 @@ func BroadcastWithRetry(event *nostr.Event, relays []string, pool *RelayPool, ma
 	log.ClientCore().Info("Broadcasting with retry", "event_id", event.ID, "max_retries", maxRetries)
 
 	// Initial broadcast attempt
-	results = BroadcastEvent(event, relays, pool)
+	results = BroadcastEvent(ctx, event, relays, pool)
 
 	// Collect failed relays for retry
 	for _, result := range results {
@@ -325,10 +366,15 @@ func BroadcastWithRetry(event *nostr.Event, relays []string, pool *RelayPool, ma
 	for attempt := 2; attempt <= maxRetries && len(failedRelays) > 0; attempt++ {
 		log.ClientCore().Debug("Retry attempt", "attempt", attempt, "failed_relay_count", len(failedRelays))
 
-		// Wait before retry
-		time.Sleep(time.Duration(attempt) * time.Second)
+		// Wait before retry — cancellable so a deadline/cancel stops the backoff.
+		select {
+		case <-time.After(time.Duration(attempt) * time.Second):
+		case <-ctx.Done():
+			log.ClientCore().Debug("Broadcast retry cancelled", "error", ctx.Err())
+			return results
+		}
 
-		retryResults := BroadcastEvent(event, failedRelays, pool)
+		retryResults := BroadcastEvent(ctx, event, failedRelays, pool)
 
 		// Update results and collect still-failed relays
 		newFailedRelays := make([]string, 0)
@@ -368,7 +414,7 @@ func BroadcastWithRetry(event *nostr.Event, relays []string, pool *RelayPool, ma
 }
 
 // PublishEvent is a high-level function to build, sign, and broadcast an event
-func PublishEvent(client *Client, signer *EventSigner, eventBuilder *EventBuilder, targetRelays []string) (*nostr.Event, []BroadcastResult, error) {
+func PublishEvent(ctx context.Context, client *Client, signer *EventSigner, eventBuilder *EventBuilder, targetRelays []string) (*nostr.Event, []BroadcastResult, error) {
 	if client == nil {
 		return nil, nil, fmt.Errorf("client cannot be nil")
 	}
@@ -404,13 +450,13 @@ func PublishEvent(client *Client, signer *EventSigner, eventBuilder *EventBuilde
 	log.ClientCore().Info("Publishing event", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
 
 	// Broadcast the event
-	results := BroadcastEvent(event, relays, client.relayPool)
+	results := BroadcastEvent(ctx, event, relays, client.relayPool)
 
 	return event, results, nil
 }
 
 // PublishEventWithRetry publishes an event with retry logic
-func PublishEventWithRetry(client *Client, signer *EventSigner, eventBuilder *EventBuilder, targetRelays []string, maxRetries int) (*nostr.Event, []BroadcastResult, error) {
+func PublishEventWithRetry(ctx context.Context, client *Client, signer *EventSigner, eventBuilder *EventBuilder, targetRelays []string, maxRetries int) (*nostr.Event, []BroadcastResult, error) {
 	if client == nil {
 		return nil, nil, fmt.Errorf("client cannot be nil")
 	}
@@ -446,7 +492,7 @@ func PublishEventWithRetry(client *Client, signer *EventSigner, eventBuilder *Ev
 	log.ClientCore().Info("Publishing event with retry", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
 
 	// Broadcast the event with retry
-	results := BroadcastWithRetry(event, relays, client.relayPool, maxRetries)
+	results := BroadcastWithRetry(ctx, event, relays, client.relayPool, maxRetries)
 
 	return event, results, nil
 }

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -9,10 +9,14 @@ import (
 	"github.com/0ceanslim/grain/server/utils/log"
 )
 
-// BroadcastResult represents the result of broadcasting to a single relay
+// BroadcastResult represents the result of broadcasting to a single relay.
+// Success means the EVENT was sent; Accepted is the relay's NIP-20 OK verdict
+// (whether it actually stored the event), with Reason carrying any message.
 type BroadcastResult struct {
 	RelayURL string
 	Success  bool
+	Accepted bool
+	Reason   string
 	Error    error
 	Message  string
 	Duration time.Duration
@@ -38,6 +42,11 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 
 	log.ClientCore().Info("Broadcasting event", "event_id", event.ID, "relay_count", len(relays))
 
+	// Start collecting NIP-20 OK responses BEFORE sending, so a relay that
+	// replies fast can't beat the waiter into place.
+	okCh := pool.messageRouter.RegisterOKWaiter(event.ID, len(relays))
+	defer pool.messageRouter.UnregisterOKWaiter(event.ID)
+
 	// Create EVENT message
 	eventMessage := []interface{}{"EVENT", event}
 
@@ -59,6 +68,11 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 
 	wg.Wait()
 
+	// Collect OK responses for the relays we successfully sent to, matched by
+	// relay URL, within a short window. A relay that never answers is left as
+	// Accepted=false (sent but unconfirmed).
+	collectOKResponses(okCh, results)
+
 	// Log summary
 	successful := 0
 	failed := 0
@@ -77,6 +91,43 @@ func BroadcastEvent(event *nostr.Event, relays []string, pool *RelayPool) []Broa
 		"total", len(relays))
 
 	return results
+}
+
+// collectOKResponses waits on okCh for NIP-20 OK responses and fills the
+// Accepted/Reason fields of the matching results, for up to a short window. It
+// only waits for relays we successfully sent to; a relay that never answers is
+// left Accepted=false (sent but unconfirmed).
+func collectOKResponses(okCh <-chan OKResult, results []BroadcastResult) {
+	relayIndex := make(map[string]int, len(results))
+	pending := 0
+	for i := range results {
+		relayIndex[results[i].RelayURL] = i
+		if results[i].Success {
+			pending++
+		}
+	}
+	if pending == 0 {
+		return
+	}
+
+	deadline := time.After(5 * time.Second)
+	received := make(map[string]bool, pending)
+	for pending > 0 {
+		select {
+		case ok := <-okCh:
+			if received[ok.Relay] {
+				continue
+			}
+			received[ok.Relay] = true
+			if idx, found := relayIndex[ok.Relay]; found {
+				results[idx].Accepted = ok.Accepted
+				results[idx].Reason = ok.Reason
+			}
+			pending--
+		case <-deadline:
+			return
+		}
+	}
 }
 
 // broadcastToSingleRelay broadcasts to a single relay

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -280,7 +280,7 @@ func BroadcastToUserRelays(event *nostr.Event, pubkey string, client *Client) []
 	mailboxes, err := client.GetUserRelays(pubkey)
 	if err != nil {
 		log.ClientCore().Warn("Failed to get user relays, using index relays", "pubkey", pubkey, "error", err)
-		return BroadcastEvent(event, client.config.IndexRelays, client.relayPool)
+		return BroadcastEvent(event, client.indexRelays(), client.relayPool)
 	}
 
 	// Use write relays for broadcasting
@@ -293,7 +293,7 @@ func BroadcastToUserRelays(event *nostr.Event, pubkey string, client *Client) []
 	if len(relays) == 0 {
 		// Fall back to index relays if user has no relay preferences
 		log.ClientCore().Warn("User has no relay preferences, using index relays", "pubkey", pubkey)
-		relays = client.config.IndexRelays
+		relays = client.indexRelays()
 	}
 
 	log.ClientCore().Info("Broadcasting to user relays", "pubkey", pubkey, "relay_count", len(relays))

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -229,7 +229,24 @@ func (c *Client) PublishEventStream(event *nostr.Event, relays []string) <-chan 
 }
 
 // broadcastToSingleRelay broadcasts to a single relay
+// publishConnectTimeout bounds the redial of a dropped publish target before the
+// broadcast gives up on it with a server-timeout result.
+const publishConnectTimeout = 10 * time.Second
+
 func broadcastToSingleRelay(relayURL string, message []interface{}, pool *RelayPool) BroadcastResult {
+	// Make sure the target relay is connected before sending. A publish target
+	// that has dropped would otherwise fail instantly with "not connected";
+	// redial it (an explicit publish ignores dial backoff), bounded by
+	// publishConnectTimeout, and report a server timeout if it won't come up.
+	if err := pool.EnsureConnectedForSend(relayURL, publishConnectTimeout); err != nil {
+		log.ClientCore().Warn("Couldn't connect to relay to broadcast", "relay", relayURL, "error", err)
+		return BroadcastResult{
+			Success: false,
+			Error:   err,
+			Message: "server timeout (couldn't connect)",
+		}
+	}
+
 	err := pool.SendMessage(relayURL, message)
 	if err != nil {
 		log.ClientCore().Warn("Failed to broadcast to relay", "relay", relayURL, "error", err)

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -130,6 +130,104 @@ func collectOKResponses(okCh <-chan OKResult, results []BroadcastResult) {
 	}
 }
 
+// broadcastEventStream broadcasts like BroadcastEvent but emits each relay's
+// result on the returned channel the moment it resolves: a send failure right
+// away, an accept/reject when that relay's NIP-20 OK arrives, and a "sent but no
+// response" at the collect deadline. The channel is closed once every relay has
+// resolved. This powers the live, count-up publish toast.
+func broadcastEventStream(event *nostr.Event, relays []string, pool *RelayPool) <-chan BroadcastResult {
+	out := make(chan BroadcastResult, len(relays)) // buffered to the relay count: each relay emits exactly once, so sends never block
+
+	go func() {
+		defer close(out)
+		if event == nil || len(relays) == 0 {
+			return
+		}
+
+		// Register the OK waiter BEFORE sending so a fast relay can't beat it.
+		okCh := pool.messageRouter.RegisterOKWaiter(event.ID, len(relays))
+		defer pool.messageRouter.UnregisterOKWaiter(event.ID)
+
+		eventMessage := []interface{}{"EVENT", event}
+
+		sent := make([]BroadcastResult, len(relays))
+		relayIndex := make(map[string]int, len(relays))
+		for i, u := range relays {
+			relayIndex[u] = i
+		}
+
+		// Send to every relay concurrently. A send FAILURE is final — emit it
+		// immediately; a successful send waits for the relay's OK below.
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		for i, relayURL := range relays {
+			wg.Add(1)
+			go func(index int, relay string) {
+				defer wg.Done()
+				start := time.Now()
+				r := broadcastToSingleRelay(relay, eventMessage, pool)
+				r.RelayURL = relay
+				r.Duration = time.Since(start)
+				mu.Lock()
+				sent[index] = r
+				mu.Unlock()
+				if !r.Success {
+					out <- r
+				}
+			}(i, relayURL)
+		}
+		wg.Wait()
+
+		pending := 0
+		for i := range sent {
+			if sent[i].Success {
+				pending++
+			}
+		}
+		if pending == 0 {
+			return
+		}
+
+		deadline := time.After(5 * time.Second)
+		received := make(map[string]bool, pending)
+		for pending > 0 {
+			select {
+			case ok := <-okCh:
+				if received[ok.Relay] {
+					continue
+				}
+				idx, found := relayIndex[ok.Relay]
+				if !found || !sent[idx].Success {
+					continue
+				}
+				received[ok.Relay] = true
+				sent[idx].Accepted = ok.Accepted
+				sent[idx].Reason = ok.Reason
+				out <- sent[idx]
+				pending--
+			case <-deadline:
+				// Emit the relays that were sent but never answered.
+				for i := range sent {
+					if sent[i].Success && !received[sent[i].RelayURL] {
+						out <- sent[i] // Accepted=false, no reason => "no response"
+					}
+				}
+				return
+			}
+		}
+	}()
+
+	return out
+}
+
+// PublishEventStream broadcasts an already-signed event to the given relays and
+// returns a channel that emits each relay's result as it resolves. The caller
+// ranges the channel until it closes. Used by the streaming publish endpoint to
+// drive the live broadcast toast.
+func (c *Client) PublishEventStream(event *nostr.Event, relays []string) <-chan BroadcastResult {
+	return broadcastEventStream(event, relays, c.relayPool)
+}
+
 // broadcastToSingleRelay broadcasts to a single relay
 func broadcastToSingleRelay(relayURL string, message []interface{}, pool *RelayPool) BroadcastResult {
 	err := pool.SendMessage(relayURL, message)

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -243,7 +243,7 @@ func broadcastToSingleRelay(relayURL string, message []interface{}, pool *RelayP
 		return BroadcastResult{
 			Success: false,
 			Error:   err,
-			Message: "server timeout (couldn't connect)",
+			Message: "unreachable (server timeout)",
 		}
 	}
 

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -228,21 +228,11 @@ func PublishEvent(client *Client, signer *EventSigner, eventBuilder *EventBuilde
 		return nil, nil, fmt.Errorf("event validation failed: %w", err)
 	}
 
-	// Use provided relays or fall back to user's write relays
+	// Use provided relays, or route by the outbox model: the author's outbox
+	// plus every p-tagged recipient's inbox (so replies / mentions reach them).
 	relays := targetRelays
 	if len(relays) == 0 {
-		mailboxes, err := client.GetUserRelays(signer.GetPublicKey())
-		if err == nil && mailboxes != nil {
-			relays = mailboxes.Write
-			if len(relays) == 0 {
-				relays = mailboxes.Both
-			}
-		}
-
-		// Final fallback to index relays
-		if len(relays) == 0 {
-			relays = client.config.IndexRelays
-		}
+		relays = client.RoutePublish(event)
 	}
 
 	log.ClientCore().Info("Publishing event", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
@@ -280,21 +270,11 @@ func PublishEventWithRetry(client *Client, signer *EventSigner, eventBuilder *Ev
 		return nil, nil, fmt.Errorf("event validation failed: %w", err)
 	}
 
-	// Use provided relays or fall back to user's write relays
+	// Use provided relays, or route by the outbox model: the author's outbox
+	// plus every p-tagged recipient's inbox (so replies / mentions reach them).
 	relays := targetRelays
 	if len(relays) == 0 {
-		mailboxes, err := client.GetUserRelays(signer.GetPublicKey())
-		if err == nil && mailboxes != nil {
-			relays = mailboxes.Write
-			if len(relays) == 0 {
-				relays = mailboxes.Both
-			}
-		}
-
-		// Final fallback to index relays
-		if len(relays) == 0 {
-			relays = client.config.IndexRelays
-		}
+		relays = client.RoutePublish(event)
 	}
 
 	log.ClientCore().Info("Publishing event with retry", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))

--- a/client/core/eventBroadcaster.go
+++ b/client/core/eventBroadcaster.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // BroadcastResult represents the result of broadcasting to a single relay.
@@ -60,7 +59,7 @@ func BroadcastEvent(ctx context.Context, event *nostr.Event, relays []string, po
 		}}
 	}
 
-	log.ClientCore().Info("Broadcasting event", "event_id", event.ID, "relay_count", len(relays))
+	clog().Info("Broadcasting event", "event_id", event.ID, "relay_count", len(relays))
 
 	// Start collecting NIP-20 OK responses BEFORE sending, so a relay that
 	// replies fast can't beat the waiter into place.
@@ -104,7 +103,7 @@ func BroadcastEvent(ctx context.Context, event *nostr.Event, relays []string, po
 		}
 	}
 
-	log.ClientCore().Info("Broadcast completed",
+	clog().Info("Broadcast completed",
 		"event_id", event.ID,
 		"successful", successful,
 		"failed", failed,
@@ -280,7 +279,7 @@ func broadcastToSingleRelay(ctx context.Context, relayURL string, message []inte
 	// publishConnectTimeout or the caller's deadline if sooner, and report a
 	// server timeout if it won't come up.
 	if err := pool.EnsureConnectedForSend(relayURL, effectiveTimeout(ctx, publishConnectTimeout)); err != nil {
-		log.ClientCore().Warn("Couldn't connect to relay to broadcast", "relay", relayURL, "error", err)
+		clog().Warn("Couldn't connect to relay to broadcast", "relay", relayURL, "error", err)
 		return BroadcastResult{
 			Success: false,
 			Error:   err,
@@ -290,7 +289,7 @@ func broadcastToSingleRelay(ctx context.Context, relayURL string, message []inte
 
 	err := pool.SendMessage(relayURL, message)
 	if err != nil {
-		log.ClientCore().Warn("Failed to broadcast to relay", "relay", relayURL, "error", err)
+		clog().Warn("Failed to broadcast to relay", "relay", relayURL, "error", err)
 		return BroadcastResult{
 			Success: false,
 			Error:   err,
@@ -298,7 +297,7 @@ func broadcastToSingleRelay(ctx context.Context, relayURL string, message []inte
 		}
 	}
 
-	log.ClientCore().Debug("Event broadcast successful", "relay", relayURL)
+	clog().Debug("Event broadcast successful", "relay", relayURL)
 	return BroadcastResult{
 		Success: true,
 		Message: "broadcast successful",
@@ -315,12 +314,12 @@ func BroadcastToUserRelays(ctx context.Context, event *nostr.Event, pubkey strin
 		}}
 	}
 
-	log.ClientCore().Debug("Getting user relays for broadcast", "pubkey", pubkey)
+	clog().Debug("Getting user relays for broadcast", "pubkey", pubkey)
 
 	// Get user's relay list
 	mailboxes, err := client.GetUserRelays(pubkey)
 	if err != nil {
-		log.ClientCore().Warn("Failed to get user relays, using index relays", "pubkey", pubkey, "error", err)
+		clog().Warn("Failed to get user relays, using index relays", "pubkey", pubkey, "error", err)
 		return BroadcastEvent(ctx, event, client.indexRelays(), client.relayPool)
 	}
 
@@ -333,11 +332,11 @@ func BroadcastToUserRelays(ctx context.Context, event *nostr.Event, pubkey strin
 
 	if len(relays) == 0 {
 		// Fall back to index relays if user has no relay preferences
-		log.ClientCore().Warn("User has no relay preferences, using index relays", "pubkey", pubkey)
+		clog().Warn("User has no relay preferences, using index relays", "pubkey", pubkey)
 		relays = client.indexRelays()
 	}
 
-	log.ClientCore().Info("Broadcasting to user relays", "pubkey", pubkey, "relay_count", len(relays))
+	clog().Info("Broadcasting to user relays", "pubkey", pubkey, "relay_count", len(relays))
 	return BroadcastEvent(ctx, event, relays, client.relayPool)
 }
 
@@ -350,7 +349,7 @@ func BroadcastWithRetry(ctx context.Context, event *nostr.Event, relays []string
 	var results []BroadcastResult
 	failedRelays := make([]string, 0)
 
-	log.ClientCore().Info("Broadcasting with retry", "event_id", event.ID, "max_retries", maxRetries)
+	clog().Info("Broadcasting with retry", "event_id", event.ID, "max_retries", maxRetries)
 
 	// Initial broadcast attempt
 	results = BroadcastEvent(ctx, event, relays, pool)
@@ -364,13 +363,13 @@ func BroadcastWithRetry(ctx context.Context, event *nostr.Event, relays []string
 
 	// Retry failed relays
 	for attempt := 2; attempt <= maxRetries && len(failedRelays) > 0; attempt++ {
-		log.ClientCore().Debug("Retry attempt", "attempt", attempt, "failed_relay_count", len(failedRelays))
+		clog().Debug("Retry attempt", "attempt", attempt, "failed_relay_count", len(failedRelays))
 
 		// Wait before retry — cancellable so a deadline/cancel stops the backoff.
 		select {
 		case <-time.After(time.Duration(attempt) * time.Second):
 		case <-ctx.Done():
-			log.ClientCore().Debug("Broadcast retry cancelled", "error", ctx.Err())
+			clog().Debug("Broadcast retry cancelled", "error", ctx.Err())
 			return results
 		}
 
@@ -404,7 +403,7 @@ func BroadcastWithRetry(ctx context.Context, event *nostr.Event, relays []string
 		}
 	}
 
-	log.ClientCore().Info("Broadcast with retry completed",
+	clog().Info("Broadcast with retry completed",
 		"event_id", event.ID,
 		"successful", successful,
 		"total", len(relays),
@@ -447,7 +446,7 @@ func PublishEvent(ctx context.Context, client *Client, signer *EventSigner, even
 		relays = client.RoutePublish(event)
 	}
 
-	log.ClientCore().Info("Publishing event", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
+	clog().Info("Publishing event", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
 
 	// Broadcast the event
 	results := BroadcastEvent(ctx, event, relays, client.relayPool)
@@ -489,7 +488,7 @@ func PublishEventWithRetry(ctx context.Context, client *Client, signer *EventSig
 		relays = client.RoutePublish(event)
 	}
 
-	log.ClientCore().Info("Publishing event with retry", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
+	clog().Info("Publishing event with retry", "event_id", event.ID, "kind", event.Kind, "relay_count", len(relays))
 
 	// Broadcast the event with retry
 	results := BroadcastWithRetry(ctx, event, relays, client.relayPool, maxRetries)

--- a/client/core/eventBuilder.go
+++ b/client/core/eventBuilder.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // EventBuilder provides a fluent interface for building Nostr events
@@ -37,7 +36,7 @@ func (eb *EventBuilder) Tag(name string, values ...string) *EventBuilder {
 	copy(tag[1:], values)
 	eb.tags = append(eb.tags, tag)
 
-	log.ClientCore().Debug("Added tag to event", "tag_name", name, "values", values)
+	clog().Debug("Added tag to event", "tag_name", name, "values", values)
 	return eb
 }
 
@@ -49,7 +48,7 @@ func (eb *EventBuilder) PTag(pubkey string, relayHint ...string) *EventBuilder {
 	}
 	eb.tags = append(eb.tags, tag)
 
-	log.ClientCore().Debug("Added p tag to event", "pubkey", pubkey)
+	clog().Debug("Added p tag to event", "pubkey", pubkey)
 	return eb
 }
 
@@ -69,7 +68,7 @@ func (eb *EventBuilder) ETag(eventID string, relayHint, marker string) *EventBui
 
 	eb.tags = append(eb.tags, tag)
 
-	log.ClientCore().Debug("Added e tag to event", "event_id", eventID, "marker", marker)
+	clog().Debug("Added e tag to event", "event_id", eventID, "marker", marker)
 	return eb
 }
 
@@ -81,7 +80,7 @@ func (eb *EventBuilder) RTag(relayURL string, marker string) *EventBuilder {
 	}
 	eb.tags = append(eb.tags, tag)
 
-	log.ClientCore().Debug("Added r tag to event", "relay", relayURL, "marker", marker)
+	clog().Debug("Added r tag to event", "relay", relayURL, "marker", marker)
 	return eb
 }
 
@@ -89,7 +88,7 @@ func (eb *EventBuilder) RTag(relayURL string, marker string) *EventBuilder {
 func (eb *EventBuilder) DTag(identifier string) *EventBuilder {
 	eb.tags = append(eb.tags, []string{"d", identifier})
 
-	log.ClientCore().Debug("Added d tag to event", "identifier", identifier)
+	clog().Debug("Added d tag to event", "identifier", identifier)
 	return eb
 }
 
@@ -104,7 +103,7 @@ func (eb *EventBuilder) ATag(kind int, pubkey string, dTag string, relayHint ...
 
 	eb.tags = append(eb.tags, tag)
 
-	log.ClientCore().Debug("Added a tag to event", "coordinate", coordinate)
+	clog().Debug("Added a tag to event", "coordinate", coordinate)
 	return eb
 }
 
@@ -112,7 +111,7 @@ func (eb *EventBuilder) ATag(kind int, pubkey string, dTag string, relayHint ...
 func (eb *EventBuilder) TTag(hashtag string) *EventBuilder {
 	eb.tags = append(eb.tags, []string{"t", hashtag})
 
-	log.ClientCore().Debug("Added t tag to event", "hashtag", hashtag)
+	clog().Debug("Added t tag to event", "hashtag", hashtag)
 	return eb
 }
 
@@ -137,7 +136,7 @@ func (eb *EventBuilder) Build() *nostr.Event {
 		event.CreatedAt = time.Now().Unix()
 	}
 
-	log.ClientCore().Debug("Built event",
+	clog().Debug("Built event",
 		"kind", event.Kind,
 		"content_length", len(event.Content),
 		"tag_count", len(event.Tags),

--- a/client/core/eventSerializer.go
+++ b/client/core/eventSerializer.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // SerializeEvent manually constructs the JSON string for event serialization according to NIP-01
@@ -26,7 +25,7 @@ func SerializeEvent(evt nostr.Event) string {
 	// Use Go's standard JSON marshaling first
 	jsonBytes, err := json.Marshal(eventData)
 	if err != nil {
-		log.ClientCore().Error("Failed to serialize event",
+		clog().Error("Failed to serialize event",
 			"event_id", evt.ID,
 			"pubkey", evt.PubKey,
 			"kind", evt.Kind,
@@ -40,7 +39,7 @@ func SerializeEvent(evt nostr.Event) string {
 
 	// Only log at debug level for very important events or when troubleshooting
 	if evt.Kind == 0 || evt.Kind == 3 {
-		log.ClientCore().Debug("Event serialized",
+		clog().Debug("Event serialized",
 			"event_id", evt.ID,
 			"kind", evt.Kind,
 			"size_bytes", len(jsonStr))
@@ -81,11 +80,11 @@ func DeserializeEvent(data []byte) (*nostr.Event, error) {
 
 	var event nostr.Event
 	if err := json.Unmarshal(data, &event); err != nil {
-		log.ClientCore().Error("Failed to deserialize event", "error", err)
+		clog().Error("Failed to deserialize event", "error", err)
 		return nil, fmt.Errorf("failed to unmarshal event: %w", err)
 	}
 
-	log.ClientCore().Debug("Event deserialized", "event_id", event.ID, "kind", event.Kind)
+	clog().Debug("Event deserialized", "event_id", event.ID, "kind", event.Kind)
 	return &event, nil
 }
 
@@ -105,7 +104,7 @@ func ComputeEventID(event *nostr.Event) (string, error) {
 	hash := sha256.Sum256([]byte(serialized))
 	eventID := hex.EncodeToString(hash[:])
 
-	log.ClientCore().Debug("Computed event ID", "event_id", eventID, "kind", event.Kind)
+	clog().Debug("Computed event ID", "event_id", eventID, "kind", event.Kind)
 	return eventID, nil
 }
 
@@ -166,7 +165,7 @@ func ValidateEventStructure(event *nostr.Event) error {
 		}
 	}
 
-	log.ClientCore().Debug("Event structure validated", "event_id", event.ID, "kind", event.Kind)
+	clog().Debug("Event structure validated", "event_id", event.ID, "kind", event.Kind)
 	return nil
 }
 
@@ -205,7 +204,7 @@ func SerializeEventArray(events []*nostr.Event) ([]byte, error) {
 		return nil, fmt.Errorf("failed to serialize event array: %w", err)
 	}
 
-	log.ClientCore().Debug("Event array serialized", "event_count", len(events), "size_bytes", len(data))
+	clog().Debug("Event array serialized", "event_count", len(events), "size_bytes", len(data))
 	return data, nil
 }
 
@@ -220,7 +219,7 @@ func CreateNostrMessage(messageType string, args ...interface{}) ([]byte, error)
 		return nil, fmt.Errorf("failed to create Nostr message: %w", err)
 	}
 
-	log.ClientCore().Debug("Nostr message created", "type", messageType, "size_bytes", len(data))
+	clog().Debug("Nostr message created", "type", messageType, "size_bytes", len(data))
 	return data, nil
 }
 
@@ -243,6 +242,6 @@ func ParseNostrMessage(data []byte) (messageType string, args []interface{}, err
 
 	args = message[1:]
 
-	log.ClientCore().Debug("Nostr message parsed", "type", messageType, "arg_count", len(args))
+	clog().Debug("Nostr message parsed", "type", messageType, "arg_count", len(args))
 	return messageType, args, nil
 }

--- a/client/core/eventSigner.go
+++ b/client/core/eventSigner.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 )
@@ -38,7 +37,7 @@ func NewEventSigner(privateKeyHex string) (*EventSigner, error) {
 		publicKey:  pubKeyHex,
 	}
 
-	log.ClientCore().Debug("Event signer created", "pubkey", pubKeyHex)
+	clog().Debug("Event signer created", "pubkey", pubKeyHex)
 	return signer, nil
 }
 
@@ -79,7 +78,7 @@ func (es *EventSigner) SignEvent(event *nostr.Event) error {
 	}
 	event.Sig = signature
 
-	log.ClientCore().Debug("Event signed", "event_id", eventID, "pubkey", es.publicKey)
+	clog().Debug("Event signed", "event_id", eventID, "pubkey", es.publicKey)
 	return nil
 }
 
@@ -117,12 +116,12 @@ func (es *EventSigner) GetPrivateKeyHex() string {
 // VerifyEventSignature verifies an event's signature
 func VerifyEventSignature(event *nostr.Event) bool {
 	if event == nil {
-		log.ClientCore().Warn("Cannot verify nil event")
+		clog().Warn("Cannot verify nil event")
 		return false
 	}
 
 	if event.ID == "" || event.PubKey == "" || event.Sig == "" {
-		log.ClientCore().Warn("Event missing required fields for verification",
+		clog().Warn("Event missing required fields for verification",
 			"has_id", event.ID != "",
 			"has_pubkey", event.PubKey != "",
 			"has_sig", event.Sig != "")
@@ -132,45 +131,45 @@ func VerifyEventSignature(event *nostr.Event) bool {
 	// Verify the event ID matches the computed ID
 	computedID, err := ComputeEventID(event)
 	if err != nil {
-		log.ClientCore().Error("Failed to compute event ID for verification", "error", err)
+		clog().Error("Failed to compute event ID for verification", "error", err)
 		return false
 	}
 
 	if event.ID != computedID {
-		log.ClientCore().Warn("Event ID mismatch", "event_id", event.ID, "computed_id", computedID)
+		clog().Warn("Event ID mismatch", "event_id", event.ID, "computed_id", computedID)
 		return false
 	}
 
 	// Parse public key
 	pubKeyBytes, err := hex.DecodeString(event.PubKey)
 	if err != nil {
-		log.ClientCore().Error("Invalid public key hex", "pubkey", event.PubKey, "error", err)
+		clog().Error("Invalid public key hex", "pubkey", event.PubKey, "error", err)
 		return false
 	}
 
 	publicKey, err := schnorr.ParsePubKey(pubKeyBytes)
 	if err != nil {
-		log.ClientCore().Error("Failed to parse public key", "error", err)
+		clog().Error("Failed to parse public key", "error", err)
 		return false
 	}
 
 	// Parse signature
 	sigBytes, err := hex.DecodeString(event.Sig)
 	if err != nil {
-		log.ClientCore().Error("Invalid signature hex", "signature", event.Sig, "error", err)
+		clog().Error("Invalid signature hex", "signature", event.Sig, "error", err)
 		return false
 	}
 
 	signature, err := schnorr.ParseSignature(sigBytes)
 	if err != nil {
-		log.ClientCore().Error("Failed to parse signature", "error", err)
+		clog().Error("Failed to parse signature", "error", err)
 		return false
 	}
 
 	// Parse event ID as hash
 	hashBytes, err := hex.DecodeString(event.ID)
 	if err != nil {
-		log.ClientCore().Error("Invalid event ID hex", "event_id", event.ID, "error", err)
+		clog().Error("Invalid event ID hex", "event_id", event.ID, "error", err)
 		return false
 	}
 
@@ -178,9 +177,9 @@ func VerifyEventSignature(event *nostr.Event) bool {
 	valid := signature.Verify(hashBytes, publicKey)
 
 	if valid {
-		log.ClientCore().Debug("Event signature verified", "event_id", event.ID)
+		clog().Debug("Event signature verified", "event_id", event.ID)
 	} else {
-		log.ClientCore().Warn("Event signature verification failed", "event_id", event.ID)
+		clog().Warn("Event signature verification failed", "event_id", event.ID)
 	}
 
 	return valid
@@ -192,7 +191,7 @@ func VerifyEventSignature(event *nostr.Event) bool {
 func SignEventWithExtension(event *nostr.Event) error {
 	// This is a placeholder for browser extension integration
 	// In a real implementation, this would use JavaScript bridge to call window.nostr.signEvent()
-	log.ClientCore().Warn("Browser extension signing not implemented - this is a server-side client")
+	clog().Warn("Browser extension signing not implemented - this is a server-side client")
 	return fmt.Errorf("browser extension signing not available in server environment")
 }
 
@@ -200,7 +199,7 @@ func SignEventWithExtension(event *nostr.Event) error {
 func GetPublicKeyFromExtension() (string, error) {
 	// This is a placeholder for browser extension integration
 	// In a real implementation, this would use JavaScript bridge to call window.nostr.getPublicKey()
-	log.ClientCore().Warn("Browser extension key retrieval not implemented - this is a server-side client")
+	clog().Warn("Browser extension key retrieval not implemented - this is a server-side client")
 	return "", fmt.Errorf("browser extension not available in server environment")
 }
 

--- a/client/core/eventSigner.go
+++ b/client/core/eventSigner.go
@@ -98,6 +98,12 @@ func (es *EventSigner) signHash(hashHex string) (string, error) {
 	return hex.EncodeToString(signature.Serialize()), nil
 }
 
+// PublicKey returns the public key in hex format. It satisfies the [Signer]
+// seam; GetPublicKey is retained as an alias for existing callers.
+func (es *EventSigner) PublicKey() string {
+	return es.publicKey
+}
+
 // GetPublicKey returns the public key in hex format
 func (es *EventSigner) GetPublicKey() string {
 	return es.publicKey

--- a/client/core/example_test.go
+++ b/client/core/example_test.go
@@ -39,7 +39,7 @@ func ExampleUserContext_Reply() {
 	uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
 
 	parent := &nostr.Event{ID: "parent-id", PubKey: "parent-author", Kind: 1}
-	reply, results, err := uc.Reply(parent, "well said!")
+	reply, results, err := uc.Reply(context.Background(), parent, "well said!")
 	if err != nil {
 		return
 	}
@@ -119,7 +119,7 @@ func ExampleAssembleRelayListEvent() {
 	if err != nil {
 		return
 	}
-	results, err := uc.SignAndPublish(unsigned)
+	results, err := uc.SignAndPublish(context.Background(), unsigned)
 	if err != nil {
 		return
 	}

--- a/client/core/example_test.go
+++ b/client/core/example_test.go
@@ -205,3 +205,27 @@ func ExampleApplyClientTag() {
 func ExampleSetLogger() {
 	core.SetLogger(slog.Default())
 }
+
+// exampleStore is a minimal RelayListStore — a pubkey -> *UserRelays map. The
+// directory owns the TTL and single-flight logic, so a store only needs to be a
+// correct key-value map; a real one would persist to a database.
+type exampleStore struct{ m map[string]*core.UserRelays }
+
+func (s exampleStore) Get(pk string) (*core.UserRelays, bool) { ur, ok := s.m[pk]; return ur, ok }
+func (s exampleStore) Set(pk string, ur *core.UserRelays)     { s.m[pk] = ur }
+func (s exampleStore) Delete(pk string)                       { delete(s.m, pk) }
+func (s exampleStore) Range(fn func(string, *core.UserRelays) bool) {
+	for k, v := range s.m {
+		if !fn(k, v) {
+			return
+		}
+	}
+}
+
+// Backing the relay directory with a custom store (e.g. a database) instead of
+// the default in-memory cache.
+func ExampleConfig_relayListStore() {
+	cfg := core.DefaultConfig()
+	cfg.RelayListStore = exampleStore{m: map[string]*core.UserRelays{}}
+	_ = core.NewClient(cfg)
+}

--- a/client/core/example_test.go
+++ b/client/core/example_test.go
@@ -74,3 +74,126 @@ func ExampleSessionRelays() {
 		fmt.Println("outbox:", url)
 	}
 }
+
+// Resolving a user's media servers (Blossom + NIP-96) before an upload. HasAny
+// is the "open the picker vs. prompt to set some up" decision.
+func ExampleClient_ResolveMediaServers() {
+	client := core.NewClient(core.DefaultConfig())
+
+	ms := client.ResolveMediaServers("author-pubkey-hex")
+	if !ms.HasAny() {
+		fmt.Println("no media servers configured")
+		return
+	}
+	fmt.Printf("blossom: %v\n", ms.Blossom) // primary first
+}
+
+// Reading a user's relay lists: NIP-65 (with read/write markers) plus the
+// NIP-51/37 mailbox lists.
+func ExampleClient_FetchUserRelayLists() {
+	client := core.NewClient(core.DefaultConfig())
+
+	lists := client.FetchUserRelayLists("author-pubkey-hex")
+	for _, e := range lists.NIP65 {
+		fmt.Println(e.URL, "read:", e.Read, "write:", e.Write)
+	}
+	fmt.Println("dm relays:", lists.DM)
+}
+
+// Writing a relay list: assemble an UNSIGNED 10002 from the desired entries,
+// then sign + outbox-route + publish it with the user context.
+func ExampleAssembleRelayListEvent() {
+	client := core.NewClient(core.DefaultConfig())
+	signer, err := core.NewEventSigner("64-char-hex-private-key")
+	if err != nil {
+		return
+	}
+	uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
+
+	entries := []core.RelayListEntry{
+		{URL: "wss://out.example.com", Write: true},              // outbox only
+		{URL: "wss://in.example.com", Read: true},                // inbox only
+		{URL: "wss://both.example.com", Read: true, Write: true}, // both (unmarked)
+	}
+	unsigned, err := core.AssembleRelayListEvent(nil, 10002, uc.PublicKey(), entries)
+	if err != nil {
+		return
+	}
+	results, err := uc.SignAndPublish(unsigned)
+	if err != nil {
+		return
+	}
+	fmt.Printf("published to %d relays\n", len(results))
+}
+
+// NIP-44 v2 conversation encryption with the built-in signer (the same key
+// holder decrypts).
+func ExampleEventSigner_NIP44Encrypt() {
+	signer, err := core.NewEventSigner("64-char-hex-private-key")
+	if err != nil {
+		return
+	}
+	ciphertext, err := signer.NIP44Encrypt("peer-pubkey-hex", "hello")
+	if err != nil {
+		return
+	}
+	plaintext, err := signer.NIP44Decrypt("peer-pubkey-hex", ciphertext)
+	if err != nil {
+		return
+	}
+	fmt.Println(plaintext)
+}
+
+// Answering a relay's NIP-42 AUTH challenge: build + sign a kind-22242 event and
+// forward it on the challenged connection.
+func ExampleClient_SendAuth() {
+	client := core.NewClient(core.DefaultConfig())
+	signer, err := core.NewEventSigner("64-char-hex-private-key")
+	if err != nil {
+		return
+	}
+	uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
+
+	for _, req := range client.AuthRequests() {
+		if req.Authed {
+			continue // already answered this session
+		}
+		ev := &nostr.Event{
+			Kind: 22242,
+			Tags: [][]string{
+				{"relay", req.Relay},
+				{"challenge", req.Challenge},
+			},
+		}
+		if err := uc.Sign(ev); err != nil {
+			continue
+		}
+		if err := client.SendAuth(req.Relay, ev); err != nil {
+			continue
+		}
+	}
+}
+
+// Browsing known relays: the live set, NIP-11 metadata, and TCP latency.
+func ExampleClient_KnownRelays() {
+	client := core.NewClient(core.DefaultConfig())
+
+	known := client.KnownRelays()
+	pings := client.PingRelays(known) // map[url]ms, concurrent
+
+	for _, url := range known {
+		name := url
+		if info := client.FetchRelayInfo(url); info != nil && info.Name != "" {
+			name = info.Name // NIP-11, TTL-cached; nil if the relay serves none
+		}
+		fmt.Printf("%s — %dms\n", name, pings[url])
+	}
+}
+
+// Stamping grain's NIP-89 client tag on an event before signing (any foreign
+// client tag is stripped first; pass false to strip without re-adding).
+func ExampleApplyClientTag() {
+	ev := &nostr.Event{Kind: 1, Content: "gm"}
+	core.ApplyClientTag(ev, true, "grain")
+	fmt.Println(len(ev.Tags))
+}

--- a/client/core/example_test.go
+++ b/client/core/example_test.go
@@ -9,6 +9,7 @@ package core_test
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/0ceanslim/grain/client/core"
@@ -196,4 +197,11 @@ func ExampleApplyClientTag() {
 	ev := &nostr.Event{Kind: 1, Content: "gm"}
 	core.ApplyClientTag(ev, true, "grain")
 	fmt.Println(len(ev.Tags))
+}
+
+// Replacing grain's logging so the library writes through a consumer's logger.
+// Any *slog.Logger satisfies core.Logger; a consumer can also implement the four
+// methods (Debug/Info/Warn/Error) over their own logging stack.
+func ExampleSetLogger() {
+	core.SetLogger(slog.Default())
 }

--- a/client/core/example_test.go
+++ b/client/core/example_test.go
@@ -1,0 +1,76 @@
+package core_test
+
+// These examples are the compile-checked public-API surface of the importable
+// library: they live in an external test package (core_test) and import the
+// library the way a downstream consumer does, so the API can't silently drift
+// without breaking the build (CI runs `go test ./...`). They demonstrate shape,
+// not output, so they compile but do not run (no `// Output:`).
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/0ceanslim/grain/client/core"
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// Read-only: fetch a user's recent notes from their outbox relays. No signer is
+// attached, so the context can read but not publish.
+func ExampleClient_readOnly() {
+	client := core.NewClient(core.DefaultConfig())
+	uc := client.NewUserContext("author-pubkey-hex")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	notes := uc.FetchNotes(ctx, "author-pubkey-hex", core.WithLimit(20))
+	fmt.Printf("fetched %d notes\n", len(notes))
+}
+
+// Publishing: attach a local-key signer and post an outbox-routed reply.
+func ExampleUserContext_Reply() {
+	client := core.NewClient(core.DefaultConfig())
+
+	signer, err := core.NewEventSigner("64-char-hex-private-key")
+	if err != nil {
+		return
+	}
+	uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
+
+	parent := &nostr.Event{ID: "parent-id", PubKey: "parent-author", Kind: 1}
+	reply, results, err := uc.Reply(parent, "well said!")
+	if err != nil {
+		return
+	}
+	fmt.Printf("published %s to %d relays\n", reply.ID, len(results))
+}
+
+// Streaming: a live feed of kind-1 notes from a single relay (e.g. grain's own).
+func ExampleClient_StreamEvents() {
+	client := core.NewClient(core.DefaultConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	feed := client.StreamEvents(ctx,
+		nostr.Filter{Kinds: []int{1}},
+		[]string{"wss://relay.example.com"},
+		core.WithLive(), core.WithLimit(50))
+
+	for ev := range feed {
+		fmt.Println(ev.ID)
+	}
+}
+
+// Inspecting and editing the role-tagged session relay configuration.
+func ExampleSessionRelays() {
+	client := core.NewClient(core.DefaultConfig())
+	uc := client.NewUserContext("pubkey-hex")
+
+	uc.Relays().Set("wss://relay.example.com", core.RoleOutbox|core.RoleInbox)
+	uc.Relays().Add("wss://dm.example.com", core.RoleDMInbox)
+
+	for _, url := range uc.Relays().ByRole(core.RoleOutbox) {
+		fmt.Println("outbox:", url)
+	}
+}

--- a/client/core/logger.go
+++ b/client/core/logger.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"sync/atomic"
+
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// Logger is the structured-logging seam for the importable client library. It
+// matches the method set of *slog.Logger, so the standard library logger — and
+// grain's own log.ClientCore() — satisfy it as-is. A consumer that doesn't want
+// to be tied to grain's logging plugs in their own with SetLogger.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+// loggerBox keeps the atomic.Value's stored concrete type constant (it panics on
+// a type change) while letting the wrapped Logger vary between the default and a
+// consumer-supplied one.
+type loggerBox struct{ Logger }
+
+// coreLogger holds the active loggerBox. It defaults to grain's client-core slog
+// logger, so behaviour is unchanged until a consumer calls SetLogger.
+var coreLogger atomic.Value
+
+func init() {
+	coreLogger.Store(loggerBox{log.ClientCore()})
+}
+
+// SetLogger replaces the process-wide logger the client library writes through.
+// It is package-global by design: the library logs from many package-level
+// functions with no Client in scope, so threading a per-Client logger everywhere
+// would add a parameter to most of the surface for little gain. Call it once at
+// startup. A nil logger is ignored; passing log.ClientCore() restores the
+// default. Safe for concurrent use.
+func SetLogger(l Logger) {
+	if l != nil {
+		coreLogger.Store(loggerBox{l})
+	}
+}
+
+// clog returns the active client-library logger.
+func clog() Logger {
+	return coreLogger.Load().(loggerBox).Logger
+}

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -227,14 +227,19 @@ func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
 		nip96   *nostr.Event
 		wg      sync.WaitGroup
 	)
+	// Most users have no media-server lists, so this resolve is usually a
+	// negative that would otherwise wait the full default deadline on any slow
+	// relay. A shorter deadline keeps the media settings section snappy; a real
+	// list still comes back well within it.
+	const mediaResolveTimeout = 3 * time.Second
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		blossom = c.fetchLatestEvent(pubkey, 10063, relays)
+		blossom = c.fetchLatestEventWithin(pubkey, 10063, relays, mediaResolveTimeout)
 	}()
 	go func() {
 		defer wg.Done()
-		nip96 = c.fetchLatestEvent(pubkey, 10096, relays)
+		nip96 = c.fetchLatestEventWithin(pubkey, 10096, relays, mediaResolveTimeout)
 	}()
 	wg.Wait()
 

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -146,7 +147,7 @@ func (c *Client) FetchMediaServerList(pubkey string, kind int) *nostr.Event {
 	if ur, ok := c.directory.Cached(pubkey); ok {
 		relays = appendUnique(relays, ur.Outbox)
 	}
-	return c.fetchLatestEvent(pubkey, kind, relays)
+	return c.fetchLatestEvent(context.Background(), pubkey, kind, relays)
 }
 
 // AssembleMediaServerEvent builds an UNSIGNED media-server list event (Blossom
@@ -235,11 +236,11 @@ func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		blossom = c.fetchLatestEventWithin(pubkey, 10063, relays, mediaResolveTimeout)
+		blossom = c.fetchLatestEventWithin(context.Background(), pubkey, 10063, relays, mediaResolveTimeout)
 	}()
 	go func() {
 		defer wg.Done()
-		nip96 = c.fetchLatestEventWithin(pubkey, 10096, relays, mediaResolveTimeout)
+		nip96 = c.fetchLatestEventWithin(context.Background(), pubkey, 10096, relays, mediaResolveTimeout)
 	}()
 	wg.Wait()
 

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -130,6 +130,12 @@ func (c *Client) InvalidateMediaServers(pubkey string) {
 	c.mediaDir.Invalidate(pubkey)
 }
 
+// WarmMediaServers resolves a user's media-server lists into the cache in the
+// background — used by login-hydration so the media settings page is instant.
+func (c *Client) WarmMediaServers(pubkey string) {
+	go c.ResolveMediaServers(pubkey)
+}
+
 // FetchMediaServerList returns the user's latest raw event of the given
 // media-server list kind (10063 Blossom or 10096 NIP-96), or nil if none is
 // found. Used by the build flow to preserve any non-server tags when

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"sync"
@@ -127,6 +128,73 @@ func (c *Client) ResolveMediaServers(pubkey string) *MediaServers {
 // resolve re-fetches — used after the user publishes an updated list.
 func (c *Client) InvalidateMediaServers(pubkey string) {
 	c.mediaDir.Invalidate(pubkey)
+}
+
+// FetchMediaServerList returns the user's latest raw event of the given
+// media-server list kind (10063 Blossom or 10096 NIP-96), or nil if none is
+// found. Used by the build flow to preserve any non-server tags when
+// republishing the list. Queries the index relays plus the user's cached
+// outbox, where these lists most often live.
+func (c *Client) FetchMediaServerList(pubkey string, kind int) *nostr.Event {
+	relays := c.config.IndexRelays
+	if ur, ok := c.directory.Cached(pubkey); ok {
+		relays = appendUnique(relays, ur.Outbox)
+	}
+	return c.fetchLatestEvent(pubkey, kind, relays)
+}
+
+// AssembleMediaServerEvent builds an UNSIGNED media-server list event (Blossom
+// kind 10063 or NIP-96 kind 10096) from the user's existing one, replacing the
+// server list while preserving every other tag and the content — the same
+// conservative "don't drop data" rule as AssembleProfileEvent.
+//
+// servers are written as `["server", <url>]` tags in the given order (primary
+// first), normalised and de-duplicated. existing may be nil (a first list). The
+// returned event has no ID or Sig: the caller signs it.
+func AssembleMediaServerEvent(existing *nostr.Event, kind int, pubkey string, servers []string) (*nostr.Event, error) {
+	if kind != 10063 && kind != 10096 {
+		return nil, fmt.Errorf("unsupported media-server list kind %d (want 10063 or 10096)", kind)
+	}
+
+	var existingTags [][]string
+	content := ""
+	if existing != nil {
+		existingTags = existing.Tags
+		content = existing.Content
+		if existing.PubKey != "" {
+			pubkey = existing.PubKey
+		}
+	}
+
+	// Preserve every non-server tag; the server list itself is fully rewritten.
+	tags := make([][]string, 0, len(existingTags)+len(servers))
+	for _, t := range existingTags {
+		if len(t) >= 1 && t[0] == "server" {
+			continue
+		}
+		tags = append(tags, t)
+	}
+	// Append the new server list in order, normalised + de-duplicated.
+	seen := make(map[string]struct{})
+	for _, s := range servers {
+		u, ok := normalizeMediaURL(s)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		tags = append(tags, []string{"server", u})
+	}
+
+	return &nostr.Event{
+		PubKey:    pubkey,
+		Kind:      kind,
+		CreatedAt: time.Now().Unix(),
+		Content:   content,
+		Tags:      tags,
+	}, nil
 }
 
 // fetchUserMediaServersFromNetwork is the MediaDirectory's resolver: it queries

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -143,7 +143,7 @@ func (c *Client) WarmMediaServers(pubkey string) {
 // republishing the list. Queries the index relays plus the user's cached
 // outbox, where these lists most often live.
 func (c *Client) FetchMediaServerList(pubkey string, kind int) *nostr.Event {
-	relays := c.config.IndexRelays
+	relays := c.indexRelays()
 	if ur, ok := c.directory.Cached(pubkey); ok {
 		relays = appendUnique(relays, ur.Outbox)
 	}
@@ -215,7 +215,7 @@ func AssembleMediaServerEvent(existing *nostr.Event, kind int, pubkey string, se
 // outbox is included without a blocking resolve (same rule as RouteMetadata);
 // for the logged-in user it is warmed by the mailbox lookup done at login.
 func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
-	relays := c.config.IndexRelays
+	relays := c.indexRelays()
 	if len(relays) == 0 {
 		relays = c.GetConnectedRelays()
 	}

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -144,7 +144,10 @@ func (c *Client) WarmMediaServers(pubkey string) {
 // outbox, where these lists most often live.
 func (c *Client) FetchMediaServerList(pubkey string, kind int) *nostr.Event {
 	relays := c.indexRelays()
-	if ur, ok := c.directory.Cached(pubkey); ok {
+	// Blocking relay-list resolve so the outbox (where the list usually lives) is
+	// included — otherwise a cold directory makes the rebuild miss the existing
+	// event and drop its non-server tags (#83).
+	if ur := c.directory.Lookup(pubkey); ur != nil {
 		relays = appendUnique(relays, ur.Outbox)
 	}
 	return c.fetchLatestEvent(context.Background(), pubkey, kind, relays)
@@ -211,15 +214,20 @@ func AssembleMediaServerEvent(existing *nostr.Event, kind int, pubkey string, se
 //
 // The outbox matters here more than for profiles: media-server lists are often
 // published only to the user's own write relays, not the metadata indexers, so
-// querying indexers alone can miss a list the user really has. The cached
-// outbox is included without a blocking resolve (same rule as RouteMetadata);
-// for the logged-in user it is warmed by the mailbox lookup done at login.
+// querying indexers alone can miss a list the user really has. The outbox is
+// resolved blocking, so an expired directory cache can't silently fall back to
+// indexers-only and cache a false negative (#83).
 func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
 	relays := c.indexRelays()
 	if len(relays) == 0 {
 		relays = c.GetConnectedRelays()
 	}
-	if ur, ok := c.directory.Cached(pubkey); ok {
+	// Include the user's outbox, where 10063/10096 are most often published.
+	// Resolve the relay list *blocking* (not a non-blocking cache peek): a cold
+	// or expired directory would otherwise skip the outbox, query only the
+	// indexers, miss the list, and cache a false negative — the user sees "no
+	// media servers" even though they have some (#83).
+	if ur := c.directory.Lookup(pubkey); ur != nil {
 		relays = appendUnique(relays, ur.Outbox)
 	}
 

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // MediaServers holds a user's published media-server lists: Blossom servers
@@ -261,7 +260,7 @@ func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
 	}
 	m.Negative = len(m.Blossom) == 0 && len(m.NIP96) == 0
 
-	log.ClientCore().Debug("Resolved user media servers", "pubkey", pubkey,
+	clog().Debug("Resolved user media servers", "pubkey", pubkey,
 		"blossom", len(m.Blossom), "nip96", len(m.NIP96), "negative", m.Negative)
 	return m
 }

--- a/client/core/media.go
+++ b/client/core/media.go
@@ -1,0 +1,230 @@
+package core
+
+import (
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// MediaServers holds a user's published media-server lists: Blossom servers
+// (NIP-B7 / BUD-03 kind 10063) and legacy NIP-96 HTTP servers (kind 10096).
+// Both are `["server", <url>]` tag lists in preference order — the first entry
+// is the user's primary, the rest are mirrors / fallbacks. Resolved from the
+// network and cached with a TTL, mirroring the relay directory.
+type MediaServers struct {
+	Blossom   []string  // kind 10063 — Blossom servers, primary first
+	NIP96     []string  // kind 10096 — legacy NIP-96 HTTP servers, primary first
+	FetchedAt time.Time // when this was resolved
+	Negative  bool      // user has published neither list — cached briefly
+}
+
+// HasAny reports whether the user has any media server configured at all. The
+// upload flow uses this to decide between "open the picker" and "prompt the
+// user to set some up".
+func (m *MediaServers) HasAny() bool {
+	return m != nil && (len(m.Blossom) > 0 || len(m.NIP96) > 0)
+}
+
+// MediaDirectory caches per-user media-server resolutions with a TTL, collapsing
+// concurrent lookups for the same pubkey into a single network fetch. It is
+// structurally identical to RelayDirectory but kept separate: media servers are
+// a distinct concern from relays and resolve from different event kinds.
+type MediaDirectory struct {
+	mu       sync.Mutex
+	entries  map[string]*MediaServers
+	inflight map[string]chan struct{}
+	ttl      time.Duration
+	negTTL   time.Duration
+	resolve  func(pubkey string) *MediaServers
+}
+
+func newMediaDirectory(ttl, negTTL time.Duration, resolve func(string) *MediaServers) *MediaDirectory {
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	if negTTL <= 0 {
+		negTTL = time.Minute
+	}
+	return &MediaDirectory{
+		entries:  make(map[string]*MediaServers),
+		inflight: make(map[string]chan struct{}),
+		ttl:      ttl,
+		negTTL:   negTTL,
+		resolve:  resolve,
+	}
+}
+
+// fresh reports whether a cached entry is still within its TTL. A "no list
+// published" result uses the shorter negative TTL so a user who sets up media
+// servers is picked up soon instead of looking server-less for an hour.
+func (d *MediaDirectory) fresh(m *MediaServers) bool {
+	if m == nil {
+		return false
+	}
+	ttl := d.ttl
+	if m.Negative {
+		ttl = d.negTTL
+	}
+	return time.Since(m.FetchedAt) < ttl
+}
+
+// Lookup returns the user's media servers, resolving and caching on a miss or
+// stale entry. Concurrent lookups for the same pubkey share one resolution.
+func (d *MediaDirectory) Lookup(pubkey string) *MediaServers {
+	for {
+		d.mu.Lock()
+		if m, ok := d.entries[pubkey]; ok && d.fresh(m) {
+			d.mu.Unlock()
+			return m
+		}
+		if ch, ok := d.inflight[pubkey]; ok {
+			d.mu.Unlock()
+			<-ch
+			continue
+		}
+		ch := make(chan struct{})
+		d.inflight[pubkey] = ch
+		d.mu.Unlock()
+
+		m := d.resolve(pubkey)
+		if m == nil {
+			m = &MediaServers{Negative: true}
+		}
+		// Stamp the fetch time here, not in the resolver, so a resolver that
+		// forgets can't silently disable caching (entry never reads as fresh).
+		m.FetchedAt = time.Now()
+
+		d.mu.Lock()
+		d.entries[pubkey] = m
+		delete(d.inflight, pubkey)
+		close(ch)
+		d.mu.Unlock()
+		return m
+	}
+}
+
+// Invalidate drops a cached entry so the next Lookup re-resolves — call after
+// the user publishes an updated list, so the change shows immediately.
+func (d *MediaDirectory) Invalidate(pubkey string) {
+	d.mu.Lock()
+	delete(d.entries, pubkey)
+	d.mu.Unlock()
+}
+
+// ResolveMediaServers returns a user's Blossom (kind 10063) and NIP-96
+// (kind 10096) media-server lists, resolved from their published events and
+// cached with a TTL. Safe for concurrent use; the logged-in user is just
+// another pubkey.
+func (c *Client) ResolveMediaServers(pubkey string) *MediaServers {
+	return c.mediaDir.Lookup(pubkey)
+}
+
+// InvalidateMediaServers drops a user's cached media-server lists so the next
+// resolve re-fetches — used after the user publishes an updated list.
+func (c *Client) InvalidateMediaServers(pubkey string) {
+	c.mediaDir.Invalidate(pubkey)
+}
+
+// fetchUserMediaServersFromNetwork is the MediaDirectory's resolver: it queries
+// the index relays AND the user's own outbox (when already cached) for the
+// user's latest kind 10063 (Blossom) and 10096 (NIP-96) events concurrently and
+// maps them to server lists.
+//
+// The outbox matters here more than for profiles: media-server lists are often
+// published only to the user's own write relays, not the metadata indexers, so
+// querying indexers alone can miss a list the user really has. The cached
+// outbox is included without a blocking resolve (same rule as RouteMetadata);
+// for the logged-in user it is warmed by the mailbox lookup done at login.
+func (c *Client) fetchUserMediaServersFromNetwork(pubkey string) *MediaServers {
+	relays := c.config.IndexRelays
+	if len(relays) == 0 {
+		relays = c.GetConnectedRelays()
+	}
+	if ur, ok := c.directory.Cached(pubkey); ok {
+		relays = appendUnique(relays, ur.Outbox)
+	}
+
+	var (
+		blossom *nostr.Event
+		nip96   *nostr.Event
+		wg      sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		blossom = c.fetchLatestEvent(pubkey, 10063, relays)
+	}()
+	go func() {
+		defer wg.Done()
+		nip96 = c.fetchLatestEvent(pubkey, 10096, relays)
+	}()
+	wg.Wait()
+
+	m := &MediaServers{FetchedAt: time.Now()}
+	if blossom != nil {
+		m.Blossom = parseServerListEvent(blossom)
+	}
+	if nip96 != nil {
+		m.NIP96 = parseServerListEvent(nip96)
+	}
+	m.Negative = len(m.Blossom) == 0 && len(m.NIP96) == 0
+
+	log.ClientCore().Debug("Resolved user media servers", "pubkey", pubkey,
+		"blossom", len(m.Blossom), "nip96", len(m.NIP96), "negative", m.Negative)
+	return m
+}
+
+// parseServerListEvent extracts the `["server", <url>]` tag values from a
+// media-server list event (Blossom kind 10063 / NIP-96 kind 10096), preserving
+// order (primary first) and dropping duplicates. URLs are normalised so
+// near-duplicate entries collapse.
+func parseServerListEvent(event *nostr.Event) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, tag := range event.Tags {
+		if len(tag) >= 2 && tag[0] == "server" && tag[1] != "" {
+			u, ok := normalizeMediaURL(tag[1])
+			if !ok {
+				continue
+			}
+			if _, dup := seen[u]; dup {
+				continue
+			}
+			seen[u] = struct{}{}
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// normalizeMediaURL canonicalises a media-server base URL: it defaults to
+// https, lowercases the host, and strips a trailing slash, so near-duplicate
+// entries collapse. Unlike relay URLs these are HTTP(S), not ws/wss. Returns
+// false for input that can't be made into a valid absolute http(s) URL.
+func normalizeMediaURL(raw string) (string, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", false
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return "", false
+	}
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.Fragment = ""
+	u.RawQuery = ""
+	return u.String(), true
+}

--- a/client/core/media_servers.go
+++ b/client/core/media_servers.go
@@ -41,11 +41,6 @@ var suggestedMediaServers = []MediaServerInfo{
 		Note: "Free · ~20 MB/file · runs on nostr.build infra",
 	},
 	{
-		URL: "https://blossom.primal.net", Kind: MediaKindBlossom, Name: "Primal",
-		Cost: "free", Retention: "permanent", Mirror: true,
-		Note: "Free · reliable, widely-used default",
-	},
-	{
 		URL: "https://0x0.happytavern.co", Kind: MediaKindBlossom, Name: "Happy Tavern (free)",
 		Cost: "free", Retention: "ephemeral", Mirror: true,
 		Note: "Free · auto-pruned by size/age — pair as a fast primary with a permanent mirror",
@@ -55,6 +50,11 @@ var suggestedMediaServers = []MediaServerInfo{
 		Cost: "paid", Retention: "permanent", Mirror: true,
 		Note: "Tavern membership · 10k sats one-time · 100 MB/file · 8 GB · kept forever",
 		CTA:  "https://happytavern.co/nostr-verified",
+	},
+	{
+		URL: "https://blossom.primal.net", Kind: MediaKindBlossom, Name: "Primal",
+		Cost: "free", Retention: "permanent", Mirror: true,
+		Note: "Free · reliable, widely-used default",
 	},
 	// NIP-96 (legacy fallback)
 	{

--- a/client/core/media_servers.go
+++ b/client/core/media_servers.go
@@ -1,0 +1,94 @@
+package core
+
+// Media-server protocol kinds. Blossom is nostr-native (blobs addressed by
+// sha256, signed kind-24242 auth); NIP-96 is traditional HTTP storage authed
+// with NIP-98. grain prefers Blossom and treats NIP-96 as a legacy fallback.
+const (
+	MediaKindBlossom = "blossom" // BUD-03 kind 10063; BUD-02 /upload, BUD-04 /mirror
+	MediaKindNIP96   = "nip96"   // kind 10096; NIP-96 multipart upload + NIP-98 auth
+)
+
+// MediaServerInfo is static metadata about a media server grain knows: what
+// protocol it speaks, what it costs, how long it keeps blobs, and whether it
+// accepts BUD-04 mirror requests. It drives the free/paid + retention chips in
+// the settings UI and decides which servers can be offered as mirror targets.
+type MediaServerInfo struct {
+	URL       string `json:"url"`       // normalised base URL
+	Kind      string `json:"kind"`      // MediaKindBlossom | MediaKindNIP96
+	Name      string `json:"name"`      // display name, e.g. "Happy Tavern"
+	Cost      string `json:"cost"`      // "free" | "paid"
+	Retention string `json:"retention"` // "permanent" | "ephemeral"
+	Mirror    bool   `json:"mirror"`    // accepts BUD-04 /mirror (Blossom only)
+	Note      string `json:"note"`      // short blurb shown under the entry
+	CTA       string `json:"cta"`       // optional signup / pricing link
+}
+
+// suggestedMediaServers is grain's curated quick-add list for users with no
+// media servers yet. Blossom is preferred; NIP-96 is the legacy fallback.
+// Neutral free options lead; the Happy Tavern offer is included rather than
+// pushed (the settings UI keeps it unobtrusive).
+//
+// Mirror support: the Happy Tavern servers are confirmed to accept BUD-04
+// /mirror. The public Blossom servers are marked best-effort — BUD-04 is widely
+// supported, and a server that turns out not to accept a mirror just surfaces a
+// per-server failure in the upload toast (no data loss), so this stays
+// permissive rather than gating. Verified at runtime when used as a target.
+var suggestedMediaServers = []MediaServerInfo{
+	// Blossom (preferred)
+	{
+		URL: "https://blossom.band", Kind: MediaKindBlossom, Name: "blossom.band",
+		Cost: "free", Retention: "permanent", Mirror: true,
+		Note: "Free · ~20 MB/file · runs on nostr.build infra",
+	},
+	{
+		URL: "https://blossom.primal.net", Kind: MediaKindBlossom, Name: "Primal",
+		Cost: "free", Retention: "permanent", Mirror: true,
+		Note: "Free · reliable, widely-used default",
+	},
+	{
+		URL: "https://0x0.happytavern.co", Kind: MediaKindBlossom, Name: "Happy Tavern (free)",
+		Cost: "free", Retention: "ephemeral", Mirror: true,
+		Note: "Free · auto-pruned by size/age — pair as a fast primary with a permanent mirror",
+	},
+	{
+		URL: "https://blossom.happytavern.co", Kind: MediaKindBlossom, Name: "Happy Tavern (permanent)",
+		Cost: "paid", Retention: "permanent", Mirror: true,
+		Note: "Tavern membership · 10k sats one-time · 100 MB/file · 8 GB · kept forever",
+		CTA:  "https://happytavern.co/nostr-verified",
+	},
+	// NIP-96 (legacy fallback)
+	{
+		URL: "https://nostr.build", Kind: MediaKindNIP96, Name: "nostr.build",
+		Cost: "free", Retention: "permanent", Mirror: false,
+		Note: "Legacy HTTP storage · free tier + paid upgrades",
+	},
+	{
+		URL: "https://nostrcheck.me", Kind: MediaKindNIP96, Name: "nostrcheck.me",
+		Cost: "free", Retention: "permanent", Mirror: false,
+		Note: "Legacy HTTP storage · open source, self-hostable",
+	},
+}
+
+// SuggestedMediaServers returns a copy of grain's curated quick-add suggestions
+// (Blossom preferred, NIP-96 legacy fallback).
+func SuggestedMediaServers() []MediaServerInfo {
+	out := make([]MediaServerInfo, len(suggestedMediaServers))
+	copy(out, suggestedMediaServers)
+	return out
+}
+
+// LookupMediaServerInfo returns grain's static capability metadata for a server
+// URL if it knows it, matching on the normalised URL. The boolean reports a
+// hit; unknown servers (a user's own additions) simply carry no chips.
+func LookupMediaServerInfo(rawURL string) (MediaServerInfo, bool) {
+	norm, ok := normalizeMediaURL(rawURL)
+	if !ok {
+		return MediaServerInfo{}, false
+	}
+	for _, info := range suggestedMediaServers {
+		if info.URL == norm {
+			return info, true
+		}
+	}
+	return MediaServerInfo{}, false
+}

--- a/client/core/media_test.go
+++ b/client/core/media_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"reflect"
 	"testing"
 
 	nostr "github.com/0ceanslim/grain/server/types"
@@ -102,5 +103,52 @@ func TestSuggestedMediaServersAreWellFormed(t *testing.T) {
 		if info.Kind == MediaKindNIP96 && info.Mirror {
 			t.Errorf("suggested %q is NIP-96 but flagged as a mirror target (BUD-04 is Blossom-only)", info.URL)
 		}
+	}
+}
+
+// Saving a list must rewrite the server tags in order while preserving every
+// other tag and the content — the same "don't drop data" rule as the kind-0
+// editor.
+func TestAssembleMediaServerEventPreservesOtherTags(t *testing.T) {
+	existing := &nostr.Event{
+		PubKey:  "abc",
+		Kind:    10063,
+		Content: "keep me",
+		Tags: [][]string{
+			{"server", "https://old.example"}, // dropped — the server list is rewritten
+			{"client", "amethyst"},            // preserved — not a server tag
+		},
+	}
+	got, err := AssembleMediaServerEvent(existing, 10063, "abc",
+		[]string{"https://blossom.band/", "https://blossom.band", "https://nostr.build"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != 10063 || got.PubKey != "abc" || got.Content != "keep me" {
+		t.Fatalf("kind/pubkey/content not carried over: %+v", got)
+	}
+	if got.ID != "" || got.Sig != "" {
+		t.Fatal("assembled event must be unsigned")
+	}
+	want := [][]string{
+		{"client", "amethyst"},
+		{"server", "https://blossom.band"}, // normalised + deduped, order preserved
+		{"server", "https://nostr.build"},
+	}
+	if !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("tags = %v, want %v", got.Tags, want)
+	}
+}
+
+func TestAssembleMediaServerEventNilExistingAndBadKind(t *testing.T) {
+	got, err := AssembleMediaServerEvent(nil, 10096, "pk", []string{"nostr.build"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != 10096 || got.PubKey != "pk" || len(got.Tags) != 1 || got.Tags[0][1] != "https://nostr.build" {
+		t.Fatalf("nil-existing build wrong: %+v", got)
+	}
+	if _, err := AssembleMediaServerEvent(nil, 10002, "pk", nil); err == nil {
+		t.Fatal("expected an error for an unsupported kind")
 	}
 }

--- a/client/core/media_test.go
+++ b/client/core/media_test.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"testing"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+func TestNormalizeMediaURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"blossom.band", "https://blossom.band", true},          // bare host → https
+		{"https://blossom.band/", "https://blossom.band", true}, // trailing slash stripped
+		{"https://Blossom.Band", "https://blossom.band", true},  // host lowercased
+		{"http://example.com", "http://example.com", true},      // http kept
+		{"https://nostr.build/upload/", "https://nostr.build/upload", true},
+		{"wss://relay.example", "", false}, // ws/wss is not a media server
+		{"  ", "", false},                  // blank
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := normalizeMediaURL(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("normalizeMediaURL(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestParseServerListEventOrderAndDedup(t *testing.T) {
+	ev := &nostr.Event{Tags: [][]string{
+		{"server", "https://blossom.band/"}, // normalises to https://blossom.band
+		{"other", "ignored"},                // non-server tags skipped
+		{"server", "https://nostr.build"},   //
+		{"server", "https://blossom.band"},  // duplicate of the first after normalisation
+		{"server"},                          // malformed (no value) skipped
+		{"server", "wss://relay.example"},   // non-http skipped
+	}}
+	got := parseServerListEvent(ev)
+	want := []string{"https://blossom.band", "https://nostr.build"}
+	if len(got) != len(want) {
+		t.Fatalf("parseServerListEvent = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseServerListEvent = %v, want %v (order matters: primary first)", got, want)
+		}
+	}
+}
+
+func TestLookupMediaServerInfo(t *testing.T) {
+	if info, ok := LookupMediaServerInfo("https://blossom.band"); !ok || info.Kind != MediaKindBlossom {
+		t.Errorf("LookupMediaServerInfo(blossom.band) = (%+v, %v), want a blossom hit", info, ok)
+	}
+	// Matches regardless of input normalisation.
+	if _, ok := LookupMediaServerInfo("blossom.band"); !ok {
+		t.Error("LookupMediaServerInfo should match an un-normalised URL")
+	}
+	if _, ok := LookupMediaServerInfo("https://unknown.example"); ok {
+		t.Error("LookupMediaServerInfo should miss an unknown server")
+	}
+}
+
+func TestMediaServersHasAny(t *testing.T) {
+	if (&MediaServers{}).HasAny() {
+		t.Error("empty MediaServers should report no servers")
+	}
+	if !(&MediaServers{Blossom: []string{"https://x"}}).HasAny() {
+		t.Error("MediaServers with a Blossom server should report HasAny")
+	}
+	if (*MediaServers)(nil).HasAny() {
+		t.Error("nil MediaServers should report no servers")
+	}
+}
+
+// The curated suggestions back the settings UI and the upload picker, so the
+// table must stay self-consistent: every URL already normalised, valid kinds /
+// costs / retentions, and no NIP-96 server ever flagged as a mirror target
+// (BUD-04 is Blossom-only).
+func TestSuggestedMediaServersAreWellFormed(t *testing.T) {
+	for _, info := range SuggestedMediaServers() {
+		if norm, ok := normalizeMediaURL(info.URL); !ok || norm != info.URL {
+			t.Errorf("suggested %q is not already normalised (got %q)", info.URL, norm)
+		}
+		switch info.Kind {
+		case MediaKindBlossom, MediaKindNIP96:
+		default:
+			t.Errorf("suggested %q has invalid kind %q", info.URL, info.Kind)
+		}
+		switch info.Cost {
+		case "free", "paid":
+		default:
+			t.Errorf("suggested %q has invalid cost %q", info.URL, info.Cost)
+		}
+		switch info.Retention {
+		case "permanent", "ephemeral":
+		default:
+			t.Errorf("suggested %q has invalid retention %q", info.URL, info.Retention)
+		}
+		if info.Kind == MediaKindNIP96 && info.Mirror {
+			t.Errorf("suggested %q is NIP-96 but flagged as a mirror target (BUD-04 is Blossom-only)", info.URL)
+		}
+	}
+}

--- a/client/core/nip42.go
+++ b/client/core/nip42.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// NIP-42 AUTH (https://github.com/nostr-protocol/nips/blob/master/42.md).
+//
+// grain's pool holds the relay socket; the signer lives in the browser. So the
+// pool records each relay's AUTH challenge as it arrives, the relay manager
+// surfaces the relays that have asked, the browser signs a kind-22242 event, and
+// SendAuth relays it back on the same connection. A relay stays "authed" for the
+// session once answered; a fresh challenge (new connection / expiry) overwrites
+// the stored one so the signer can answer again.
+
+// AuthState is what the pool has observed about one relay's NIP-42 status this
+// session: its latest challenge and whether we've answered it.
+type AuthState struct {
+	Relay     string    `json:"relay"`
+	Challenge string    `json:"challenge"`
+	Authed    bool      `json:"authed"`
+	At        time.Time `json:"at"`
+}
+
+// RouteAuth records a relay's AUTH challenge. A new challenge clears the authed
+// flag for that relay so the manager prompts a fresh answer.
+func (mr *MessageRouter) RouteAuth(relayURL, challenge string) {
+	mr.authMu.Lock()
+	defer mr.authMu.Unlock()
+	st := mr.authStates[relayURL]
+	if st == nil {
+		st = &AuthState{Relay: relayURL}
+		mr.authStates[relayURL] = st
+	}
+	if challenge != st.Challenge {
+		st.Authed = false
+	}
+	st.Challenge = challenge
+	st.At = time.Now()
+}
+
+// MarkAuthed records that we've answered a relay's challenge this session.
+func (mr *MessageRouter) MarkAuthed(relayURL string) {
+	mr.authMu.Lock()
+	defer mr.authMu.Unlock()
+	if st := mr.authStates[relayURL]; st != nil {
+		st.Authed = true
+	}
+}
+
+// AuthChallenge returns a relay's current challenge ("" if none pending).
+func (mr *MessageRouter) AuthChallenge(relayURL string) string {
+	mr.authMu.RLock()
+	defer mr.authMu.RUnlock()
+	if st := mr.authStates[relayURL]; st != nil {
+		return st.Challenge
+	}
+	return ""
+}
+
+// AuthStates returns a snapshot of every relay that has challenged us.
+func (mr *MessageRouter) AuthStates() []AuthState {
+	mr.authMu.RLock()
+	defer mr.authMu.RUnlock()
+	out := make([]AuthState, 0, len(mr.authStates))
+	for _, st := range mr.authStates {
+		out = append(out, *st)
+	}
+	return out
+}
+
+// RemoveAuth forgets a relay's AUTH state (the user revoked trust).
+func (mr *MessageRouter) RemoveAuth(relayURL string) {
+	mr.authMu.Lock()
+	delete(mr.authStates, relayURL)
+	mr.authMu.Unlock()
+}
+
+// ── Pool-level NIP-42 surface ────────────────────────────────────────────────
+
+// AuthRequests returns the relays that have sent an AUTH challenge this session.
+func (rp *RelayPool) AuthRequests() []AuthState { return rp.messageRouter.AuthStates() }
+
+// AuthChallenge returns a relay's pending challenge ("" if none).
+func (rp *RelayPool) AuthChallenge(url string) string { return rp.messageRouter.AuthChallenge(url) }
+
+// SendAuth sends a signed NIP-42 auth event (kind 22242) to a relay and marks it
+// authed for the session. The connection that issued the challenge must still be
+// open (the challenge is bound to it).
+func (rp *RelayPool) SendAuth(url string, signedEvent *nostr.Event) error {
+	if err := rp.SendMessage(url, []interface{}{"AUTH", signedEvent}); err != nil {
+		return err
+	}
+	rp.messageRouter.MarkAuthed(url)
+	return nil
+}
+
+// RemoveAuth forgets a relay's AUTH state.
+func (rp *RelayPool) RemoveAuth(url string) { rp.messageRouter.RemoveAuth(url) }
+
+// ── Client convenience wrappers ──────────────────────────────────────────────
+
+// AuthRequests returns the relays that have challenged the pool for NIP-42 AUTH.
+func (c *Client) AuthRequests() []AuthState { return c.relayPool.AuthRequests() }
+
+// AuthChallenge returns a relay's pending AUTH challenge ("" if none).
+func (c *Client) AuthChallenge(url string) string { return c.relayPool.AuthChallenge(url) }
+
+// SendAuth relays a browser-signed kind-22242 event to a relay.
+func (c *Client) SendAuth(url string, signedEvent *nostr.Event) error {
+	return c.relayPool.SendAuth(url, signedEvent)
+}
+
+// RemoveAuth forgets a relay's session AUTH state.
+func (c *Client) RemoveAuth(url string) { c.relayPool.RemoveAuth(url) }

--- a/client/core/nip42_test.go
+++ b/client/core/nip42_test.go
@@ -1,0 +1,44 @@
+package core
+
+import "testing"
+
+func TestMessageRouterAuthState(t *testing.T) {
+	mr := NewMessageRouter()
+	const relay = "wss://relay.example.com"
+
+	if got := mr.AuthChallenge(relay); got != "" {
+		t.Fatalf("expected no challenge initially, got %q", got)
+	}
+
+	mr.RouteAuth(relay, "chal-1")
+	if got := mr.AuthChallenge(relay); got != "chal-1" {
+		t.Errorf("challenge = %q, want chal-1", got)
+	}
+	states := mr.AuthStates()
+	if len(states) != 1 || states[0].Relay != relay || states[0].Authed {
+		t.Fatalf("unexpected states: %+v", states)
+	}
+
+	mr.MarkAuthed(relay)
+	if !mr.AuthStates()[0].Authed {
+		t.Error("expected authed after MarkAuthed")
+	}
+
+	// A different challenge resets authed (the relay re-challenged).
+	mr.RouteAuth(relay, "chal-2")
+	if st := mr.AuthStates()[0]; st.Authed || st.Challenge != "chal-2" {
+		t.Errorf("new challenge should reset authed: %+v", st)
+	}
+
+	// The same challenge again must not reset authed.
+	mr.MarkAuthed(relay)
+	mr.RouteAuth(relay, "chal-2")
+	if !mr.AuthStates()[0].Authed {
+		t.Error("identical challenge should not reset authed")
+	}
+
+	mr.RemoveAuth(relay)
+	if len(mr.AuthStates()) != 0 {
+		t.Errorf("expected empty after RemoveAuth, got %d", len(mr.AuthStates()))
+	}
+}

--- a/client/core/nip44.go
+++ b/client/core/nip44.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -172,6 +173,45 @@ func nip44DecryptV2(payloadB64 string, convKey []byte) (string, error) {
 		return "", err
 	}
 	return string(unpadded), nil
+}
+
+// nip44PayloadVersion peeks the version byte of a base64 payload without
+// decrypting, so decrypt can route to the right scheme (v2 and v3 derive their
+// conversation keys differently).
+func nip44PayloadVersion(payload string) (byte, error) {
+	if len(payload) == 0 || payload[0] == '#' {
+		return 0, errors.New("nip44: unsupported payload version")
+	}
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil || len(data) < 1 {
+		return 0, errors.New("nip44: invalid payload")
+	}
+	return data[0], nil
+}
+
+// nip44Encrypt encrypts plaintext from priv to peerPub using the default scheme
+// (v2 — the deployed standard) with a fresh random nonce. v3 stays opt-in until
+// the proposal has deployed peers.
+func nip44Encrypt(priv *btcec.PrivateKey, peerPub *btcec.PublicKey, plaintext string) (string, error) {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	return nip44EncryptV2(plaintext, nip44ConversationKeyV2(priv, peerPub), nonce)
+}
+
+// nip44Decrypt routes a payload to the matching version's decryptor.
+func nip44Decrypt(priv *btcec.PrivateKey, peerPub *btcec.PublicKey, payload string) (string, error) {
+	ver, err := nip44PayloadVersion(payload)
+	if err != nil {
+		return "", err
+	}
+	switch ver {
+	case nip44VersionV2:
+		return nip44DecryptV2(payload, nip44ConversationKeyV2(priv, peerPub))
+	default:
+		return "", fmt.Errorf("nip44: unsupported version %d", ver)
+	}
 }
 
 // nip44HMACAad is HMAC-SHA256 over (aad || message) — NIP-44 authenticates the

--- a/client/core/nip44.go
+++ b/client/core/nip44.go
@@ -1,0 +1,210 @@
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/bits"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"golang.org/x/crypto/chacha20"
+	"golang.org/x/crypto/hkdf"
+)
+
+// NIP-44 versioned payload encryption (https://github.com/nostr-protocol/nips/blob/master/44.md).
+//
+// v2 — the deployed standard — is implemented here: secp256k1 ECDH → HKDF-SHA256
+// conversation key, per-message HKDF-expanded ChaCha20 + HMAC-SHA256, with the
+// spec's power-of-two padding. Validated against the official test vectors in
+// nip44_test.go. v3 (the nostr-land proposal) layers on top in nip44_v3.go.
+//
+// grain rolls its own nostr layer, so this is a from-scratch implementation
+// rather than a library dependency; correctness rides entirely on the vectors.
+
+const nip44VersionV2 = 0x02
+
+// nip44ConversationKeyV2 derives the v2 conversation key shared between a private
+// key and a peer's public key: hkdf_extract(IKM = ecdh_x, salt = "nip44-v2").
+func nip44ConversationKeyV2(priv *btcec.PrivateKey, pub *btcec.PublicKey) []byte {
+	shared := ecdhX(priv, pub)
+	return hkdf.Extract(sha256.New, shared, []byte("nip44-v2"))
+}
+
+// ecdhX returns the 32-byte big-endian X coordinate of priv*pub on secp256k1 —
+// the raw shared coordinate NIP-44 feeds into HKDF (not the SHA-256-hashed
+// shared secret that btcec.GenerateSharedSecret would give).
+func ecdhX(priv *btcec.PrivateKey, pub *btcec.PublicKey) []byte {
+	var point, result secp256k1.JacobianPoint
+	pub.AsJacobian(&point)
+	secp256k1.ScalarMultNonConst(&priv.Key, &point, &result)
+	result.ToAffine()
+	xb := result.X.Bytes() // *[32]byte
+	return xb[:]
+}
+
+// nip44MessageKeysV2 expands the conversation key + 32-byte nonce into the
+// per-message ChaCha20 key (32), ChaCha20 nonce (12), and HMAC key (32).
+func nip44MessageKeysV2(convKey, nonce []byte) (chachaKey, chachaNonce, hmacKey []byte, err error) {
+	r := hkdf.Expand(sha256.New, convKey, nonce)
+	out := make([]byte, 76)
+	if _, err = io.ReadFull(r, out); err != nil {
+		return nil, nil, nil, err
+	}
+	return out[0:32], out[32:44], out[44:76], nil
+}
+
+// nip44PadLen is the spec's calc_padded_len: pad the plaintext up to a
+// power-of-two-derived chunk so ciphertext length leaks as little as possible.
+func nip44PadLen(unpadded int) int {
+	if unpadded <= 32 {
+		return 32
+	}
+	nextPower := 1 << bits.Len(uint(unpadded-1)) // = 2^(floor(log2(n-1))+1), exact
+	chunk := 32
+	if nextPower > 256 {
+		chunk = nextPower / 8
+	}
+	return chunk * ((unpadded-1)/chunk + 1)
+}
+
+// nip44Pad frames plaintext as: u16_be(len) || plaintext || zero padding.
+func nip44Pad(plaintext []byte) ([]byte, error) {
+	ul := len(plaintext)
+	if ul < 1 || ul > 65535 {
+		return nil, fmt.Errorf("nip44: plaintext length %d out of range [1,65535]", ul)
+	}
+	out := make([]byte, 2+nip44PadLen(ul))
+	binary.BigEndian.PutUint16(out[0:2], uint16(ul))
+	copy(out[2:], plaintext)
+	return out, nil
+}
+
+// nip44Unpad recovers and validates the plaintext from a padded buffer.
+func nip44Unpad(padded []byte) ([]byte, error) {
+	if len(padded) < 2 {
+		return nil, errors.New("nip44: padding too short")
+	}
+	ul := int(binary.BigEndian.Uint16(padded[0:2]))
+	if ul < 1 || 2+ul > len(padded) || len(padded) != 2+nip44PadLen(ul) {
+		return nil, errors.New("nip44: invalid padding")
+	}
+	return padded[2 : 2+ul], nil
+}
+
+// nip44EncryptV2 encrypts plaintext under a conversation key with the given
+// 32-byte nonce, returning the base64 payload (version || nonce || ct || mac).
+func nip44EncryptV2(plaintext string, convKey, nonce []byte) (string, error) {
+	if len(convKey) != 32 {
+		return "", errors.New("nip44: conversation key must be 32 bytes")
+	}
+	if len(nonce) != 32 {
+		return "", errors.New("nip44: nonce must be 32 bytes")
+	}
+	chachaKey, chachaNonce, hmacKey, err := nip44MessageKeysV2(convKey, nonce)
+	if err != nil {
+		return "", err
+	}
+	padded, err := nip44Pad([]byte(plaintext))
+	if err != nil {
+		return "", err
+	}
+	cipher, err := chacha20.NewUnauthenticatedCipher(chachaKey, chachaNonce)
+	if err != nil {
+		return "", err
+	}
+	ciphertext := make([]byte, len(padded))
+	cipher.XORKeyStream(ciphertext, padded)
+
+	mac := nip44HMACAad(hmacKey, nonce, ciphertext)
+
+	payload := make([]byte, 0, 1+len(nonce)+len(ciphertext)+len(mac))
+	payload = append(payload, nip44VersionV2)
+	payload = append(payload, nonce...)
+	payload = append(payload, ciphertext...)
+	payload = append(payload, mac...)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+// nip44DecryptV2 decrypts a v2 base64 payload under a conversation key.
+func nip44DecryptV2(payloadB64 string, convKey []byte) (string, error) {
+	if len(convKey) != 32 {
+		return "", errors.New("nip44: conversation key must be 32 bytes")
+	}
+	if len(payloadB64) == 0 || payloadB64[0] == '#' {
+		return "", errors.New("nip44: unsupported payload version")
+	}
+	data, err := base64.StdEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return "", errors.New("nip44: invalid base64 payload")
+	}
+	// version(1) + nonce(32) + min ciphertext(34) + mac(32)
+	if len(data) < 99 || len(data) > 65603 {
+		return "", fmt.Errorf("nip44: invalid payload size %d", len(data))
+	}
+	if data[0] != nip44VersionV2 {
+		return "", fmt.Errorf("nip44: unknown version %d", data[0])
+	}
+	nonce := data[1:33]
+	ciphertext := data[33 : len(data)-32]
+	mac := data[len(data)-32:]
+
+	chachaKey, chachaNonce, hmacKey, err := nip44MessageKeysV2(convKey, nonce)
+	if err != nil {
+		return "", err
+	}
+	if !hmac.Equal(nip44HMACAad(hmacKey, nonce, ciphertext), mac) {
+		return "", errors.New("nip44: invalid MAC")
+	}
+	cipher, err := chacha20.NewUnauthenticatedCipher(chachaKey, chachaNonce)
+	if err != nil {
+		return "", err
+	}
+	padded := make([]byte, len(ciphertext))
+	cipher.XORKeyStream(padded, ciphertext)
+	unpadded, err := nip44Unpad(padded)
+	if err != nil {
+		return "", err
+	}
+	return string(unpadded), nil
+}
+
+// nip44HMACAad is HMAC-SHA256 over (aad || message) — NIP-44 authenticates the
+// nonce as associated data alongside the ciphertext.
+func nip44HMACAad(key, aad, message []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(aad)
+	h.Write(message)
+	return h.Sum(nil)
+}
+
+// nip44ParseXOnlyPub lifts a 32-byte x-only (BIP340) public key to a full point
+// with even Y, as NIP-44 ECDH expects.
+func nip44ParseXOnlyPub(xOnly []byte) (*btcec.PublicKey, error) {
+	if len(xOnly) != 32 {
+		return nil, fmt.Errorf("nip44: x-only pubkey must be 32 bytes, got %d", len(xOnly))
+	}
+	return schnorr.ParsePubKey(xOnly)
+}
+
+// nip44ParsePriv validates and parses a 32-byte secret key, rejecting keys that
+// are zero or >= the curve order (which btcec.PrivKeyFromBytes would silently
+// reduce instead of rejecting).
+func nip44ParsePriv(secKey []byte) (*btcec.PrivateKey, error) {
+	if len(secKey) != 32 {
+		return nil, fmt.Errorf("nip44: secret key must be 32 bytes, got %d", len(secKey))
+	}
+	var s secp256k1.ModNScalar
+	if overflow := s.SetByteSlice(secKey); overflow {
+		return nil, errors.New("nip44: secret key >= curve order")
+	}
+	if s.IsZero() {
+		return nil, errors.New("nip44: secret key is zero")
+	}
+	return secp256k1.NewPrivateKey(&s), nil
+}

--- a/client/core/nip44.go
+++ b/client/core/nip44.go
@@ -209,6 +209,9 @@ func nip44Decrypt(priv *btcec.PrivateKey, peerPub *btcec.PublicKey, payload stri
 	switch ver {
 	case nip44VersionV2:
 		return nip44DecryptV2(payload, nip44ConversationKeyV2(priv, peerPub))
+	case nip44VersionV3:
+		// v3 authenticates an event kind + scope the generic seam doesn't carry.
+		return "", errors.New("nip44: v3 payload requires kind+scope context")
 	default:
 		return "", fmt.Errorf("nip44: unsupported version %d", ver)
 	}

--- a/client/core/nip44_signer.go
+++ b/client/core/nip44_signer.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// EventSigner satisfies Encrypter: NIP-44 encrypt/decrypt with the held private
+// key. grain's own web client encrypts in the browser (NIP-07/NIP-46); these
+// methods are for downstream Go consumers and server-side-key sessions.
+
+// NIP44Encrypt encrypts plaintext to peerPubKey using NIP-44 v2. peerPubKey is
+// 64-char hex (x-only); for NIP-51 private lists (encrypted to self) pass the
+// signer's own pubkey.
+func (es *EventSigner) NIP44Encrypt(peerPubKey, plaintext string) (string, error) {
+	pub, err := xOnlyPubFromHex(peerPubKey)
+	if err != nil {
+		return "", err
+	}
+	return nip44Encrypt(es.privateKey, pub, plaintext)
+}
+
+// NIP44Decrypt decrypts a base64 NIP-44 payload from peerPubKey (any supported
+// version).
+func (es *EventSigner) NIP44Decrypt(peerPubKey, payload string) (string, error) {
+	pub, err := xOnlyPubFromHex(peerPubKey)
+	if err != nil {
+		return "", err
+	}
+	return nip44Decrypt(es.privateKey, pub, payload)
+}
+
+// xOnlyPubFromHex parses a 64-char hex x-only pubkey into a curve point.
+func xOnlyPubFromHex(pubHex string) (*btcec.PublicKey, error) {
+	b, err := hex.DecodeString(pubHex)
+	if err != nil {
+		return nil, fmt.Errorf("nip44: invalid pubkey hex: %w", err)
+	}
+	return nip44ParseXOnlyPub(b)
+}

--- a/client/core/nip44_signer.go
+++ b/client/core/nip44_signer.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 
@@ -30,6 +31,30 @@ func (es *EventSigner) NIP44Decrypt(peerPubKey, payload string) (string, error) 
 		return "", err
 	}
 	return nip44Decrypt(es.privateKey, pub, payload)
+}
+
+// NIP44V3Encrypt encrypts plaintext to peerPubKey under NIP-44 v3, binding the
+// event kind and scope. v3 is a draft — prefer NIP44Encrypt (v2) for interop.
+func (es *EventSigner) NIP44V3Encrypt(peerPubKey string, kind uint32, scope, plaintext []byte) (string, error) {
+	pub, err := xOnlyPubFromHex(peerPubKey)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	return nip44EncryptV3(es.privateKey, pub, kind, scope, plaintext, nonce)
+}
+
+// NIP44V3Decrypt decrypts a NIP-44 v3 payload from peerPubKey, requiring it to
+// match the expected kind + scope.
+func (es *EventSigner) NIP44V3Decrypt(peerPubKey string, expectedKind uint32, expectedScope []byte, payload string) ([]byte, error) {
+	pub, err := xOnlyPubFromHex(peerPubKey)
+	if err != nil {
+		return nil, err
+	}
+	return nip44DecryptV3(es.privateKey, pub, expectedKind, expectedScope, payload)
 }
 
 // xOnlyPubFromHex parses a 64-char hex x-only pubkey into a curve point.

--- a/client/core/nip44_test.go
+++ b/client/core/nip44_test.go
@@ -1,0 +1,235 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// nip44VectorFile mirrors the official NIP-44 test vectors
+// (testdata/nip44.vectors.json from github.com/paulmillr/nip44).
+type nip44VectorFile struct {
+	V2 struct {
+		Valid struct {
+			GetConversationKey []struct {
+				Sec1            string `json:"sec1"`
+				Pub2            string `json:"pub2"`
+				ConversationKey string `json:"conversation_key"`
+			} `json:"get_conversation_key"`
+			GetMessageKeys struct {
+				ConversationKey string `json:"conversation_key"`
+				Keys            []struct {
+					Nonce       string `json:"nonce"`
+					ChachaKey   string `json:"chacha_key"`
+					ChachaNonce string `json:"chacha_nonce"`
+					HmacKey     string `json:"hmac_key"`
+				} `json:"keys"`
+			} `json:"get_message_keys"`
+			CalcPaddedLen         [][2]int `json:"calc_padded_len"`
+			EncryptDecrypt        []nip44EncDecVec
+			EncryptDecryptLongMsg []struct {
+				ConversationKey string `json:"conversation_key"`
+				Nonce           string `json:"nonce"`
+				Pattern         string `json:"pattern"`
+				Repeat          int    `json:"repeat"`
+				PlaintextSha256 string `json:"plaintext_sha256"`
+				PayloadSha256   string `json:"payload_sha256"`
+			} `json:"encrypt_decrypt_long_msg"`
+		} `json:"valid"`
+		Invalid struct {
+			GetConversationKey []struct {
+				Sec1 string `json:"sec1"`
+				Pub2 string `json:"pub2"`
+				Note string `json:"note"`
+			} `json:"get_conversation_key"`
+			Decrypt []struct {
+				ConversationKey string `json:"conversation_key"`
+				Payload         string `json:"payload"`
+				Note            string `json:"note"`
+			} `json:"decrypt"`
+		} `json:"invalid"`
+	} `json:"v2"`
+}
+
+type nip44EncDecVec struct {
+	Sec1            string `json:"sec1"`
+	Sec2            string `json:"sec2"`
+	ConversationKey string `json:"conversation_key"`
+	Nonce           string `json:"nonce"`
+	Plaintext       string `json:"plaintext"`
+	Payload         string `json:"payload"`
+}
+
+func loadNIP44Vectors(t *testing.T) *nip44VectorFile {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/nip44.vectors.json")
+	if err != nil {
+		t.Fatalf("read vectors: %v", err)
+	}
+	var v nip44VectorFile
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("parse vectors: %v", err)
+	}
+	return &v
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+func TestNIP44V2GetConversationKey(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for i, c := range v.V2.Valid.GetConversationKey {
+		priv, err := nip44ParsePriv(mustHex(t, c.Sec1))
+		if err != nil {
+			t.Fatalf("case %d: parse sec1: %v", i, err)
+		}
+		pub, err := nip44ParseXOnlyPub(mustHex(t, c.Pub2))
+		if err != nil {
+			t.Fatalf("case %d: parse pub2: %v", i, err)
+		}
+		got := hex.EncodeToString(nip44ConversationKeyV2(priv, pub))
+		if got != c.ConversationKey {
+			t.Errorf("case %d: conversation key = %s, want %s", i, got, c.ConversationKey)
+		}
+	}
+}
+
+func TestNIP44V2GetMessageKeys(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	convKey := mustHex(t, v.V2.Valid.GetMessageKeys.ConversationKey)
+	for i, k := range v.V2.Valid.GetMessageKeys.Keys {
+		ck, cn, hk, err := nip44MessageKeysV2(convKey, mustHex(t, k.Nonce))
+		if err != nil {
+			t.Fatalf("case %d: %v", i, err)
+		}
+		if got := hex.EncodeToString(ck); got != k.ChachaKey {
+			t.Errorf("case %d: chacha_key = %s, want %s", i, got, k.ChachaKey)
+		}
+		if got := hex.EncodeToString(cn); got != k.ChachaNonce {
+			t.Errorf("case %d: chacha_nonce = %s, want %s", i, got, k.ChachaNonce)
+		}
+		if got := hex.EncodeToString(hk); got != k.HmacKey {
+			t.Errorf("case %d: hmac_key = %s, want %s", i, got, k.HmacKey)
+		}
+	}
+}
+
+func TestNIP44V2CalcPaddedLen(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for _, pair := range v.V2.Valid.CalcPaddedLen {
+		if got := nip44PadLen(pair[0]); got != pair[1] {
+			t.Errorf("padLen(%d) = %d, want %d", pair[0], got, pair[1])
+		}
+	}
+}
+
+func TestNIP44V2EncryptDecrypt(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for i, c := range v.V2.Valid.EncryptDecrypt {
+		convKey := mustHex(t, c.ConversationKey)
+
+		// The ECDH path must reproduce the stated conversation key.
+		priv, err := nip44ParsePriv(mustHex(t, c.Sec1))
+		if err != nil {
+			t.Fatalf("case %d: parse sec1: %v", i, err)
+		}
+		pub2 := nip44PubFromPriv(t, c.Sec2)
+		if got := hex.EncodeToString(nip44ConversationKeyV2(priv, pub2)); got != c.ConversationKey {
+			t.Errorf("case %d: derived conversation key = %s, want %s", i, got, c.ConversationKey)
+		}
+
+		gotPayload, err := nip44EncryptV2(c.Plaintext, convKey, mustHex(t, c.Nonce))
+		if err != nil {
+			t.Fatalf("case %d: encrypt: %v", i, err)
+		}
+		if gotPayload != c.Payload {
+			t.Errorf("case %d: payload = %s, want %s", i, gotPayload, c.Payload)
+		}
+		gotPlain, err := nip44DecryptV2(c.Payload, convKey)
+		if err != nil {
+			t.Fatalf("case %d: decrypt: %v", i, err)
+		}
+		if gotPlain != c.Plaintext {
+			t.Errorf("case %d: plaintext = %q, want %q", i, gotPlain, c.Plaintext)
+		}
+	}
+}
+
+func TestNIP44V2LongMessages(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for i, c := range v.V2.Valid.EncryptDecryptLongMsg {
+		convKey := mustHex(t, c.ConversationKey)
+		plaintext := strings.Repeat(c.Pattern, c.Repeat)
+		if got := sha256Hex(plaintext); got != c.PlaintextSha256 {
+			t.Fatalf("case %d: plaintext sha256 = %s, want %s", i, got, c.PlaintextSha256)
+		}
+		payload, err := nip44EncryptV2(plaintext, convKey, mustHex(t, c.Nonce))
+		if err != nil {
+			t.Fatalf("case %d: encrypt: %v", i, err)
+		}
+		if got := sha256Hex(payload); got != c.PayloadSha256 {
+			t.Errorf("case %d: payload sha256 = %s, want %s", i, got, c.PayloadSha256)
+		}
+		plain, err := nip44DecryptV2(payload, convKey)
+		if err != nil {
+			t.Fatalf("case %d: decrypt: %v", i, err)
+		}
+		if plain != plaintext {
+			t.Errorf("case %d: round-trip mismatch", i)
+		}
+	}
+}
+
+func TestNIP44V2InvalidConversationKeys(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for i, c := range v.V2.Invalid.GetConversationKey {
+		sec, errSec := hex.DecodeString(c.Sec1)
+		pub, errPub := hex.DecodeString(c.Pub2)
+		if errSec != nil || errPub != nil {
+			continue // malformed hex is itself a rejection
+		}
+		_, e1 := nip44ParsePriv(sec)
+		_, e2 := nip44ParseXOnlyPub(pub)
+		if e1 == nil && e2 == nil {
+			t.Errorf("case %d (%s): expected key parse to fail, both succeeded", i, c.Note)
+		}
+	}
+}
+
+func TestNIP44V2InvalidDecrypt(t *testing.T) {
+	v := loadNIP44Vectors(t)
+	for i, c := range v.V2.Invalid.Decrypt {
+		convKey, err := hex.DecodeString(c.ConversationKey)
+		if err != nil {
+			continue
+		}
+		if _, err := nip44DecryptV2(c.Payload, convKey); err == nil {
+			t.Errorf("case %d (%s): expected decrypt to fail, it succeeded", i, c.Note)
+		}
+	}
+}
+
+func nip44PubFromPriv(t *testing.T, secHex string) *btcec.PublicKey {
+	t.Helper()
+	priv, err := nip44ParsePriv(mustHex(t, secHex))
+	if err != nil {
+		t.Fatalf("parse priv %q: %v", secHex, err)
+	}
+	return priv.PubKey()
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/client/core/nip44_test.go
+++ b/client/core/nip44_test.go
@@ -233,3 +233,44 @@ func sha256Hex(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])
 }
+
+// TestNIP44EventSignerRoundTrip exercises the Encrypter seam: self-encryption
+// (NIP-51 lists), a two-party round trip, and rejection by a wrong key.
+func TestNIP44EventSignerRoundTrip(t *testing.T) {
+	alice, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const msg = "hello, private relay list 🌾"
+
+	// Self-encryption — how NIP-51 private list content is stored.
+	selfCt, err := alice.NIP44Encrypt(alice.PublicKey(), msg)
+	if err != nil {
+		t.Fatalf("self encrypt: %v", err)
+	}
+	if got, err := alice.NIP44Decrypt(alice.PublicKey(), selfCt); err != nil || got != msg {
+		t.Fatalf("self round-trip: got %q err %v", got, err)
+	}
+
+	// Two-party: both sides derive the same conversation key.
+	ct, err := alice.NIP44Encrypt(bob.PublicKey(), msg)
+	if err != nil {
+		t.Fatalf("a->b encrypt: %v", err)
+	}
+	if got, err := bob.NIP44Decrypt(alice.PublicKey(), ct); err != nil || got != msg {
+		t.Fatalf("a->b round-trip: got %q err %v", got, err)
+	}
+
+	// A third party can't read it.
+	carol, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := carol.NIP44Decrypt(alice.PublicKey(), ct); err == nil {
+		t.Error("expected decrypt with wrong key to fail")
+	}
+}

--- a/client/core/nip44_v3.go
+++ b/client/core/nip44_v3.go
@@ -1,0 +1,205 @@
+package core
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/bits"
+	"unicode/utf8"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"golang.org/x/crypto/chacha20"
+	"golang.org/x/crypto/hkdf"
+)
+
+// NIP-44 v3 (https://github.com/nostr-land/nip44v3) — a draft proposal, not yet
+// merged into nostr-protocol/nips. It improves on v2 by binding event `kind` and
+// a custom `scope` into the authenticated data (cross-context replay protection
+// + signer access control), supporting binary plaintext via a u32 length prefix,
+// and salting the per-message HKDF with the nonce so ChaCha20 runs with a fixed
+// zero nonce. Implemented against the proposal's official test-vectors.json.
+//
+// Encrypt still defaults to v2 elsewhere (deployed peers); v3 is opt-in here.
+
+const nip44VersionV3 = 0x03
+
+var nip44V3Salt = []byte("nip44-v3\x00")
+
+// nip44PRKV3 is HKDF-Extract(salt = "nip44-v3\x00" || nonce, IKM = ecdh_x).
+func nip44PRKV3(priv *btcec.PrivateKey, pub *btcec.PublicKey, nonce []byte) []byte {
+	salt := make([]byte, 0, len(nip44V3Salt)+len(nonce))
+	salt = append(salt, nip44V3Salt...)
+	salt = append(salt, nonce...)
+	return hkdf.Extract(sha256.New, ecdhX(priv, pub), salt)
+}
+
+// nip44MessageKeysV3 expands the PRK into the 32-byte encryption and MAC keys.
+func nip44MessageKeysV3(priv *btcec.PrivateKey, pub *btcec.PublicKey, nonce []byte) (encKey, macKey []byte, err error) {
+	prk := nip44PRKV3(priv, pub, nonce)
+	if encKey, err = nip44HKDFExpand(prk, "encryption_key", 32); err != nil {
+		return nil, nil, err
+	}
+	if macKey, err = nip44HKDFExpand(prk, "mac_key", 32); err != nil {
+		return nil, nil, err
+	}
+	return encKey, macKey, nil
+}
+
+func nip44HKDFExpand(prk []byte, info string, l int) ([]byte, error) {
+	out := make([]byte, l)
+	if _, err := io.ReadFull(hkdf.Expand(sha256.New, prk, []byte(info)), out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// nip44TargetSizeV3 is the v3 padding target for a buffer of the given length
+// (the spec's target_size, applied to the u32-prefixed plaintext).
+func nip44TargetSizeV3(length int) int {
+	const minSize, smallSub, largeSub, largeThresh = 32, 4, 8, 32768
+	if length <= 0 {
+		return minSize
+	}
+	nextPower := 1 << bits.Len(uint(length-1)) // smallest power of two >= length
+	subdivs := smallSub
+	if nextPower >= largeThresh {
+		subdivs = largeSub
+	}
+	chunk := max(nextPower/subdivs, minSize)
+	return chunk * ((length + chunk - 1) / chunk) // chunk * ceil(length/chunk)
+}
+
+// nip44ChaCha20V3 runs ChaCha20 with a 96-bit zero nonce (the key is unique per
+// message, so the nonce can be fixed).
+func nip44ChaCha20V3(key, data []byte) ([]byte, error) {
+	c, err := chacha20.NewUnauthenticatedCipher(key, make([]byte, chacha20.NonceSize))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, len(data))
+	c.XORKeyStream(out, data)
+	return out, nil
+}
+
+// nip44AuthDataV3 builds the MAC input: nonce || kind || len(scope) || scope || ct.
+func nip44AuthDataV3(nonce []byte, kind uint32, scope, ciphertext []byte) []byte {
+	ad := make([]byte, 0, len(nonce)+8+len(scope)+len(ciphertext))
+	ad = append(ad, nonce...)
+	ad = binary.BigEndian.AppendUint32(ad, kind)
+	ad = binary.BigEndian.AppendUint32(ad, uint32(len(scope)))
+	ad = append(ad, scope...)
+	ad = append(ad, ciphertext...)
+	return ad
+}
+
+// nip44EncryptV3 encrypts plaintext from priv to pub, binding kind + scope,
+// with the given 32-byte nonce. Returns the base64 v3 payload.
+func nip44EncryptV3(priv *btcec.PrivateKey, pub *btcec.PublicKey, kind uint32, scope, plaintext, nonce []byte) (string, error) {
+	if len(nonce) != 32 {
+		return "", errors.New("nip44: nonce must be 32 bytes")
+	}
+	if !utf8.Valid(scope) {
+		return "", errors.New("nip44: scope is not valid UTF-8")
+	}
+	if int64(len(plaintext)) > (1<<31)-1 {
+		return "", errors.New("nip44: plaintext too long")
+	}
+	encKey, macKey, err := nip44MessageKeysV3(priv, pub, nonce)
+	if err != nil {
+		return "", err
+	}
+	// prefixed = u32_be(len) || plaintext, then zero-padded to the target size.
+	prefixed := binary.BigEndian.AppendUint32(make([]byte, 0, 4+len(plaintext)), uint32(len(plaintext)))
+	prefixed = append(prefixed, plaintext...)
+	padded := make([]byte, nip44TargetSizeV3(len(prefixed)))
+	copy(padded, prefixed)
+
+	ciphertext, err := nip44ChaCha20V3(encKey, padded)
+	if err != nil {
+		return "", err
+	}
+	mac := nip44HMACAad(macKey, nip44AuthDataV3(nonce, kind, scope, ciphertext), nil)
+
+	// payload = 0x03 || nonce || mac || kind || len(scope) || scope || ct
+	payload := make([]byte, 0, 1+32+32+8+len(scope)+len(ciphertext))
+	payload = append(payload, nip44VersionV3)
+	payload = append(payload, nonce...)
+	payload = append(payload, mac...)
+	payload = binary.BigEndian.AppendUint32(payload, kind)
+	payload = binary.BigEndian.AppendUint32(payload, uint32(len(scope)))
+	payload = append(payload, scope...)
+	payload = append(payload, ciphertext...)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+// nip44DecryptV3 decrypts a v3 payload, verifying it was encrypted for the
+// expected kind + scope. Returns the binary plaintext.
+func nip44DecryptV3(priv *btcec.PrivateKey, pub *btcec.PublicKey, expectedKind uint32, expectedScope []byte, payloadB64 string) ([]byte, error) {
+	if len(payloadB64) == 0 || payloadB64[0] == '#' {
+		return nil, errors.New("nip44: unsupported payload version")
+	}
+	data, err := base64.StdEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return nil, errors.New("nip44: invalid base64 payload")
+	}
+	if len(data) < 77 {
+		return nil, fmt.Errorf("nip44: payload too small (%d)", len(data))
+	}
+	if data[0] != nip44VersionV3 {
+		return nil, fmt.Errorf("nip44: unknown version %d", data[0])
+	}
+	nonce := data[1:33]
+	mac := data[33:65]
+	kind := binary.BigEndian.Uint32(data[65:69])
+	scopeLen := binary.BigEndian.Uint32(data[69:73])
+	if int64(scopeLen) > int64(len(data)-73) {
+		return nil, errors.New("nip44: scope length overflows payload")
+	}
+	scope := data[73 : 73+scopeLen]
+	if !utf8.Valid(scope) {
+		return nil, errors.New("nip44: scope is not valid UTF-8")
+	}
+	ciphertext := data[73+scopeLen:]
+	if len(ciphertext) < 4 {
+		return nil, errors.New("nip44: ciphertext too short")
+	}
+	if kind != expectedKind {
+		return nil, fmt.Errorf("nip44: kind mismatch (got %d, want %d)", kind, expectedKind)
+	}
+	if !bytes.Equal(scope, expectedScope) {
+		return nil, errors.New("nip44: scope mismatch")
+	}
+	encKey, macKey, err := nip44MessageKeysV3(priv, pub, nonce)
+	if err != nil {
+		return nil, err
+	}
+	if !hmac.Equal(nip44HMACAad(macKey, nip44AuthDataV3(nonce, kind, scope, ciphertext), nil), mac) {
+		return nil, errors.New("nip44: invalid MAC")
+	}
+	padded, err := nip44ChaCha20V3(encKey, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	plLen := binary.BigEndian.Uint32(padded[0:4])
+	if int64(plLen)+4 > int64(len(padded)) || plLen > (1<<31)-1 {
+		return nil, errors.New("nip44: invalid plaintext length")
+	}
+	if !nip44AllZero(padded[4+plLen:]) {
+		return nil, errors.New("nip44: non-zero padding")
+	}
+	return padded[4 : 4+plLen], nil
+}
+
+// nip44AllZero reports whether b is all zero bytes, in constant time.
+func nip44AllZero(b []byte) bool {
+	var v byte
+	for _, x := range b {
+		v |= x
+	}
+	return v == 0
+}

--- a/client/core/nip44_v3_test.go
+++ b/client/core/nip44_v3_test.go
@@ -1,0 +1,215 @@
+package core
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+type nip44V3EncDec struct {
+	Secret1       string `json:"secret1"`
+	Secret2       string `json:"secret2"`
+	Nonce         string `json:"nonce"`
+	Kind          uint32 `json:"kind"`
+	ScopeHex      string `json:"scope_hex"`
+	PRK           string `json:"prk"`
+	EncryptionKey string `json:"encryption_key"`
+	MacKey        string `json:"mac_key"`
+	PlaintextHex  string `json:"plaintext_hex"`
+	Ciphertext    string `json:"ciphertext"`
+	Note          string `json:"note"`
+}
+
+type nip44V3VectorFile struct {
+	EncryptDecrypt     []nip44V3EncDec `json:"encrypt_decrypt"`
+	DecryptOnly        []nip44V3EncDec `json:"decrypt_only"`
+	LongEncryptDecrypt []struct {
+		Secret1          string `json:"secret1"`
+		Secret2          string `json:"secret2"`
+		Nonce            string `json:"nonce"`
+		Kind             uint32 `json:"kind"`
+		ScopeHex         string `json:"scope_hex"`
+		PatternHex       string `json:"pattern_hex"`
+		Repeat           int    `json:"repeat"`
+		CiphertextSha256 string `json:"ciphertext_sha256"`
+	} `json:"long_encrypt_decrypt"`
+	PaddedLength      [][2]int `json:"padded_length"`
+	InvalidDecryption []struct {
+		Secret     string `json:"secret"`
+		Public     string `json:"public"`
+		Kind       uint32 `json:"kind"`
+		ScopeHex   string `json:"scope_hex"`
+		Ciphertext string `json:"ciphertext"`
+		Why        string `json:"why"`
+	} `json:"invalid_decryption"`
+}
+
+func loadNIP44V3Vectors(t *testing.T) *nip44V3VectorFile {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/nip44v3.vectors.json")
+	if err != nil {
+		t.Fatalf("read v3 vectors: %v", err)
+	}
+	var v nip44V3VectorFile
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("parse v3 vectors: %v", err)
+	}
+	return &v
+}
+
+// nip44V3KeyPair returns the encrypting party's private key and the peer's
+// public key from two secret-key hexes.
+func nip44V3KeyPair(t *testing.T, sec1, sec2 string) (priv *btcec.PrivateKey, pub *btcec.PublicKey) {
+	t.Helper()
+	p1, err := nip44ParsePriv(mustHex(t, sec1))
+	if err != nil {
+		t.Fatalf("parse secret1: %v", err)
+	}
+	p2, err := nip44ParsePriv(mustHex(t, sec2))
+	if err != nil {
+		t.Fatalf("parse secret2: %v", err)
+	}
+	return p1, p2.PubKey()
+}
+
+func TestNIP44V3PaddedLength(t *testing.T) {
+	v := loadNIP44V3Vectors(t)
+	for _, pair := range v.PaddedLength {
+		if got := nip44TargetSizeV3(pair[0]); got != pair[1] {
+			t.Errorf("targetSize(%d) = %d, want %d", pair[0], got, pair[1])
+		}
+	}
+}
+
+func TestNIP44V3EncryptDecrypt(t *testing.T) {
+	v := loadNIP44V3Vectors(t)
+	for i, c := range v.EncryptDecrypt {
+		priv, pub := nip44V3KeyPair(t, c.Secret1, c.Secret2)
+		nonce := mustHex(t, c.Nonce)
+		scope := mustHex(t, c.ScopeHex)
+		plaintext := mustHex(t, c.PlaintextHex)
+
+		// Validate every key-derivation step the vector exposes.
+		if got := hex.EncodeToString(nip44PRKV3(priv, pub, nonce)); got != c.PRK {
+			t.Errorf("case %d: prk = %s, want %s", i, got, c.PRK)
+		}
+		ek, mk, err := nip44MessageKeysV3(priv, pub, nonce)
+		if err != nil {
+			t.Fatalf("case %d: message keys: %v", i, err)
+		}
+		if got := hex.EncodeToString(ek); got != c.EncryptionKey {
+			t.Errorf("case %d: encryption_key = %s, want %s", i, got, c.EncryptionKey)
+		}
+		if got := hex.EncodeToString(mk); got != c.MacKey {
+			t.Errorf("case %d: mac_key = %s, want %s", i, got, c.MacKey)
+		}
+
+		got, err := nip44EncryptV3(priv, pub, c.Kind, scope, plaintext, nonce)
+		if err != nil {
+			t.Fatalf("case %d: encrypt: %v", i, err)
+		}
+		if got != c.Ciphertext {
+			t.Errorf("case %d: ciphertext = %s, want %s", i, got, c.Ciphertext)
+		}
+		out, err := nip44DecryptV3(priv, pub, c.Kind, scope, c.Ciphertext)
+		if err != nil {
+			t.Fatalf("case %d: decrypt: %v", i, err)
+		}
+		if !bytes.Equal(out, plaintext) {
+			t.Errorf("case %d: plaintext = %x, want %x", i, out, plaintext)
+		}
+	}
+}
+
+func TestNIP44V3DecryptOnly(t *testing.T) {
+	v := loadNIP44V3Vectors(t)
+	for i, c := range v.DecryptOnly {
+		priv, pub := nip44V3KeyPair(t, c.Secret1, c.Secret2)
+		out, err := nip44DecryptV3(priv, pub, c.Kind, mustHex(t, c.ScopeHex), c.Ciphertext)
+		if err != nil {
+			t.Fatalf("case %d (%s): decrypt: %v", i, c.Note, err)
+		}
+		if want := mustHex(t, c.PlaintextHex); !bytes.Equal(out, want) {
+			t.Errorf("case %d: plaintext = %x, want %x", i, out, want)
+		}
+	}
+}
+
+func TestNIP44V3LongMessages(t *testing.T) {
+	v := loadNIP44V3Vectors(t)
+	for i, c := range v.LongEncryptDecrypt {
+		priv, pub := nip44V3KeyPair(t, c.Secret1, c.Secret2)
+		plaintext := bytes.Repeat(mustHex(t, c.PatternHex), c.Repeat)
+		scope := mustHex(t, c.ScopeHex)
+		payload, err := nip44EncryptV3(priv, pub, c.Kind, scope, plaintext, mustHex(t, c.Nonce))
+		if err != nil {
+			t.Fatalf("case %d: encrypt: %v", i, err)
+		}
+		if got := sha256Hex(payload); got != c.CiphertextSha256 {
+			t.Errorf("case %d: ciphertext sha256 = %s, want %s", i, got, c.CiphertextSha256)
+		}
+		out, err := nip44DecryptV3(priv, pub, c.Kind, scope, payload)
+		if err != nil {
+			t.Fatalf("case %d: decrypt: %v", i, err)
+		}
+		if !bytes.Equal(out, plaintext) {
+			t.Errorf("case %d: round-trip mismatch", i)
+		}
+	}
+}
+
+// TestNIP44V3EventSignerRoundTrip exercises the v3 seam and its defining
+// feature: a payload only decrypts under the kind + scope it was bound to.
+func TestNIP44V3EventSignerRoundTrip(t *testing.T) {
+	alice, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const kind = uint32(10013)
+	scope := []byte("spec.nostr.land/relay-lists")
+	plaintext := []byte("private relay list payload \x00\x01\x02") // binary-safe
+
+	ct, err := alice.NIP44V3Encrypt(bob.PublicKey(), kind, scope, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if got, err := bob.NIP44V3Decrypt(alice.PublicKey(), kind, scope, ct); err != nil || !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip: got %x err %v", got, err)
+	}
+	// Context binding: wrong kind or scope must fail.
+	if _, err := bob.NIP44V3Decrypt(alice.PublicKey(), kind+1, scope, ct); err == nil {
+		t.Error("expected wrong-kind decrypt to fail")
+	}
+	if _, err := bob.NIP44V3Decrypt(alice.PublicKey(), kind, []byte("other-scope"), ct); err == nil {
+		t.Error("expected wrong-scope decrypt to fail")
+	}
+	// The generic (v2) decrypt path must refuse a v3 payload.
+	if _, err := bob.NIP44Decrypt(alice.PublicKey(), ct); err == nil {
+		t.Error("expected v2 decrypt path to reject a v3 payload")
+	}
+}
+
+func TestNIP44V3InvalidDecryption(t *testing.T) {
+	v := loadNIP44V3Vectors(t)
+	for i, c := range v.InvalidDecryption {
+		priv, err := nip44ParsePriv(mustHex(t, c.Secret))
+		if err != nil {
+			continue // an unusable key is itself a rejection
+		}
+		pub, err := nip44ParseXOnlyPub(mustHex(t, c.Public))
+		if err != nil {
+			continue
+		}
+		if _, err := nip44DecryptV3(priv, pub, c.Kind, mustHex(t, c.ScopeHex), c.Ciphertext); err == nil {
+			t.Errorf("case %d (%s): expected decrypt to fail, it succeeded", i, c.Why)
+		}
+	}
+}

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -42,6 +42,32 @@ func (rp *RelayPool) Pin(urls ...string) {
 // so the connection can eventually be idle-evicted. Concurrent Acquires for the
 // same url share a single dial (single-flight) and the resulting connection.
 func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
+	openTimeout := rp.config.OpenTimeout
+	if openTimeout <= 0 {
+		openTimeout = rp.config.ConnectionTimeout
+	}
+	return rp.acquire(url, openTimeout, false)
+}
+
+// EnsureConnectedForSend makes sure url is connected so the publish path can send
+// to it, redialing a dropped target relay bounded by timeout. It ignores dial
+// backoff because a publish is an explicit user action (unlike a background
+// outbox dial that should fail fast), and it does not retain the lease — the
+// caller only needs the pooled connection for the immediate send, and the
+// sweeper evicts it later if it stays idle. Returns an error if it can't connect
+// in time, which the broadcast surfaces as a per-relay timeout.
+func (rp *RelayPool) EnsureConnectedForSend(url string, timeout time.Duration) error {
+	if _, err := rp.acquire(url, timeout, true); err != nil {
+		return err
+	}
+	rp.Release(url)
+	return nil
+}
+
+// acquire is the shared dial-and-lease core behind Acquire and
+// EnsureConnectedForSend. openTimeout bounds the dial; bypassBackoff skips the
+// dial-backoff gate.
+func (rp *RelayPool) acquire(url string, openTimeout time.Duration, bypassBackoff bool) (*RelayConnection, error) {
 	normalized, ok := normalizeRelayURL(url)
 	if !ok {
 		return nil, fmt.Errorf("invalid relay url: %q", url)
@@ -65,9 +91,11 @@ func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
 			delete(rp.connections, url)
 		}
 
-		if t, ok := rp.backoff[url]; ok && time.Now().Before(t) {
-			rp.mu.Unlock()
-			return nil, fmt.Errorf("relay %s in dial backoff", url)
+		if !bypassBackoff {
+			if t, ok := rp.backoff[url]; ok && time.Now().Before(t) {
+				rp.mu.Unlock()
+				return nil, fmt.Errorf("relay %s in dial backoff", url)
+			}
 		}
 
 		// Single-flight: if a dial for this url is already in progress, wait for
@@ -85,13 +113,9 @@ func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
 		rp.mu.Unlock()
 
 		// Dial without holding the pool lock, bounded by the dial semaphore so a
-		// burst of outbox lookups can't open unbounded sockets at once. Use the
-		// shorter per-dial open timeout (not ConnectionTimeout) so a dead relay
-		// in someone's outbox fails fast instead of stalling a query.
-		openTimeout := rp.config.OpenTimeout
-		if openTimeout <= 0 {
-			openTimeout = rp.config.ConnectionTimeout
-		}
+		// burst of outbox lookups can't open unbounded sockets at once. The dial
+		// timeout is the caller's: short for background outbox dials (fail fast),
+		// longer for an explicit publish reconnect.
 		rp.dialSem <- struct{}{}
 		conn, err := rp.dialFn(url, openTimeout)
 		<-rp.dialSem

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -79,9 +79,15 @@ func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
 		rp.mu.Unlock()
 
 		// Dial without holding the pool lock, bounded by the dial semaphore so a
-		// burst of outbox lookups can't open unbounded sockets at once.
+		// burst of outbox lookups can't open unbounded sockets at once. Use the
+		// shorter per-dial open timeout (not ConnectionTimeout) so a dead relay
+		// in someone's outbox fails fast instead of stalling a query.
+		openTimeout := rp.config.OpenTimeout
+		if openTimeout <= 0 {
+			openTimeout = rp.config.ConnectionTimeout
+		}
 		rp.dialSem <- struct{}{}
-		conn, err := rp.dialFn(url, rp.config.ConnectionTimeout)
+		conn, err := rp.dialFn(url, openTimeout)
 		<-rp.dialSem
 
 		rp.mu.Lock()

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -367,10 +367,14 @@ func (rp *RelayPool) StatusOf(url string) RelayLiveStatus {
 }
 
 // KnownRelayStatus pairs a known relay URL with its live pool status, for the
-// known-relays browser.
+// known-relays browser. The status fields are inlined rather than embedding
+// RelayLiveStatus so the OpenAPI generator (swag) can resolve the type — the
+// JSON shape is identical either way.
 type KnownRelayStatus struct {
-	URL string `json:"url"`
-	RelayLiveStatus
+	URL       string `json:"url"`
+	Connected bool   `json:"connected"`
+	Pinned    bool   `json:"pinned"`
+	Leased    bool   `json:"leased"`
 }
 
 // KnownRelaysWithStatus returns every known relay (sorted) annotated with its
@@ -379,7 +383,8 @@ func (c *Client) KnownRelaysWithStatus() []KnownRelayStatus {
 	urls := c.KnownRelays()
 	out := make([]KnownRelayStatus, 0, len(urls))
 	for _, u := range urls {
-		out = append(out, KnownRelayStatus{URL: u, RelayLiveStatus: c.relayPool.StatusOf(u)})
+		st := c.relayPool.StatusOf(u)
+		out = append(out, KnownRelayStatus{URL: u, Connected: st.Connected, Pinned: st.Pinned, Leased: st.Leased})
 	}
 	return out
 }

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -236,6 +236,38 @@ func (rp *RelayPool) evictIdle(now time.Time, idleTTL time.Duration) int {
 	return len(victims)
 }
 
+// PoolStats is a snapshot of the relay pool's connection counts, for status /
+// observability (e.g. an "x / y relays connected" dashboard indicator).
+type PoolStats struct {
+	Total     int `json:"total"`     // relays tracked in the pool
+	Connected int `json:"connected"` // currently connected
+	Pinned    int `json:"pinned"`    // index/seed relays kept alive
+	Leased    int `json:"leased"`    // connections with at least one active lease
+}
+
+// Stats returns a snapshot of the pool's connection counts.
+func (rp *RelayPool) Stats() PoolStats {
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	s := PoolStats{Total: len(rp.connections), Pinned: len(rp.pinned)}
+	for _, conn := range rp.connections {
+		conn.mu.RLock()
+		if conn.Status == StatusConnected {
+			s.Connected++
+		}
+		if conn.leases > 0 {
+			s.Leased++
+		}
+		conn.mu.RUnlock()
+	}
+	return s
+}
+
+// PoolStats returns a snapshot of the relay pool's connection counts.
+func (c *Client) PoolStats() PoolStats {
+	return c.relayPool.Stats()
+}
+
 // StartEvictionSweeper runs evictIdle on an interval until ctx is cancelled,
 // bounded to the caller's lifetime like the relay health check (#93).
 func (rp *RelayPool) StartEvictionSweeper(ctx context.Context, interval time.Duration) {

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/0ceanslim/grain/server/utils/log"
 	"golang.org/x/net/websocket"
 )
 
@@ -128,7 +127,7 @@ func (rp *RelayPool) acquire(url string, openTimeout time.Duration, bypassBackof
 		if err != nil {
 			rp.recordFailureLocked(url)
 			rp.mu.Unlock()
-			log.ClientCore().Debug("Dial failed", "relay", url, "error", err)
+			clog().Debug("Dial failed", "relay", url, "error", err)
 			return nil, err
 		}
 
@@ -159,7 +158,7 @@ func (rp *RelayPool) acquire(url string, openTimeout time.Duration, bypassBackof
 		rp.mu.Unlock()
 
 		rp.startReader(rc)
-		log.ClientCore().Debug("Acquired relay connection", "relay", url)
+		clog().Debug("Acquired relay connection", "relay", url)
 		return rc, nil
 	}
 }
@@ -239,7 +238,7 @@ func (rp *RelayPool) closeAndRemoveLocked(url string) {
 	if conn, ok := rp.connections[url]; ok {
 		_ = conn.close()
 		delete(rp.connections, url)
-		log.ClientCore().Debug("Evicted relay connection", "relay", url)
+		clog().Debug("Evicted relay connection", "relay", url)
 	}
 }
 
@@ -391,15 +390,15 @@ func (rp *RelayPool) StartEvictionSweeper(ctx context.Context, interval time.Dur
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		log.ClientCore().Info("Relay pool eviction sweeper started", "interval", interval)
+		clog().Info("Relay pool eviction sweeper started", "interval", interval)
 		for {
 			select {
 			case <-ctx.Done():
-				log.ClientCore().Info("Relay pool eviction sweeper stopping")
+				clog().Info("Relay pool eviction sweeper stopping")
 				return
 			case <-ticker.C:
 				if n := rp.evictIdle(time.Now(), rp.config.IdleTTL); n > 0 {
-					log.ClientCore().Debug("Idle relay connections evicted", "count", n)
+					clog().Debug("Idle relay connections evicted", "count", n)
 				}
 			}
 		}

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/0ceanslim/grain/server/utils/log"
@@ -312,9 +313,15 @@ func (rp *RelayPool) allURLs() []string {
 // has resolved. Known climbs as you interact; connections grow on demand.
 func (c *Client) PoolStats() PoolStats {
 	s := c.relayPool.Stats()
+	s.Known = len(c.knownSet())
+	return s
+}
 
+// knownSet is the distinct relays the client is aware of: the effective index
+// seeds, every relay in the pool, and every relay the directory has resolved.
+func (c *Client) knownSet() map[string]struct{} {
 	known := make(map[string]struct{})
-	for _, u := range c.config.IndexRelays {
+	for _, u := range c.indexRelays() {
 		known[u] = struct{}{}
 	}
 	for _, u := range c.relayPool.allURLs() {
@@ -323,8 +330,59 @@ func (c *Client) PoolStats() PoolStats {
 	for _, u := range c.directory.KnownRelays() {
 		known[u] = struct{}{}
 	}
-	s.Known = len(known)
-	return s
+	return known
+}
+
+// KnownRelays returns the known set as a sorted slice — the relays behind
+// PoolStats.Known, for the known-relays browser.
+func (c *Client) KnownRelays() []string {
+	known := c.knownSet()
+	out := make([]string, 0, len(known))
+	for u := range known {
+		out = append(out, u)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RelayLiveStatus is the pool's live view of one relay for the known-relays
+// browser. The zero value means "known but not currently in the pool".
+type RelayLiveStatus struct {
+	Connected bool `json:"connected"`
+	Pinned    bool `json:"pinned"`
+	Leased    bool `json:"leased"`
+}
+
+// StatusOf returns the pool's live status for url.
+func (rp *RelayPool) StatusOf(url string) RelayLiveStatus {
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	st := RelayLiveStatus{Pinned: rp.pinned[url]}
+	if conn, ok := rp.connections[url]; ok {
+		conn.mu.RLock()
+		st.Connected = conn.Status == StatusConnected
+		st.Leased = conn.leases > 0
+		conn.mu.RUnlock()
+	}
+	return st
+}
+
+// KnownRelayStatus pairs a known relay URL with its live pool status, for the
+// known-relays browser.
+type KnownRelayStatus struct {
+	URL string `json:"url"`
+	RelayLiveStatus
+}
+
+// KnownRelaysWithStatus returns every known relay (sorted) annotated with its
+// live pool status. NIP-11 detail is fetched separately, lazily, per relay.
+func (c *Client) KnownRelaysWithStatus() []KnownRelayStatus {
+	urls := c.KnownRelays()
+	out := make([]KnownRelayStatus, 0, len(urls))
+	for _, u := range urls {
+		out = append(out, KnownRelayStatus{URL: u, RelayLiveStatus: c.relayPool.StatusOf(u)})
+	}
+	return out
 }
 
 // StartEvictionSweeper runs evictIdle on an interval until ctx is cancelled,

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -239,13 +239,15 @@ func (rp *RelayPool) evictIdle(now time.Time, idleTTL time.Duration) int {
 // PoolStats is a snapshot of the relay pool's connection counts, for status /
 // observability (e.g. an "x / y relays connected" dashboard indicator).
 type PoolStats struct {
-	Total     int `json:"total"`     // relays tracked in the pool
+	Known     int `json:"known"`     // relays the client is aware of (defaults + resolved lists + connections)
+	Total     int `json:"total"`     // relays tracked in the pool (have a connection slot)
 	Connected int `json:"connected"` // currently connected
 	Pinned    int `json:"pinned"`    // index/seed relays kept alive
 	Leased    int `json:"leased"`    // connections with at least one active lease
 }
 
-// Stats returns a snapshot of the pool's connection counts.
+// Stats returns a snapshot of the pool's connection counts (without Known,
+// which the Client fills in since it spans the directory too).
 func (rp *RelayPool) Stats() PoolStats {
 	rp.mu.RLock()
 	defer rp.mu.RUnlock()
@@ -263,9 +265,36 @@ func (rp *RelayPool) Stats() PoolStats {
 	return s
 }
 
-// PoolStats returns a snapshot of the relay pool's connection counts.
+// allURLs returns every relay URL currently tracked in the pool.
+func (rp *RelayPool) allURLs() []string {
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	out := make([]string, 0, len(rp.connections))
+	for u := range rp.connections {
+		out = append(out, u)
+	}
+	return out
+}
+
+// PoolStats returns a snapshot of the pool's counts plus Known — the distinct
+// relays the client is aware of: configured defaults, every relay tracked in
+// the pool, and every relay from the indexer-seeded mailbox lists the directory
+// has resolved. Known climbs as you interact; connections grow on demand.
 func (c *Client) PoolStats() PoolStats {
-	return c.relayPool.Stats()
+	s := c.relayPool.Stats()
+
+	known := make(map[string]struct{})
+	for _, u := range c.config.IndexRelays {
+		known[u] = struct{}{}
+	}
+	for _, u := range c.relayPool.allURLs() {
+		known[u] = struct{}{}
+	}
+	for _, u := range c.directory.KnownRelays() {
+		known[u] = struct{}{}
+	}
+	s.Known = len(known)
+	return s
 }
 
 // StartEvictionSweeper runs evictIdle on an interval until ctx is cancelled,

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -42,6 +42,12 @@ func (rp *RelayPool) Pin(urls ...string) {
 // so the connection can eventually be idle-evicted. Concurrent Acquires for the
 // same url share a single dial (single-flight) and the resulting connection.
 func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
+	normalized, ok := normalizeRelayURL(url)
+	if !ok {
+		return nil, fmt.Errorf("invalid relay url: %q", url)
+	}
+	url = normalized
+
 	for {
 		rp.mu.Lock()
 

--- a/client/core/pool_lease.go
+++ b/client/core/pool_lease.go
@@ -1,0 +1,252 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/0ceanslim/grain/server/utils/log"
+	"golang.org/x/net/websocket"
+)
+
+// realDial opens a websocket to url with a dial timeout. It is the default
+// RelayPool.dialFn; tests inject a fake so Acquire can be exercised without a
+// live relay.
+func realDial(url string, timeout time.Duration) (*websocket.Conn, error) {
+	cfg, err := websocket.NewConfig(url, "http://localhost/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config for relay %s: %w", url, err)
+	}
+	cfg.Dialer = &net.Dialer{Timeout: timeout}
+	conn, err := websocket.DialConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to relay %s: %w", url, err)
+	}
+	return conn, nil
+}
+
+// Pin marks urls so the idle sweeper never evicts them — used for the index/
+// seed relays that must stay connected to resolve relay lists for anyone. It
+// does not dial; Acquire still establishes the connection on demand.
+func (rp *RelayPool) Pin(urls ...string) {
+	rp.mu.Lock()
+	defer rp.mu.Unlock()
+	for _, u := range urls {
+		rp.pinned[u] = true
+	}
+}
+
+// Acquire returns a connected RelayConnection for url, dialing on demand, and
+// takes a lease on it. Every successful Acquire must be balanced by a Release
+// so the connection can eventually be idle-evicted. Concurrent Acquires for the
+// same url share a single dial (single-flight) and the resulting connection.
+func (rp *RelayPool) Acquire(url string) (*RelayConnection, error) {
+	for {
+		rp.mu.Lock()
+
+		if conn, ok := rp.connections[url]; ok {
+			if conn.Status == StatusConnected {
+				// Fast path: reuse the live connection, take a lease.
+				conn.mu.Lock()
+				conn.leases++
+				conn.idleAt = time.Time{}
+				conn.mu.Unlock()
+				rp.mu.Unlock()
+				return conn, nil
+			}
+			// A dead/errored connection is lingering — drop it and redial.
+			delete(rp.connections, url)
+		}
+
+		if t, ok := rp.backoff[url]; ok && time.Now().Before(t) {
+			rp.mu.Unlock()
+			return nil, fmt.Errorf("relay %s in dial backoff", url)
+		}
+
+		// Single-flight: if a dial for this url is already in progress, wait for
+		// it to finish and then retry the whole check (it may now be connected,
+		// failed into backoff, or evicted).
+		if ch, ok := rp.dialing[url]; ok {
+			rp.mu.Unlock()
+			<-ch
+			continue
+		}
+
+		// We own the dial. Publish the in-flight marker so others wait on us.
+		ch := make(chan struct{})
+		rp.dialing[url] = ch
+		rp.mu.Unlock()
+
+		// Dial without holding the pool lock, bounded by the dial semaphore so a
+		// burst of outbox lookups can't open unbounded sockets at once.
+		rp.dialSem <- struct{}{}
+		conn, err := rp.dialFn(url, rp.config.ConnectionTimeout)
+		<-rp.dialSem
+
+		rp.mu.Lock()
+		delete(rp.dialing, url)
+		close(ch)
+
+		if err != nil {
+			rp.recordFailureLocked(url)
+			rp.mu.Unlock()
+			log.ClientCore().Debug("Dial failed", "relay", url, "error", err)
+			return nil, err
+		}
+
+		// Dial succeeded — clear any failure history.
+		delete(rp.backoff, url)
+		delete(rp.failCount, url)
+
+		// Soft cap: if we're at capacity, evict the longest-idle unpinned,
+		// lease-free connection to make room for this one.
+		if len(rp.connections) >= rp.config.MaxConnections {
+			if victim := rp.lruIdleVictimLocked(); victim != "" {
+				rp.closeAndRemoveLocked(victim)
+			}
+		}
+
+		rc := &RelayConnection{
+			URL:           url,
+			Conn:          conn,
+			Status:        StatusConnected,
+			LastPing:      time.Now(),
+			Subscriptions: make(map[string]bool),
+			writeChan:     make(chan []byte, 100),
+			done:          make(chan struct{}),
+			messageRouter: rp.messageRouter,
+			leases:        1,
+		}
+		rp.connections[url] = rc
+		rp.mu.Unlock()
+
+		rp.startReader(rc)
+		log.ClientCore().Debug("Acquired relay connection", "relay", url)
+		return rc, nil
+	}
+}
+
+// Release drops one lease on url's connection. When the last lease is released
+// the connection is marked idle (eligible for the sweeper) but not closed, so a
+// later Acquire can reuse it. Releasing an unknown url, or one already at zero
+// leases, is a safe no-op — this guards against the lease-counter underflow
+// class of bug.
+func (rp *RelayPool) Release(url string) {
+	rp.mu.RLock()
+	conn, ok := rp.connections[url]
+	rp.mu.RUnlock()
+	if !ok {
+		return
+	}
+	conn.mu.Lock()
+	if conn.leases > 0 {
+		conn.leases--
+	}
+	if conn.leases == 0 {
+		conn.idleAt = time.Now()
+	}
+	conn.mu.Unlock()
+}
+
+// recordFailureLocked grows url's dial backoff exponentially (base * 2^(n-1),
+// capped at BackoffMax). Caller holds mu.
+func (rp *RelayPool) recordFailureLocked(url string) {
+	rp.failCount[url]++
+
+	base := rp.config.BackoffBase
+	if base <= 0 {
+		base = 2 * time.Second
+	}
+	ceiling := rp.config.BackoffMax
+	if ceiling <= 0 {
+		ceiling = 60 * time.Second
+	}
+
+	d := base
+	for i := 1; i < rp.failCount[url]; i++ {
+		d *= 2
+		if d >= ceiling {
+			d = ceiling
+			break
+		}
+	}
+	rp.backoff[url] = time.Now().Add(d)
+}
+
+// lruIdleVictimLocked returns the url of the unpinned, lease-free connection
+// that has been idle the longest, or "" if there is none. Caller holds mu.
+func (rp *RelayPool) lruIdleVictimLocked() string {
+	var victim string
+	var oldest time.Time
+	for url, conn := range rp.connections {
+		if rp.pinned[url] {
+			continue
+		}
+		conn.mu.RLock()
+		idle := conn.leases == 0 && !conn.idleAt.IsZero()
+		at := conn.idleAt
+		conn.mu.RUnlock()
+		if !idle {
+			continue
+		}
+		if victim == "" || at.Before(oldest) {
+			victim, oldest = url, at
+		}
+	}
+	return victim
+}
+
+// closeAndRemoveLocked tears down and forgets a connection. Caller holds mu.
+func (rp *RelayPool) closeAndRemoveLocked(url string) {
+	if conn, ok := rp.connections[url]; ok {
+		_ = conn.close()
+		delete(rp.connections, url)
+		log.ClientCore().Debug("Evicted relay connection", "relay", url)
+	}
+}
+
+// evictIdle closes and removes every unpinned, lease-free connection that has
+// been idle longer than idleTTL. Returns how many were evicted.
+func (rp *RelayPool) evictIdle(now time.Time, idleTTL time.Duration) int {
+	rp.mu.Lock()
+	defer rp.mu.Unlock()
+
+	var victims []string
+	for url, conn := range rp.connections {
+		if rp.pinned[url] {
+			continue
+		}
+		conn.mu.RLock()
+		evict := conn.leases == 0 && !conn.idleAt.IsZero() && now.Sub(conn.idleAt) > idleTTL
+		conn.mu.RUnlock()
+		if evict {
+			victims = append(victims, url)
+		}
+	}
+	for _, url := range victims {
+		rp.closeAndRemoveLocked(url)
+	}
+	return len(victims)
+}
+
+// StartEvictionSweeper runs evictIdle on an interval until ctx is cancelled,
+// bounded to the caller's lifetime like the relay health check (#93).
+func (rp *RelayPool) StartEvictionSweeper(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		log.ClientCore().Info("Relay pool eviction sweeper started", "interval", interval)
+		for {
+			select {
+			case <-ctx.Done():
+				log.ClientCore().Info("Relay pool eviction sweeper stopping")
+				return
+			case <-ticker.C:
+				if n := rp.evictIdle(time.Now(), rp.config.IdleTTL); n > 0 {
+					log.ClientCore().Debug("Idle relay connections evicted", "count", n)
+				}
+			}
+		}
+	}()
+}

--- a/client/core/pool_lease_test.go
+++ b/client/core/pool_lease_test.go
@@ -1,0 +1,245 @@
+package core
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+// newTestPool builds a pool whose dial and reader-start are stubbed, so Acquire
+// can be exercised without real sockets or read/write goroutines.
+func newTestPool(maxConns int) *RelayPool {
+	cfg := DefaultConfig()
+	if maxConns > 0 {
+		cfg.MaxConnections = maxConns
+	}
+	rp := NewRelayPool(cfg)
+	rp.dialFn = func(string, time.Duration) (*websocket.Conn, error) { return nil, nil }
+	rp.startReader = func(*RelayConnection) {}
+	return rp
+}
+
+// testConn is a socket-less connection for exercising the lifecycle helpers.
+// close() tolerates a nil Conn; done is initialised so signalDone is safe.
+func testConn(url string, leases int, idleAt time.Time) *RelayConnection {
+	return &RelayConnection{
+		URL:           url,
+		Status:        StatusConnected,
+		Subscriptions: map[string]bool{},
+		writeChan:     make(chan []byte, 1),
+		done:          make(chan struct{}),
+		leases:        leases,
+		idleAt:        idleAt,
+	}
+}
+
+func leasesOf(rp *RelayPool, url string) int {
+	rp.mu.RLock()
+	conn := rp.connections[url]
+	rp.mu.RUnlock()
+	conn.mu.RLock()
+	defer conn.mu.RUnlock()
+	return conn.leases
+}
+
+func TestAcquireDialsThenReusesAndLeases(t *testing.T) {
+	rp := newTestPool(0)
+	var dials int32
+	rp.dialFn = func(string, time.Duration) (*websocket.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		return nil, nil
+	}
+
+	if _, err := rp.Acquire("wss://a"); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, err := rp.Acquire("wss://a"); err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if got := atomic.LoadInt32(&dials); got != 1 {
+		t.Fatalf("want 1 dial (second reuses), got %d", got)
+	}
+	if got := leasesOf(rp, "wss://a"); got != 2 {
+		t.Fatalf("want 2 leases, got %d", got)
+	}
+
+	rp.Release("wss://a")
+	if got := leasesOf(rp, "wss://a"); got != 1 {
+		t.Fatalf("want 1 lease after release, got %d", got)
+	}
+	rp.Release("wss://a")
+	if got := leasesOf(rp, "wss://a"); got != 0 {
+		t.Fatalf("want 0 leases, got %d", got)
+	}
+	rp.mu.RLock()
+	idleAt := rp.connections["wss://a"].idleAt
+	rp.mu.RUnlock()
+	if idleAt.IsZero() {
+		t.Fatal("idleAt should be set once the last lease is released")
+	}
+}
+
+func TestReleaseUnderflowGuard(t *testing.T) {
+	rp := newTestPool(0)
+	rp.connections["a"] = testConn("a", 1, time.Time{})
+
+	rp.Release("a")
+	rp.Release("a") // already at zero — must not underflow
+	if got := leasesOf(rp, "a"); got != 0 {
+		t.Fatalf("want 0 leases, got %d", got)
+	}
+	rp.Release("missing") // unknown url is a safe no-op (must not panic)
+}
+
+func TestAcquireBackoffAfterDialFailure(t *testing.T) {
+	rp := newTestPool(0)
+	var dials int32
+	rp.dialFn = func(string, time.Duration) (*websocket.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		return nil, errors.New("boom")
+	}
+
+	if _, err := rp.Acquire("wss://dead"); err == nil {
+		t.Fatal("expected dial error")
+	}
+	// Immediate retry must be refused by backoff, without dialing again.
+	if _, err := rp.Acquire("wss://dead"); err == nil {
+		t.Fatal("expected backoff error on immediate retry")
+	}
+	if got := atomic.LoadInt32(&dials); got != 1 {
+		t.Fatalf("backoff should suppress the retry dial: dialed %d times", got)
+	}
+	rp.mu.RLock()
+	_, hasBackoff := rp.backoff["wss://dead"]
+	fails := rp.failCount["wss://dead"]
+	rp.mu.RUnlock()
+	if !hasBackoff || fails != 1 {
+		t.Fatalf("want backoff set and failCount 1, got backoff=%v fails=%d", hasBackoff, fails)
+	}
+}
+
+func TestAcquireSingleFlight(t *testing.T) {
+	rp := newTestPool(0)
+	var dials int32
+	gate := make(chan struct{})
+	rp.dialFn = func(string, time.Duration) (*websocket.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		<-gate // hold the dial so concurrent callers pile up behind single-flight
+		return nil, nil
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = rp.Acquire("wss://a")
+		}(i)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(&dials) < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("dial never started")
+		default:
+			runtime.Gosched()
+		}
+	}
+	close(gate)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&dials); got != 1 {
+		t.Fatalf("single-flight broken: dialed %d times, want 1", got)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("acquire %d failed: %v", i, err)
+		}
+	}
+	if got := leasesOf(rp, "wss://a"); got != n {
+		t.Fatalf("want %d leases (one per caller), got %d", n, got)
+	}
+}
+
+func TestEvictIdle(t *testing.T) {
+	rp := newTestPool(0)
+	old := time.Now().Add(-time.Hour)
+	recent := time.Now().Add(-time.Second)
+
+	rp.connections["idleOld"] = testConn("idleOld", 0, old)          // evict
+	rp.connections["idleRecent"] = testConn("idleRecent", 0, recent) // keep (not idle long enough)
+	rp.connections["leased"] = testConn("leased", 1, time.Time{})    // keep (in use)
+	rp.connections["pinnedOld"] = testConn("pinnedOld", 0, old)      // keep (pinned)
+	rp.pinned["pinnedOld"] = true
+
+	n := rp.evictIdle(time.Now(), 5*time.Minute)
+	if n != 1 {
+		t.Fatalf("want 1 eviction, got %d", n)
+	}
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	if _, ok := rp.connections["idleOld"]; ok {
+		t.Error("idleOld should have been evicted")
+	}
+	for _, keep := range []string{"idleRecent", "leased", "pinnedOld"} {
+		if _, ok := rp.connections[keep]; !ok {
+			t.Errorf("%s should have been kept", keep)
+		}
+	}
+}
+
+func TestLruIdleVictim(t *testing.T) {
+	rp := newTestPool(0)
+	rp.connections["idleOld"] = testConn("idleOld", 0, time.Now().Add(-time.Hour))
+	rp.connections["idleNew"] = testConn("idleNew", 0, time.Now().Add(-time.Minute))
+	rp.connections["leased"] = testConn("leased", 1, time.Time{})
+	rp.connections["pinnedOldest"] = testConn("pinnedOldest", 0, time.Now().Add(-2*time.Hour))
+	rp.pinned["pinnedOldest"] = true
+
+	rp.mu.Lock()
+	victim := rp.lruIdleVictimLocked()
+	rp.mu.Unlock()
+	if victim != "idleOld" {
+		t.Fatalf("want longest-idle unpinned victim 'idleOld', got %q", victim)
+	}
+}
+
+func TestAcquireSoftCapEvictsIdle(t *testing.T) {
+	rp := newTestPool(2) // cap of 2
+	rp.connections["idle"] = testConn("idle", 0, time.Now().Add(-time.Hour))
+	rp.connections["leased"] = testConn("leased", 1, time.Time{})
+
+	if _, err := rp.Acquire("wss://new"); err != nil {
+		t.Fatalf("acquire over cap: %v", err)
+	}
+
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	if _, ok := rp.connections["idle"]; ok {
+		t.Error("idle connection should have been evicted to honour the soft cap")
+	}
+	if _, ok := rp.connections["leased"]; !ok {
+		t.Error("leased connection must not be evicted")
+	}
+	if _, ok := rp.connections["wss://new"]; !ok {
+		t.Error("newly acquired connection should be present")
+	}
+}
+
+func TestPin(t *testing.T) {
+	rp := newTestPool(0)
+	rp.Pin("wss://a", "wss://b")
+	rp.mu.RLock()
+	defer rp.mu.RUnlock()
+	if !rp.pinned["wss://a"] || !rp.pinned["wss://b"] {
+		t.Fatal("Pin should mark both urls pinned")
+	}
+}

--- a/client/core/pool_lease_test.go
+++ b/client/core/pool_lease_test.go
@@ -234,6 +234,30 @@ func TestAcquireSoftCapEvictsIdle(t *testing.T) {
 	}
 }
 
+func TestPoolStats(t *testing.T) {
+	rp := newTestPool(0)
+	rp.connections["a"] = testConn("a", 1, time.Time{}) // connected, leased, pinned
+	rp.pinned["a"] = true
+	rp.connections["b"] = testConn("b", 0, time.Now()) // connected, idle
+	dead := testConn("c", 0, time.Now())
+	dead.Status = StatusDisconnected
+	rp.connections["c"] = dead // tracked but not connected
+
+	s := rp.Stats()
+	if s.Total != 3 {
+		t.Errorf("Total = %d, want 3", s.Total)
+	}
+	if s.Connected != 2 {
+		t.Errorf("Connected = %d, want 2", s.Connected)
+	}
+	if s.Pinned != 1 {
+		t.Errorf("Pinned = %d, want 1", s.Pinned)
+	}
+	if s.Leased != 1 {
+		t.Errorf("Leased = %d, want 1", s.Leased)
+	}
+}
+
 func TestPin(t *testing.T) {
 	rp := newTestPool(0)
 	rp.Pin("wss://a", "wss://b")

--- a/client/core/profile.go
+++ b/client/core/profile.go
@@ -58,8 +58,12 @@ func AssembleProfileEvent(existing *nostr.Event, edits map[string]string) (*nost
 	}
 	tags := make([][]string, 0, len(existingTags)+len(edits))
 	for _, t := range existingTags {
-		if len(t) >= 1 && edited[t[0]] {
-			continue // replaced below, not duplicated
+		if len(t) >= 1 && (edited[t[0]] || t[0] == "client") {
+			// Drop tags we're upserting below, and drop any "client" tag:
+			// kind-0 shouldn't advertise which app wrote it by default (e.g. a
+			// stale client:amethyst tag carried over from another client). A
+			// grain client tag can be an explicit opt-in later.
+			continue
 		}
 		tags = append(tags, t)
 	}

--- a/client/core/profile.go
+++ b/client/core/profile.go
@@ -58,11 +58,11 @@ func AssembleProfileEvent(existing *nostr.Event, edits map[string]string) (*nost
 	}
 	tags := make([][]string, 0, len(existingTags)+len(edits))
 	for _, t := range existingTags {
-		if len(t) >= 1 && (edited[t[0]] || t[0] == "client") {
-			// Drop tags we're upserting below, and drop any "client" tag:
-			// kind-0 shouldn't advertise which app wrote it by default (e.g. a
-			// stale client:amethyst tag carried over from another client). A
-			// grain client tag can be an explicit opt-in later.
+		if len(t) >= 1 && edited[t[0]] {
+			// Drop tags we're upserting below. The `client` tag is handled by the
+			// build handler via ApplyClientTag (strip foreign + add grain's own per
+			// config / per-user setting), not here, so the library assembler stays
+			// policy-free.
 			continue
 		}
 		tags = append(tags, t)

--- a/client/core/profile.go
+++ b/client/core/profile.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// AssembleProfileEvent builds an UNSIGNED kind-0 (profile metadata) event from
+// an existing one by applying edits. It is deliberately conservative about not
+// losing data:
+//
+//   - Every existing content field is preserved; only edited fields are
+//     overwritten. The content JSON stays the interoperable source of truth
+//     that all clients read.
+//   - Every existing tag is preserved; for each edited field a [key, value] tag
+//     is upserted — replacing a prior tag with the same key rather than
+//     duplicating — so tag-aware clients can read the field too (dual-write).
+//
+// The returned event has no ID or Sig: the caller signs it. Returns an error if
+// the existing content isn't valid JSON, rather than silently clobbering a
+// profile we can't safely parse.
+func AssembleProfileEvent(existing *nostr.Event, edits map[string]string) (*nostr.Event, error) {
+	pubkey := ""
+	var existingTags [][]string
+	content := map[string]json.RawMessage{}
+
+	if existing != nil {
+		pubkey = existing.PubKey
+		existingTags = existing.Tags
+		if existing.Content != "" {
+			if err := json.Unmarshal([]byte(existing.Content), &content); err != nil {
+				return nil, fmt.Errorf("existing kind-0 content is not valid JSON; refusing to overwrite: %w", err)
+			}
+		}
+	}
+
+	// Apply edits to the content map, preserving every other field.
+	for k, v := range edits {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("encode field %q: %w", k, err)
+		}
+		content[k] = raw
+	}
+	newContent, err := json.Marshal(content) // encoding/json marshals map keys sorted
+	if err != nil {
+		return nil, err
+	}
+
+	// Preserve existing tags except the ones we're about to upsert.
+	edited := make(map[string]bool, len(edits))
+	for k := range edits {
+		edited[k] = true
+	}
+	tags := make([][]string, 0, len(existingTags)+len(edits))
+	for _, t := range existingTags {
+		if len(t) >= 1 && edited[t[0]] {
+			continue // replaced below, not duplicated
+		}
+		tags = append(tags, t)
+	}
+	// Append the dual-write tags in a stable (sorted) order.
+	keys := make([]string, 0, len(edits))
+	for k := range edits {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		tags = append(tags, []string{k, edits[k]})
+	}
+
+	return &nostr.Event{
+		PubKey:    pubkey,
+		Kind:      0,
+		CreatedAt: time.Now().Unix(),
+		Content:   string(newContent),
+		Tags:      tags,
+	}, nil
+}

--- a/client/core/profile_test.go
+++ b/client/core/profile_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// The critical guarantee: editing some fields must preserve every other content
+// field and tag, and must dual-write each edit to both content and a tag.
+func TestAssembleProfileEventPreservesAndDualWrites(t *testing.T) {
+	existing := &nostr.Event{
+		PubKey:  "abc",
+		Kind:    0,
+		Content: `{"name":"old","about":"my bio","custom_field":"keepme"}`,
+		Tags:    [][]string{{"i", "github:alice", "proof"}, {"name", "old"}},
+	}
+
+	got, err := AssembleProfileEvent(existing, map[string]string{
+		"name":         "new",
+		"display_name": "New Name",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var c map[string]string
+	if err := json.Unmarshal([]byte(got.Content), &c); err != nil {
+		t.Fatalf("content not valid JSON: %v", err)
+	}
+	if c["name"] != "new" {
+		t.Errorf("name = %q, want new", c["name"])
+	}
+	if c["display_name"] != "New Name" {
+		t.Errorf("display_name = %q, want New Name", c["display_name"])
+	}
+	if c["about"] != "my bio" {
+		t.Errorf("about not preserved: %q", c["about"])
+	}
+	if c["custom_field"] != "keepme" {
+		t.Errorf("UNKNOWN FIELD LOST: custom_field = %q", c["custom_field"])
+	}
+
+	iCount, nameCount := 0, 0
+	var nameVal, displayVal string
+	for _, tag := range got.Tags {
+		switch tag[0] {
+		case "i":
+			iCount++
+		case "name":
+			nameCount++
+			nameVal = tag[1]
+		case "display_name":
+			displayVal = tag[1]
+		}
+	}
+	if iCount != 1 {
+		t.Errorf("NIP-39 i tag not preserved (count %d)", iCount)
+	}
+	if nameCount != 1 || nameVal != "new" {
+		t.Errorf("name tag not upserted (replaced): count=%d val=%q", nameCount, nameVal)
+	}
+	if displayVal != "New Name" {
+		t.Errorf("display_name tag missing")
+	}
+
+	if got.ID != "" || got.Sig != "" {
+		t.Error("assembled event must be unsigned")
+	}
+	if got.PubKey != "abc" || got.Kind != 0 {
+		t.Errorf("pubkey/kind wrong: %q/%d", got.PubKey, got.Kind)
+	}
+}
+
+func TestAssembleProfileEventNewProfile(t *testing.T) {
+	got, err := AssembleProfileEvent(&nostr.Event{PubKey: "abc"}, map[string]string{"name": "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var c map[string]string
+	if err := json.Unmarshal([]byte(got.Content), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c["name"] != "alice" {
+		t.Errorf("name not set on new profile: %q", c["name"])
+	}
+}
+
+func TestAssembleProfileEventRejectsInvalidExistingContent(t *testing.T) {
+	_, err := AssembleProfileEvent(&nostr.Event{PubKey: "abc", Content: "not json"}, map[string]string{"name": "x"})
+	if err == nil {
+		t.Fatal("expected an error for invalid existing content — must not clobber a profile we can't parse")
+	}
+}

--- a/client/core/profile_test.go
+++ b/client/core/profile_test.go
@@ -73,9 +73,10 @@ func TestAssembleProfileEventPreservesAndDualWrites(t *testing.T) {
 	}
 }
 
-// A stale client tag (e.g. from Amethyst) must be stripped, not preserved —
-// kind-0 shouldn't advertise the writing app by default.
-func TestAssembleProfileEventStripsClientTag(t *testing.T) {
+// The assembler is now policy-free about the client tag: it preserves whatever
+// is there (the build handler applies ApplyClientTag to strip foreign + stamp
+// grain's own). This documents that division and the end-to-end result.
+func TestAssembleProfileEventClientTagHandledByHelper(t *testing.T) {
 	existing := &nostr.Event{
 		PubKey:  "abc",
 		Content: `{"name":"alice"}`,
@@ -85,20 +86,21 @@ func TestAssembleProfileEventStripsClientTag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, tag := range got.Tags {
-		if tag[0] == "client" {
-			t.Fatalf("client tag should have been stripped, got tags %v", got.Tags)
-		}
+	// Assembler preserves the existing client tag (no longer strips it).
+	if !hasTag(got.Tags, "client", "amethyst") {
+		t.Errorf("assembler should preserve the client tag for the handler to rewrite, got %v", got.Tags)
 	}
-	// Other tags (NIP-39 i) are still preserved.
-	hasI := false
-	for _, tag := range got.Tags {
-		if tag[0] == "i" {
-			hasI = true
-		}
+	if !hasTag(got.Tags, "i", "github:alice") {
+		t.Error("non-client tags must be preserved")
 	}
-	if !hasI {
-		t.Error("non-client tags must still be preserved")
+
+	// The handler's helper then strips the foreign tag and stamps grain's.
+	ApplyClientTag(got, true, "grain")
+	if hasTag(got.Tags, "client", "amethyst") {
+		t.Error("ApplyClientTag should strip the foreign client tag")
+	}
+	if !hasTag(got.Tags, "client", "grain") || countTag(got.Tags, "client") != 1 {
+		t.Errorf("ApplyClientTag should leave exactly one client:grain, got %v", got.Tags)
 	}
 }
 

--- a/client/core/profile_test.go
+++ b/client/core/profile_test.go
@@ -73,6 +73,35 @@ func TestAssembleProfileEventPreservesAndDualWrites(t *testing.T) {
 	}
 }
 
+// A stale client tag (e.g. from Amethyst) must be stripped, not preserved —
+// kind-0 shouldn't advertise the writing app by default.
+func TestAssembleProfileEventStripsClientTag(t *testing.T) {
+	existing := &nostr.Event{
+		PubKey:  "abc",
+		Content: `{"name":"alice"}`,
+		Tags:    [][]string{{"client", "amethyst", "31990:..."}, {"i", "github:alice", "p"}},
+	}
+	got, err := AssembleProfileEvent(existing, map[string]string{"about": "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tag := range got.Tags {
+		if tag[0] == "client" {
+			t.Fatalf("client tag should have been stripped, got tags %v", got.Tags)
+		}
+	}
+	// Other tags (NIP-39 i) are still preserved.
+	hasI := false
+	for _, tag := range got.Tags {
+		if tag[0] == "i" {
+			hasI = true
+		}
+	}
+	if !hasI {
+		t.Error("non-client tags must still be preserved")
+	}
+}
+
 func TestAssembleProfileEventNewProfile(t *testing.T) {
 	got, err := AssembleProfileEvent(&nostr.Event{PubKey: "abc"}, map[string]string{"name": "alice"})
 	if err != nil {

--- a/client/core/query.go
+++ b/client/core/query.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// streamConfig is the resolved set of [StreamOption]s.
+type streamConfig struct {
+	limit   int           // stop after this many events (0 = unlimited)
+	timeout time.Duration // overall cap before closing
+	live    bool          // keep streaming after end-of-stored-events
+}
+
+// StreamOption configures [Client.StreamEvents] / [Client.QueryEvents].
+type StreamOption func(*streamConfig)
+
+// WithLimit closes the stream after n events have been delivered (0 = no limit).
+func WithLimit(n int) StreamOption { return func(c *streamConfig) { c.limit = n } }
+
+// WithTimeout caps how long the stream runs before closing (default 10s). The
+// stream also ends when every relay reports end-of-stored-events (unless
+// [WithLive]), the limit is reached, or the context is cancelled.
+func WithTimeout(d time.Duration) StreamOption { return func(c *streamConfig) { c.timeout = d } }
+
+// WithLive keeps the stream open past every relay's end-of-stored-events, so it
+// keeps delivering newly published events until the context or timeout ends it.
+// Default is a bounded fetch that closes once all stored events are in.
+func WithLive() StreamOption { return func(c *streamConfig) { c.live = true } }
+
+// StreamEvents subscribes to filter across relays and streams matching events on
+// the returned channel as each relay answers, de-duplicated by event id. The
+// channel closes when every relay has signalled end-of-stored-events (a bounded
+// fetch; see [WithLive]), the [WithLimit] count is reached, ctx is cancelled, or
+// the [WithTimeout] elapses — whichever comes first.
+//
+// This is the general, multi-relay form of a live feed: point it at a single
+// relay (e.g. grain's own) for a single-source stream, or at a user's outbox set
+// for an outbox feed. Per-relay failures are logged, not fatal. The caller must
+// drain the channel (or cancel ctx) so the underlying subscription is released.
+func (c *Client) StreamEvents(ctx context.Context, filter nostr.Filter, relays []string, opts ...StreamOption) <-chan *nostr.Event {
+	cfg := streamConfig{timeout: 10 * time.Second}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	out := make(chan *nostr.Event)
+	go func() {
+		defer close(out)
+		if len(relays) == 0 {
+			return
+		}
+		sub, err := c.Subscribe([]nostr.Filter{filter}, relays)
+		if err != nil {
+			log.ClientCore().Debug("StreamEvents subscribe failed", "error", err)
+			return
+		}
+		defer sub.Close()
+
+		var deadline <-chan time.Time
+		if cfg.timeout > 0 {
+			deadline = time.After(cfg.timeout)
+		}
+		seen := make(map[string]struct{})
+		eose := make(map[string]bool)
+		sent := 0
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-deadline:
+				return
+			case ev := <-sub.Events:
+				if ev == nil || ev.ID == "" {
+					continue
+				}
+				if _, dup := seen[ev.ID]; dup {
+					continue // same event from another relay
+				}
+				seen[ev.ID] = struct{}{}
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+				if sent++; cfg.limit > 0 && sent >= cfg.limit {
+					return
+				}
+			case relayURL := <-sub.EOSE:
+				eose[relayURL] = true
+				if !cfg.live && len(eose) >= len(relays) {
+					return // every relay has sent all its stored events
+				}
+			case err := <-sub.Errors:
+				log.ClientCore().Debug("StreamEvents relay error", "error", err)
+			}
+		}
+	}()
+
+	return out
+}
+
+// QueryEvents runs [Client.StreamEvents] and collects every event it yields, in
+// arrival order. A blocking convenience for callers that don't need incremental
+// delivery; pass [WithLimit] / [WithTimeout] to bound it.
+func (c *Client) QueryEvents(ctx context.Context, filter nostr.Filter, relays []string, opts ...StreamOption) []*nostr.Event {
+	var out []*nostr.Event
+	for ev := range c.StreamEvents(ctx, filter, relays, opts...) {
+		out = append(out, ev)
+	}
+	return out
+}

--- a/client/core/query.go
+++ b/client/core/query.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // streamConfig is the resolved set of [StreamOption]s.
@@ -55,7 +54,7 @@ func (c *Client) StreamEvents(ctx context.Context, filter nostr.Filter, relays [
 		}
 		sub, err := c.Subscribe(ctx, []nostr.Filter{filter}, relays)
 		if err != nil {
-			log.ClientCore().Debug("StreamEvents subscribe failed", "error", err)
+			clog().Debug("StreamEvents subscribe failed", "error", err)
 			return
 		}
 		defer sub.Close()
@@ -96,7 +95,7 @@ func (c *Client) StreamEvents(ctx context.Context, filter nostr.Filter, relays [
 					return // every relay has sent all its stored events
 				}
 			case err := <-sub.Errors:
-				log.ClientCore().Debug("StreamEvents relay error", "error", err)
+				clog().Debug("StreamEvents relay error", "error", err)
 			}
 		}
 	}()

--- a/client/core/query.go
+++ b/client/core/query.go
@@ -53,7 +53,7 @@ func (c *Client) StreamEvents(ctx context.Context, filter nostr.Filter, relays [
 		if len(relays) == 0 {
 			return
 		}
-		sub, err := c.Subscribe([]nostr.Filter{filter}, relays)
+		sub, err := c.Subscribe(ctx, []nostr.Filter{filter}, relays)
 		if err != nil {
 			log.ClientCore().Debug("StreamEvents subscribe failed", "error", err)
 			return

--- a/client/core/query_test.go
+++ b/client/core/query_test.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+func TestStreamOptions(t *testing.T) {
+	cfg := streamConfig{timeout: 10 * time.Second}
+	for _, o := range []StreamOption{WithLimit(5), WithTimeout(2 * time.Second), WithLive()} {
+		o(&cfg)
+	}
+	if cfg.limit != 5 {
+		t.Errorf("limit = %d, want 5", cfg.limit)
+	}
+	if cfg.timeout != 2*time.Second {
+		t.Errorf("timeout = %v, want 2s", cfg.timeout)
+	}
+	if !cfg.live {
+		t.Error("live should be true")
+	}
+}
+
+func TestStreamEventsNoRelays(t *testing.T) {
+	c := NewClient(DefaultConfig())
+	ch := c.StreamEvents(context.Background(), nostr.Filter{Kinds: []int{1}}, nil)
+
+	// With no relays the channel must close promptly with nothing delivered.
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			t.Errorf("expected closed channel, got event %v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StreamEvents with no relays did not close the channel")
+	}
+
+	if got := c.QueryEvents(context.Background(), nostr.Filter{Kinds: []int{1}}, nil); len(got) != 0 {
+		t.Errorf("QueryEvents(no relays) = %v, want empty", got)
+	}
+}

--- a/client/core/relayinfo.go
+++ b/client/core/relayinfo.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RelayInfo is the subset of a relay's NIP-11 document the relay manager shows.
+type RelayInfo struct {
+	Name          string       `json:"name,omitempty"`
+	Description   string       `json:"description,omitempty"`
+	PubKey        string       `json:"pubkey,omitempty"`
+	Software      string       `json:"software,omitempty"`
+	Version       string       `json:"version,omitempty"`
+	SupportedNIPs []int        `json:"supported_nips,omitempty"`
+	Icon          string       `json:"icon,omitempty"`
+	Limitation    *RelayLimits `json:"limitation,omitempty"`
+}
+
+// RelayLimits is the NIP-11 `limitation` block — the flags that matter to the UI
+// (whether the relay requires AUTH or payment to use).
+type RelayLimits struct {
+	AuthRequired     bool `json:"auth_required,omitempty"`
+	PaymentRequired  bool `json:"payment_required,omitempty"`
+	RestrictedWrites bool `json:"restricted_writes,omitempty"`
+	MaxMessageLength int  `json:"max_message_length,omitempty"`
+}
+
+type relayInfoEntry struct {
+	info *RelayInfo
+	at   time.Time
+}
+
+const relayInfoTTL = 6 * time.Hour
+
+var relayInfoHTTP = &http.Client{Timeout: 6 * time.Second}
+
+// FetchRelayInfo returns a relay's NIP-11 document, TTL-cached. It is a plain
+// HTTP GET of the relay's root with `Accept: application/nostr+json` — not a
+// pool/WebSocket connection — so the known-relays browser can show name,
+// software, supported NIPs, and the auth/payment flags. Returns nil when the
+// relay serves no NIP-11 or it can't be parsed (also cached, to avoid retry
+// storms on a relay that doesn't advertise one).
+func (c *Client) FetchRelayInfo(url string) *RelayInfo {
+	if norm, ok := normalizeRelayURL(url); ok {
+		url = norm
+	}
+	c.relayInfoMu.Lock()
+	if e, ok := c.relayInfoCache[url]; ok && time.Since(e.at) < relayInfoTTL {
+		c.relayInfoMu.Unlock()
+		return e.info
+	}
+	c.relayInfoMu.Unlock()
+
+	info := fetchNIP11(url)
+
+	c.relayInfoMu.Lock()
+	c.relayInfoCache[url] = relayInfoEntry{info: info, at: time.Now()}
+	c.relayInfoMu.Unlock()
+	return info
+}
+
+// fetchNIP11 does the HTTP GET for a relay's NIP-11 document, converting the
+// ws(s) URL to http(s).
+func fetchNIP11(wsURL string) *RelayInfo {
+	httpURL := strings.Replace(wsURL, "wss://", "https://", 1)
+	httpURL = strings.Replace(httpURL, "ws://", "http://", 1)
+
+	req, err := http.NewRequest(http.MethodGet, httpURL, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Accept", "application/nostr+json")
+
+	resp, err := relayInfoHTTP.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var info RelayInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil
+	}
+	return &info
+}

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -187,26 +187,54 @@ type UserRelayLists struct {
 	Blocked   []string         `json:"blocked"`   // 10006
 	Search    []string         `json:"search"`    // 10007
 	Favorites []string         `json:"favorites"` // 10012
+	// Encrypted flags NIP-51 lists whose event carried NIP-44 private content —
+	// entries grain can't read yet (#100); only the public entries are listed.
+	Encrypted EncryptedFlags `json:"encrypted"`
+}
+
+// EncryptedFlags reports which NIP-51 lists have private (encrypted) entries.
+type EncryptedFlags struct {
+	Blocked   bool `json:"blocked"`
+	Search    bool `json:"search"`
+	Favorites bool `json:"favorites"`
 }
 
 // FetchUserRelayLists resolves a user's relay lists for every kind the relay
 // manager shows, fetching the kinds concurrently. Each goroutine writes a
 // distinct field, so no locking is needed.
+//
+// A user's own NIP-51/17 lists live on their own relays, which a cold page load
+// may not have cached — so the relay set is the index relays PLUS the user's
+// resolved read+write relays, giving the lists a real chance to be found.
 func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
+	relays := append([]string(nil), c.config.IndexRelays...)
+	ur := c.ResolveRelays(pubkey) // blocking resolve — own user is cached post-login
+	relays = appendUnique(relays, ur.Outbox)
+	relays = appendUnique(relays, ur.Inbox)
+
 	out := &UserRelayLists{}
 	var wg sync.WaitGroup
 	fetch := func(kind int, assign func(*nostr.Event)) {
 		defer wg.Done()
-		if ev := c.FetchRelayList(pubkey, kind); ev != nil {
+		if ev := c.fetchLatestEvent(pubkey, kind, relays); ev != nil {
 			assign(ev)
 		}
 	}
 	wg.Add(5)
 	go fetch(10002, func(ev *nostr.Event) { out.NIP65 = ParseNIP65Entries(ev) })
 	go fetch(10050, func(ev *nostr.Event) { out.DM = ParseRelayTagURLs(ev) })
-	go fetch(10006, func(ev *nostr.Event) { out.Blocked = ParseRelayTagURLs(ev) })
-	go fetch(10007, func(ev *nostr.Event) { out.Search = ParseRelayTagURLs(ev) })
-	go fetch(10012, func(ev *nostr.Event) { out.Favorites = ParseRelayTagURLs(ev) })
+	go fetch(10006, func(ev *nostr.Event) {
+		out.Blocked = ParseRelayTagURLs(ev)
+		out.Encrypted.Blocked = ev.Content != ""
+	})
+	go fetch(10007, func(ev *nostr.Event) {
+		out.Search = ParseRelayTagURLs(ev)
+		out.Encrypted.Search = ev.Content != ""
+	})
+	go fetch(10012, func(ev *nostr.Event) {
+		out.Favorites = ParseRelayTagURLs(ev)
+		out.Encrypted.Favorites = ev.Content != ""
+	})
 	wg.Wait()
 	return out
 }

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -109,7 +109,7 @@ func AssembleRelayListEvent(existing *nostr.Event, kind int, pubkey string, entr
 // kind, or nil. Used by the build flow to preserve non-relay tags on republish.
 // Mirrors FetchMediaServerList: index relays plus the user's cached outbox.
 func (c *Client) FetchRelayList(pubkey string, kind int) *nostr.Event {
-	relays := c.config.IndexRelays
+	relays := c.indexRelays()
 	if ur, ok := c.directory.Cached(pubkey); ok {
 		relays = appendUnique(relays, ur.Outbox)
 	}
@@ -221,7 +221,7 @@ type EncryptedContent struct {
 // NIP-51/17 lists live on their own relays, which a cold load may not have
 // cached. Shared by FetchUserRelayLists and the live-sync subscription.
 func (c *Client) OwnListRelays(pubkey string) []string {
-	relays := append([]string(nil), c.config.IndexRelays...)
+	relays := append([]string(nil), c.indexRelays()...)
 	ur := c.ResolveRelays(pubkey) // blocking resolve — own user is cached post-login
 	relays = appendUnique(relays, ur.Outbox)
 	relays = appendUnique(relays, ur.Inbox)

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
@@ -119,4 +120,93 @@ func (c *Client) FetchRelayList(pubkey string, kind int) *nostr.Event {
 // so routing picks up the change immediately.
 func (c *Client) InvalidateUserRelays(pubkey string) {
 	c.directory.Invalidate(pubkey)
+}
+
+// ParseNIP65Entries parses a kind-10002 event's `r` tags into relay entries with
+// read/write flags. An unmarked entry (`["r", url]`) is both read and write;
+// `["r", url, "read"]` / `["r", url, "write"]` set one side. URLs are normalised;
+// a relay listed twice has its flags OR-ed together.
+func ParseNIP65Entries(event *nostr.Event) []RelayListEntry {
+	var out []RelayListEntry
+	seen := make(map[string]int)
+	for _, t := range event.Tags {
+		if len(t) < 2 || t[0] != "r" || t[1] == "" {
+			continue
+		}
+		u, ok := normalizeRelayURL(t[1])
+		if !ok {
+			continue
+		}
+		read, write := true, true
+		if len(t) >= 3 {
+			switch t[2] {
+			case "read":
+				read, write = true, false
+			case "write":
+				read, write = false, true
+			}
+		}
+		if idx, dup := seen[u]; dup {
+			out[idx].Read = out[idx].Read || read
+			out[idx].Write = out[idx].Write || write
+			continue
+		}
+		seen[u] = len(out)
+		out = append(out, RelayListEntry{URL: u, Read: read, Write: write})
+	}
+	return out
+}
+
+// ParseRelayTagURLs extracts the `relay` tag URLs from a NIP-17 / NIP-51
+// relay-list event (kinds 10050 / 10006 / 10007 / 10012), normalised and
+// de-duplicated, in order.
+func ParseRelayTagURLs(event *nostr.Event) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, t := range event.Tags {
+		if len(t) >= 2 && t[0] == "relay" && t[1] != "" {
+			u, ok := normalizeRelayURL(t[1])
+			if !ok {
+				continue
+			}
+			if _, dup := seen[u]; dup {
+				continue
+			}
+			seen[u] = struct{}{}
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// UserRelayLists is a user's resolved relay lists across the kinds the relay
+// manager edits. NIP65 carries read/write flags; the rest are plain URL lists.
+type UserRelayLists struct {
+	NIP65     []RelayListEntry `json:"nip65"`     // 10002
+	DM        []string         `json:"dm"`        // 10050
+	Blocked   []string         `json:"blocked"`   // 10006
+	Search    []string         `json:"search"`    // 10007
+	Favorites []string         `json:"favorites"` // 10012
+}
+
+// FetchUserRelayLists resolves a user's relay lists for every kind the relay
+// manager shows, fetching the kinds concurrently. Each goroutine writes a
+// distinct field, so no locking is needed.
+func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
+	out := &UserRelayLists{}
+	var wg sync.WaitGroup
+	fetch := func(kind int, assign func(*nostr.Event)) {
+		defer wg.Done()
+		if ev := c.FetchRelayList(pubkey, kind); ev != nil {
+			assign(ev)
+		}
+	}
+	wg.Add(5)
+	go fetch(10002, func(ev *nostr.Event) { out.NIP65 = ParseNIP65Entries(ev) })
+	go fetch(10050, func(ev *nostr.Event) { out.DM = ParseRelayTagURLs(ev) })
+	go fetch(10006, func(ev *nostr.Event) { out.Blocked = ParseRelayTagURLs(ev) })
+	go fetch(10007, func(ev *nostr.Event) { out.Search = ParseRelayTagURLs(ev) })
+	go fetch(10012, func(ev *nostr.Event) { out.Favorites = ParseRelayTagURLs(ev) })
+	wg.Wait()
+	return out
 }

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -238,3 +238,43 @@ func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
 	wg.Wait()
 	return out
 }
+
+// relayListsEntry is a TTL-cached resolution of a user's relay lists.
+type relayListsEntry struct {
+	lists *UserRelayLists
+	at    time.Time
+}
+
+// ResolveUserRelayLists returns a user's relay lists from cache when fresh,
+// otherwise resolves them from the network and caches the result. The relay
+// manager reads through this so the page renders from cache once login-hydration
+// has warmed it.
+func (c *Client) ResolveUserRelayLists(pubkey string) *UserRelayLists {
+	c.relayListsMu.Lock()
+	if e, ok := c.relayListsCache[pubkey]; ok && time.Since(e.at) < c.config.RelayListTTL {
+		c.relayListsMu.Unlock()
+		return e.lists
+	}
+	c.relayListsMu.Unlock()
+
+	lists := c.FetchUserRelayLists(pubkey)
+
+	c.relayListsMu.Lock()
+	c.relayListsCache[pubkey] = relayListsEntry{lists: lists, at: time.Now()}
+	c.relayListsMu.Unlock()
+	return lists
+}
+
+// WarmUserRelayLists resolves a user's relay lists into the cache in the
+// background — used by login-hydration so the settings page is instant.
+func (c *Client) WarmUserRelayLists(pubkey string) {
+	go c.ResolveUserRelayLists(pubkey)
+}
+
+// InvalidateUserRelayLists drops a user's cached relay lists so the next resolve
+// re-fetches — call after they publish a new relay-list event.
+func (c *Client) InvalidateUserRelayLists(pubkey string) {
+	c.relayListsMu.Lock()
+	delete(c.relayListsCache, pubkey)
+	c.relayListsMu.Unlock()
+}

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -112,7 +113,7 @@ func (c *Client) FetchRelayList(pubkey string, kind int) *nostr.Event {
 	if ur, ok := c.directory.Cached(pubkey); ok {
 		relays = appendUnique(relays, ur.Outbox)
 	}
-	return c.fetchLatestEvent(pubkey, kind, relays)
+	return c.fetchLatestEvent(context.Background(), pubkey, kind, relays)
 }
 
 // InvalidateUserRelays drops a user's cached relay-role resolution so the next
@@ -227,7 +228,7 @@ func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
 	const relayListResolveTimeout = 3 * time.Second
 	fetch := func(kind int, assign func(*nostr.Event)) {
 		defer wg.Done()
-		if ev := c.fetchLatestEventWithin(pubkey, kind, relays, relayListResolveTimeout); ev != nil {
+		if ev := c.fetchLatestEventWithin(context.Background(), pubkey, kind, relays, relayListResolveTimeout); ev != nil {
 			assign(ev)
 		}
 	}

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -188,9 +188,13 @@ type UserRelayLists struct {
 	Blocked   []string         `json:"blocked"`   // 10006
 	Search    []string         `json:"search"`    // 10007
 	Favorites []string         `json:"favorites"` // 10012
-	// Encrypted flags NIP-51 lists whose event carried NIP-44 private content —
-	// entries grain can't read yet (#100); only the public entries are listed.
+	// Encrypted flags NIP-51 lists whose event carried NIP-44/NIP-04 private
+	// content; only the public entries are listed in the fields above.
 	Encrypted EncryptedFlags `json:"encrypted"`
+	// EncryptedContent carries the raw private content blob per list so the
+	// browser — which holds the user's signer — can decrypt it on demand (#100).
+	// grain itself never decrypts; it just passes the opaque blob through.
+	EncryptedContent EncryptedContent `json:"encrypted_content"`
 }
 
 // EncryptedFlags reports which NIP-51 lists have private (encrypted) entries.
@@ -198,6 +202,15 @@ type EncryptedFlags struct {
 	Blocked   bool `json:"blocked"`
 	Search    bool `json:"search"`
 	Favorites bool `json:"favorites"`
+}
+
+// EncryptedContent holds the raw (still-encrypted) `.content` of each NIP-51
+// list that has private entries, keyed by the same names as EncryptedFlags.
+// Empty strings when a list has no private content.
+type EncryptedContent struct {
+	Blocked   string `json:"blocked,omitempty"`
+	Search    string `json:"search,omitempty"`
+	Favorites string `json:"favorites,omitempty"`
 }
 
 // OwnListRelays returns the relay set to read a user's own replaceable lists
@@ -238,14 +251,17 @@ func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
 	go fetch(10006, func(ev *nostr.Event) {
 		out.Blocked = ParseRelayTagURLs(ev)
 		out.Encrypted.Blocked = ev.Content != ""
+		out.EncryptedContent.Blocked = ev.Content
 	})
 	go fetch(10007, func(ev *nostr.Event) {
 		out.Search = ParseRelayTagURLs(ev)
 		out.Encrypted.Search = ev.Content != ""
+		out.EncryptedContent.Search = ev.Content
 	})
 	go fetch(10012, func(ev *nostr.Event) {
 		out.Favorites = ParseRelayTagURLs(ev)
 		out.Encrypted.Favorites = ev.Content != ""
+		out.EncryptedContent.Favorites = ev.Content
 	})
 	wg.Wait()
 	return out

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"fmt"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// relayListTagName returns the tag name relay URLs use in a given relay-list
+// event kind, and whether grain can publish that kind. NIP-65 (10002) uses `r`
+// tags with read/write markers; the NIP-17/51 lists use plain `relay` tags.
+func relayListTagName(kind int) (string, bool) {
+	switch kind {
+	case 10002: // NIP-65 read/write relays
+		return "r", true
+	case 10050, // NIP-17 DM relays
+		10006, // NIP-51 blocked relays
+		10007, // NIP-51 search relays
+		10012: // NIP-51 favorite relays
+		return "relay", true
+	default:
+		return "", false
+	}
+}
+
+// RelayListEntry is one relay in a relay-list event. Read / Write are only
+// meaningful for NIP-65 kind 10002 — an entry that is both (or neither) is
+// written unmarked, meaning "read and write". The other kinds ignore the flags.
+type RelayListEntry struct {
+	URL   string `json:"url"`
+	Read  bool   `json:"read"`
+	Write bool   `json:"write"`
+}
+
+// AssembleRelayListEvent builds an UNSIGNED relay-list event of the given kind
+// from the user's existing one, rewriting the relay tags while preserving the
+// content and every non-relay tag — the same conservative "don't drop data"
+// rule as the profile and media-server editors.
+//
+// Tag shape by kind:
+//   - 10002 (NIP-65): ["r", url] (both), ["r", url, "read"], or ["r", url, "write"]
+//   - 10050 / 10006 / 10007 / 10012: ["relay", url]
+//
+// existing may be nil (a first list). The returned event has no ID or Sig: the
+// caller signs it.
+func AssembleRelayListEvent(existing *nostr.Event, kind int, pubkey string, entries []RelayListEntry) (*nostr.Event, error) {
+	tagName, ok := relayListTagName(kind)
+	if !ok {
+		return nil, fmt.Errorf("unsupported relay-list kind %d", kind)
+	}
+
+	var existingTags [][]string
+	content := ""
+	if existing != nil {
+		existingTags = existing.Tags
+		content = existing.Content
+		if existing.PubKey != "" {
+			pubkey = existing.PubKey
+		}
+	}
+
+	// Preserve every tag that isn't a relay entry of this kind's tag name.
+	tags := make([][]string, 0, len(existingTags)+len(entries))
+	for _, t := range existingTags {
+		if len(t) >= 1 && t[0] == tagName {
+			continue
+		}
+		tags = append(tags, t)
+	}
+
+	// Append the new relay list in order, normalised + de-duplicated.
+	seen := make(map[string]struct{})
+	for _, e := range entries {
+		u, ok := normalizeRelayURL(e.URL)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		if kind == 10002 {
+			switch {
+			case e.Read && !e.Write:
+				tags = append(tags, []string{"r", u, "read"})
+			case e.Write && !e.Read:
+				tags = append(tags, []string{"r", u, "write"})
+			default: // both, or unspecified — NIP-65 omits the marker
+				tags = append(tags, []string{"r", u})
+			}
+		} else {
+			tags = append(tags, []string{tagName, u})
+		}
+	}
+
+	return &nostr.Event{
+		PubKey:    pubkey,
+		Kind:      kind,
+		CreatedAt: time.Now().Unix(),
+		Content:   content,
+		Tags:      tags,
+	}, nil
+}
+
+// FetchRelayList returns the user's latest raw relay-list event of the given
+// kind, or nil. Used by the build flow to preserve non-relay tags on republish.
+// Mirrors FetchMediaServerList: index relays plus the user's cached outbox.
+func (c *Client) FetchRelayList(pubkey string, kind int) *nostr.Event {
+	relays := c.config.IndexRelays
+	if ur, ok := c.directory.Cached(pubkey); ok {
+		relays = appendUnique(relays, ur.Outbox)
+	}
+	return c.fetchLatestEvent(pubkey, kind, relays)
+}
+
+// InvalidateUserRelays drops a user's cached relay-role resolution so the next
+// lookup re-resolves — call after the user republishes their own 10002 / 10050
+// so routing picks up the change immediately.
+func (c *Client) InvalidateUserRelays(pubkey string) {
+	c.directory.Invalidate(pubkey)
+}

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -219,9 +219,15 @@ func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
 
 	out := &UserRelayLists{}
 	var wg sync.WaitGroup
+	// Resolve all five kinds concurrently; the response can't return until the
+	// slowest finishes, and a user is usually missing at least one list type
+	// (a negative that would otherwise wait the full default deadline on any
+	// slow relay). A shorter deadline keeps the relay manager snappy on a cold
+	// load; a list that exists still comes back well within it.
+	const relayListResolveTimeout = 3 * time.Second
 	fetch := func(kind int, assign func(*nostr.Event)) {
 		defer wg.Done()
-		if ev := c.fetchLatestEvent(pubkey, kind, relays); ev != nil {
+		if ev := c.fetchLatestEventWithin(pubkey, kind, relays, relayListResolveTimeout); ev != nil {
 			assign(ev)
 		}
 	}
@@ -255,19 +261,32 @@ type relayListsEntry struct {
 // manager reads through this so the page renders from cache once login-hydration
 // has warmed it.
 func (c *Client) ResolveUserRelayLists(pubkey string) *UserRelayLists {
-	c.relayListsMu.Lock()
-	if e, ok := c.relayListsCache[pubkey]; ok && time.Since(e.at) < c.config.RelayListTTL {
+	for {
+		c.relayListsMu.Lock()
+		if e, ok := c.relayListsCache[pubkey]; ok && time.Since(e.at) < c.config.RelayListTTL {
+			c.relayListsMu.Unlock()
+			return e.lists
+		}
+		// A resolve for this pubkey is already running — wait for it and re-read
+		// the cache instead of launching a duplicate multi-second fetch.
+		if ch, ok := c.relayListsInflight[pubkey]; ok {
+			c.relayListsMu.Unlock()
+			<-ch
+			continue
+		}
+		ch := make(chan struct{})
+		c.relayListsInflight[pubkey] = ch
 		c.relayListsMu.Unlock()
-		return e.lists
+
+		lists := c.FetchUserRelayLists(pubkey)
+
+		c.relayListsMu.Lock()
+		c.relayListsCache[pubkey] = relayListsEntry{lists: lists, at: time.Now()}
+		delete(c.relayListsInflight, pubkey)
+		close(ch)
+		c.relayListsMu.Unlock()
+		return lists
 	}
-	c.relayListsMu.Unlock()
-
-	lists := c.FetchUserRelayLists(pubkey)
-
-	c.relayListsMu.Lock()
-	c.relayListsCache[pubkey] = relayListsEntry{lists: lists, at: time.Now()}
-	c.relayListsMu.Unlock()
-	return lists
 }
 
 // WarmUserRelayLists resolves a user's relay lists into the cache in the

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -199,18 +199,23 @@ type EncryptedFlags struct {
 	Favorites bool `json:"favorites"`
 }
 
-// FetchUserRelayLists resolves a user's relay lists for every kind the relay
-// manager shows, fetching the kinds concurrently. Each goroutine writes a
-// distinct field, so no locking is needed.
-//
-// A user's own NIP-51/17 lists live on their own relays, which a cold page load
-// may not have cached — so the relay set is the index relays PLUS the user's
-// resolved read+write relays, giving the lists a real chance to be found.
-func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
+// OwnListRelays returns the relay set to read a user's own replaceable lists
+// from: the index relays plus their resolved read+write relays. A user's own
+// NIP-51/17 lists live on their own relays, which a cold load may not have
+// cached. Shared by FetchUserRelayLists and the live-sync subscription.
+func (c *Client) OwnListRelays(pubkey string) []string {
 	relays := append([]string(nil), c.config.IndexRelays...)
 	ur := c.ResolveRelays(pubkey) // blocking resolve — own user is cached post-login
 	relays = appendUnique(relays, ur.Outbox)
 	relays = appendUnique(relays, ur.Inbox)
+	return relays
+}
+
+// FetchUserRelayLists resolves a user's relay lists for every kind the relay
+// manager shows, fetching the kinds concurrently. Each goroutine writes a
+// distinct field, so no locking is needed.
+func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
+	relays := c.OwnListRelays(pubkey)
 
 	out := &UserRelayLists{}
 	var wg sync.WaitGroup

--- a/client/core/relaylist.go
+++ b/client/core/relaylist.go
@@ -188,7 +188,8 @@ type UserRelayLists struct {
 	Blocked   []string         `json:"blocked"`   // 10006
 	Search    []string         `json:"search"`    // 10007
 	Favorites []string         `json:"favorites"` // 10012
-	// Encrypted flags NIP-51 lists whose event carried NIP-44/NIP-04 private
+	Private   []string         `json:"private"`   // 10013 (NIP-37) — usually empty; entries live in the encrypted content
+	// Encrypted flags NIP-51/37 lists whose event carried NIP-44/NIP-04 private
 	// content; only the public entries are listed in the fields above.
 	Encrypted EncryptedFlags `json:"encrypted"`
 	// EncryptedContent carries the raw private content blob per list so the
@@ -197,20 +198,22 @@ type UserRelayLists struct {
 	EncryptedContent EncryptedContent `json:"encrypted_content"`
 }
 
-// EncryptedFlags reports which NIP-51 lists have private (encrypted) entries.
+// EncryptedFlags reports which NIP-51/37 lists have private (encrypted) entries.
 type EncryptedFlags struct {
 	Blocked   bool `json:"blocked"`
 	Search    bool `json:"search"`
 	Favorites bool `json:"favorites"`
+	Private   bool `json:"private"` // 10013 — typically always encrypted
 }
 
-// EncryptedContent holds the raw (still-encrypted) `.content` of each NIP-51
+// EncryptedContent holds the raw (still-encrypted) `.content` of each NIP-51/37
 // list that has private entries, keyed by the same names as EncryptedFlags.
 // Empty strings when a list has no private content.
 type EncryptedContent struct {
 	Blocked   string `json:"blocked,omitempty"`
 	Search    string `json:"search,omitempty"`
 	Favorites string `json:"favorites,omitempty"`
+	Private   string `json:"private,omitempty"`
 }
 
 // OwnListRelays returns the relay set to read a user's own replaceable lists
@@ -245,9 +248,16 @@ func (c *Client) FetchUserRelayLists(pubkey string) *UserRelayLists {
 			assign(ev)
 		}
 	}
-	wg.Add(5)
+	wg.Add(6)
 	go fetch(10002, func(ev *nostr.Event) { out.NIP65 = ParseNIP65Entries(ev) })
 	go fetch(10050, func(ev *nostr.Event) { out.DM = ParseRelayTagURLs(ev) })
+	go fetch(10013, func(ev *nostr.Event) {
+		// NIP-37 private relays: the entries live in the encrypted content, so the
+		// public tag list is normally empty; the browser decrypts on demand (#100).
+		out.Private = ParseRelayTagURLs(ev)
+		out.Encrypted.Private = ev.Content != ""
+		out.EncryptedContent.Private = ev.Content
+	})
 	go fetch(10006, func(ev *nostr.Event) {
 		out.Blocked = ParseRelayTagURLs(ev)
 		out.Encrypted.Blocked = ev.Content != ""

--- a/client/core/relaylist_test.go
+++ b/client/core/relaylist_test.go
@@ -68,3 +68,38 @@ func TestAssembleRelayListRejectsUnsupportedKind(t *testing.T) {
 		t.Fatal("expected an error for a non relay-list kind (10063 is media)")
 	}
 }
+
+func TestParseNIP65Entries(t *testing.T) {
+	ev := &nostr.Event{Tags: [][]string{
+		{"r", "wss://a"},          // both
+		{"r", "wss://b", "read"},  // read-only
+		{"r", "wss://c", "write"}, // write-only
+		{"r", "wss://a", "write"}, // duplicate of a — flags OR together (stays both)
+		{"other", "ignored"},
+		{"r"}, // malformed
+	}}
+	got := ParseNIP65Entries(ev)
+	want := []RelayListEntry{
+		{URL: "wss://a", Read: true, Write: true},
+		{URL: "wss://b", Read: true, Write: false},
+		{URL: "wss://c", Read: false, Write: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseNIP65Entries = %v, want %v", got, want)
+	}
+}
+
+func TestParseRelayTagURLs(t *testing.T) {
+	ev := &nostr.Event{Tags: [][]string{
+		{"relay", "wss://x"},
+		{"relay", "wss://x"}, // duplicate dropped
+		{"other", "y"},
+		{"relay", "wss://y"},
+		{"relay"}, // malformed
+	}}
+	got := ParseRelayTagURLs(ev)
+	want := []string{"wss://x", "wss://y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseRelayTagURLs = %v, want %v", got, want)
+	}
+}

--- a/client/core/relaylist_test.go
+++ b/client/core/relaylist_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// NIP-65 (10002): read+write is unmarked, read-only / write-only get the
+// marker, old `r` tags are replaced, and non-relay tags survive.
+func TestAssembleRelayListNIP65Markers(t *testing.T) {
+	existing := &nostr.Event{
+		PubKey:  "pk",
+		Kind:    10002,
+		Content: "keep",
+		Tags: [][]string{
+			{"r", "wss://old"},  // dropped — relay list is rewritten
+			{"alt", "preserve"}, // preserved — not a relay tag
+		},
+	}
+	entries := []RelayListEntry{
+		{URL: "wss://a", Read: true, Write: true}, // both → unmarked
+		{URL: "wss://b", Read: true},              // read-only
+		{URL: "wss://c", Write: true},             // write-only
+		{URL: "wss://a"},                          // duplicate — dropped
+	}
+	got, err := AssembleRelayListEvent(existing, 10002, "pk", entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "keep" || got.Kind != 10002 || got.PubKey != "pk" {
+		t.Fatalf("header not carried over: %+v", got)
+	}
+	if got.ID != "" || got.Sig != "" {
+		t.Fatal("assembled event must be unsigned")
+	}
+	want := [][]string{
+		{"alt", "preserve"},
+		{"r", "wss://a"},
+		{"r", "wss://b", "read"},
+		{"r", "wss://c", "write"},
+	}
+	if !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("tags = %v, want %v", got.Tags, want)
+	}
+}
+
+// The NIP-17 / NIP-51 list kinds use plain `relay` tags and ignore read/write.
+func TestAssembleRelayListPlainRelayTags(t *testing.T) {
+	for _, kind := range []int{10050, 10006, 10007, 10012} {
+		got, err := AssembleRelayListEvent(nil, kind, "pk", []RelayListEntry{
+			{URL: "wss://dm", Read: true}, // marker ignored for these kinds
+			{URL: "wss://dm"},             // duplicate dropped
+		})
+		if err != nil {
+			t.Fatalf("kind %d: unexpected error: %v", kind, err)
+		}
+		want := [][]string{{"relay", "wss://dm"}}
+		if !reflect.DeepEqual(got.Tags, want) {
+			t.Fatalf("kind %d tags = %v, want %v", kind, got.Tags, want)
+		}
+	}
+}
+
+func TestAssembleRelayListRejectsUnsupportedKind(t *testing.T) {
+	if _, err := AssembleRelayListEvent(nil, 10063, "pk", nil); err == nil {
+		t.Fatal("expected an error for a non relay-list kind (10063 is media)")
+	}
+}

--- a/client/core/relayliststore.go
+++ b/client/core/relayliststore.go
@@ -1,0 +1,65 @@
+package core
+
+import "sync"
+
+// RelayListStore is the pluggable persistence seam for the relay directory's
+// per-user resolutions (a user's outbox / inbox / DM relays). The default is
+// in-memory; a consumer can plug a shared or persistent store — e.g. a database
+// — so resolutions survive restarts or are shared across instances.
+//
+// The RelayDirectory owns the TTL and single-flight logic and serializes access,
+// so an implementation only needs to be a correct key-value map of
+// pubkey -> *UserRelays; it does not need its own freshness or de-duplication
+// logic. (Because the directory holds its lock across store calls, a store whose
+// Get/Set hit slow I/O will serialize lookups — a DB-backed store that cares
+// should keep a fast in-memory layer in front.)
+type RelayListStore interface {
+	// Get returns the stored resolution for a pubkey and whether one exists.
+	Get(pubkey string) (*UserRelays, bool)
+	// Set stores (or replaces) the resolution for a pubkey.
+	Set(pubkey string, ur *UserRelays)
+	// Delete removes any stored resolution for a pubkey.
+	Delete(pubkey string)
+	// Range calls fn for each stored entry until fn returns false. Used to build
+	// the union "known relays" set; iteration order is unspecified.
+	Range(fn func(pubkey string, ur *UserRelays) bool)
+}
+
+// memRelayListStore is the default in-memory RelayListStore: a mutex-guarded map.
+type memRelayListStore struct {
+	mu      sync.Mutex
+	entries map[string]*UserRelays
+}
+
+func newMemRelayListStore() *memRelayListStore {
+	return &memRelayListStore{entries: make(map[string]*UserRelays)}
+}
+
+func (s *memRelayListStore) Get(pubkey string) (*UserRelays, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ur, ok := s.entries[pubkey]
+	return ur, ok
+}
+
+func (s *memRelayListStore) Set(pubkey string, ur *UserRelays) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[pubkey] = ur
+}
+
+func (s *memRelayListStore) Delete(pubkey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, pubkey)
+}
+
+func (s *memRelayListStore) Range(fn func(string, *UserRelays) bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, v := range s.entries {
+		if !fn(k, v) {
+			return
+		}
+	}
+}

--- a/client/core/relayping.go
+++ b/client/core/relayping.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"net"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type relayPingEntry struct {
+	ms int // milliseconds; -1 = unreachable within the timeout
+	at time.Time
+}
+
+const (
+	relayPingTTL     = 2 * time.Minute
+	relayPingTimeout = 3 * time.Second
+)
+
+// PingRelay measures TCP-connect latency to a relay — a cheap reachability/
+// latency probe, not a WebSocket or NIP-01 round-trip — and TTL-caches it.
+// Returns milliseconds, or -1 if the host can't be reached within the timeout
+// (also cached, so onion/unroutable hosts don't stall every sort). Used by the
+// known-relays "fastest first" ordering.
+func (c *Client) PingRelay(relayURL string) int {
+	if norm, ok := normalizeRelayURL(relayURL); ok {
+		relayURL = norm
+	}
+	c.relayPingMu.Lock()
+	if e, ok := c.relayPingCache[relayURL]; ok && time.Since(e.at) < relayPingTTL {
+		c.relayPingMu.Unlock()
+		return e.ms
+	}
+	c.relayPingMu.Unlock()
+
+	ms := tcpPing(relayURL)
+
+	c.relayPingMu.Lock()
+	c.relayPingCache[relayURL] = relayPingEntry{ms: ms, at: time.Now()}
+	c.relayPingMu.Unlock()
+	return ms
+}
+
+// PingRelays pings a set of relays in parallel (bounded worker pool), returning
+// url -> ms (-1 for unreachable). The relay manager calls this for just the rows
+// currently in view, so the set is small even though the known set is large.
+func (c *Client) PingRelays(urls []string) map[string]int {
+	const workers = 16
+	out := make(map[string]int, len(urls))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, workers)
+	for _, u := range urls {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			ms := c.PingRelay(u)
+			mu.Lock()
+			out[u] = ms
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return out
+}
+
+// tcpPing dials TCP to the relay's host:port and returns the connect time in
+// milliseconds, or -1 on failure/timeout. wss defaults to :443, ws to :80.
+func tcpPing(wsURL string) int {
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		return -1
+	}
+	host := u.Hostname()
+	if host == "" {
+		return -1
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "wss" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	start := time.Now()
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), relayPingTimeout)
+	if err != nil {
+		return -1
+	}
+	_ = conn.Close()
+	return max(int(time.Since(start).Milliseconds()), 0)
+}

--- a/client/core/relays.go
+++ b/client/core/relays.go
@@ -158,6 +158,12 @@ func NewRelayPool(config *Config) *RelayPool {
 
 // Connect establishes a connection to a relay
 func (rp *RelayPool) Connect(url string) error {
+	normalized, ok := normalizeRelayURL(url)
+	if !ok {
+		return fmt.Errorf("invalid relay url: %q", url)
+	}
+	url = normalized
+
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 

--- a/client/core/relays.go
+++ b/client/core/relays.go
@@ -75,6 +75,11 @@ type MessageRouter struct {
 	subscriptions map[string]*Subscription
 	okWaiters     map[string]chan OKResult // event id -> waiter (set during a publish)
 	mu            sync.RWMutex
+
+	// NIP-42: per-relay AUTH state observed this session (the latest challenge a
+	// relay sent and whether we've authed to it). Guarded by authMu.
+	authMu     sync.RWMutex
+	authStates map[string]*AuthState // relayURL -> state
 }
 
 // NewMessageRouter creates a new message router
@@ -82,6 +87,7 @@ func NewMessageRouter() *MessageRouter {
 	return &MessageRouter{
 		subscriptions: make(map[string]*Subscription),
 		okWaiters:     make(map[string]chan OKResult),
+		authStates:    make(map[string]*AuthState),
 	}
 }
 
@@ -614,6 +620,15 @@ func (rc *RelayConnection) processMessage(message string) error {
 			}
 			log.ClientCore().Debug("Received OK message", "relay", rc.URL, "accepted", accepted, "reason", reason)
 			rc.messageRouter.RouteOK(eventID, OKResult{Relay: rc.URL, Accepted: accepted, Reason: reason})
+		}
+	case "AUTH":
+		// NIP-42: ["AUTH", <challenge>]. Record the challenge for the session so
+		// the relay manager can surface it and the browser signer can answer it.
+		if len(messageArray) >= 2 {
+			if challenge, ok := messageArray[1].(string); ok && challenge != "" {
+				log.ClientCore().Debug("Received AUTH challenge", "relay", rc.URL)
+				rc.messageRouter.RouteAuth(rc.URL, challenge)
+			}
 		}
 	default:
 		log.ClientCore().Debug("Unknown message type", "relay", rc.URL, "type", messageType)

--- a/client/core/relays.go
+++ b/client/core/relays.go
@@ -61,9 +61,19 @@ type RelayConnection struct {
 	idleAt time.Time
 }
 
-// MessageRouter handles routing messages to subscriptions
+// OKResult is a relay's NIP-20 response to a published event: whether it was
+// accepted and any human-readable reason.
+type OKResult struct {
+	Relay    string `json:"relay"`
+	Accepted bool   `json:"accepted"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// MessageRouter handles routing messages to subscriptions and OK responses to
+// in-flight publishes.
 type MessageRouter struct {
 	subscriptions map[string]*Subscription
+	okWaiters     map[string]chan OKResult // event id -> waiter (set during a publish)
 	mu            sync.RWMutex
 }
 
@@ -71,6 +81,39 @@ type MessageRouter struct {
 func NewMessageRouter() *MessageRouter {
 	return &MessageRouter{
 		subscriptions: make(map[string]*Subscription),
+		okWaiters:     make(map[string]chan OKResult),
+	}
+}
+
+// RegisterOKWaiter starts collecting OK responses for an event being published.
+// The returned channel is buffered for up to buf relays; UnregisterOKWaiter
+// must be called when done.
+func (mr *MessageRouter) RegisterOKWaiter(eventID string, buf int) chan OKResult {
+	ch := make(chan OKResult, buf)
+	mr.mu.Lock()
+	mr.okWaiters[eventID] = ch
+	mr.mu.Unlock()
+	return ch
+}
+
+// UnregisterOKWaiter stops collecting OK responses for an event.
+func (mr *MessageRouter) UnregisterOKWaiter(eventID string) {
+	mr.mu.Lock()
+	delete(mr.okWaiters, eventID)
+	mr.mu.Unlock()
+}
+
+// RouteOK delivers a relay's OK response to the publisher waiting on it, if any.
+func (mr *MessageRouter) RouteOK(eventID string, ok OKResult) {
+	mr.mu.RLock()
+	ch, exists := mr.okWaiters[eventID]
+	mr.mu.RUnlock()
+	if !exists {
+		return
+	}
+	select {
+	case ch <- ok:
+	default: // waiter buffer full or gone — drop
 	}
 }
 
@@ -561,9 +604,16 @@ func (rc *RelayConnection) processMessage(message string) error {
 			log.ClientCore().Info("Relay notice", "relay", rc.URL, "notice", notice)
 		}
 	case "OK":
+		// NIP-20: ["OK", <event-id>, <accepted bool>, <reason string>]
 		if len(messageArray) >= 3 {
-			log.ClientCore().Debug("Received OK message", "relay", rc.URL)
-			// TODO: Handle event publication response
+			eventID, _ := messageArray[1].(string)
+			accepted, _ := messageArray[2].(bool)
+			reason := ""
+			if len(messageArray) >= 4 {
+				reason, _ = messageArray[3].(string)
+			}
+			log.ClientCore().Debug("Received OK message", "relay", rc.URL, "accepted", accepted, "reason", reason)
+			rc.messageRouter.RouteOK(eventID, OKResult{Relay: rc.URL, Accepted: accepted, Reason: reason})
 		}
 	default:
 		log.ClientCore().Debug("Unknown message type", "relay", rc.URL, "type", messageType)

--- a/client/core/relays.go
+++ b/client/core/relays.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 	"golang.org/x/net/websocket"
 )
 
@@ -144,7 +143,7 @@ func (mr *MessageRouter) RouteMessage(subID string, messageType string, data int
 	mr.mu.RUnlock()
 
 	if !exists {
-		log.ClientCore().Debug("No subscription found for message", "sub_id", subID, "message_type", messageType)
+		clog().Debug("No subscription found for message", "sub_id", subID, "message_type", messageType)
 		return
 	}
 
@@ -154,9 +153,9 @@ func (mr *MessageRouter) RouteMessage(subID string, messageType string, data int
 			if event := parseEventFromData(eventData); event != nil {
 				select {
 				case sub.Events <- event:
-					log.ClientCore().Debug("Event routed to subscription", "sub_id", subID, "event_id", event.ID)
+					clog().Debug("Event routed to subscription", "sub_id", subID, "event_id", event.ID)
 				default:
-					log.ClientCore().Warn("Subscription event channel full", "sub_id", subID)
+					clog().Warn("Subscription event channel full", "sub_id", subID)
 				}
 			}
 		}
@@ -164,17 +163,17 @@ func (mr *MessageRouter) RouteMessage(subID string, messageType string, data int
 		// Send relay URL to EOSE channel
 		select {
 		case sub.EOSE <- relayURL:
-			log.ClientCore().Debug("EOSE routed to subscription", "sub_id", subID, "relay", relayURL)
+			clog().Debug("EOSE routed to subscription", "sub_id", subID, "relay", relayURL)
 		default:
-			log.ClientCore().Debug("EOSE channel full or closed", "sub_id", subID, "relay", relayURL)
+			clog().Debug("EOSE channel full or closed", "sub_id", subID, "relay", relayURL)
 		}
 	case "CLOSED":
 		// Handle subscription closed by relay
 		select {
 		case sub.Errors <- fmt.Errorf("subscription closed by relay %s", relayURL):
-			log.ClientCore().Debug("CLOSED message routed to subscription", "sub_id", subID, "relay", relayURL)
+			clog().Debug("CLOSED message routed to subscription", "sub_id", subID, "relay", relayURL)
 		default:
-			log.ClientCore().Debug("Could not send CLOSED error to subscription", "sub_id", subID)
+			clog().Debug("Could not send CLOSED error to subscription", "sub_id", subID)
 		}
 	}
 }
@@ -219,19 +218,19 @@ func (rp *RelayPool) Connect(url string) error {
 	// Check if already connected
 	if conn, exists := rp.connections[url]; exists {
 		if conn.Status == StatusConnected {
-			log.ClientCore().Debug("Already connected to relay", "relay", url)
+			clog().Debug("Already connected to relay", "relay", url)
 			return nil
 		}
 		// Close existing dead connection before reconnecting
-		log.ClientCore().Debug("Closing existing dead connection before reconnecting", "relay", url, "status", conn.Status)
+		clog().Debug("Closing existing dead connection before reconnecting", "relay", url, "status", conn.Status)
 		if err := conn.close(); err != nil {
-			log.ClientCore().Warn("Error closing dead connection", "relay", url, "error", err)
+			clog().Warn("Error closing dead connection", "relay", url, "error", err)
 		}
 		// Remove from map
 		delete(rp.connections, url)
 	}
 
-	log.ClientCore().Debug("Connecting to relay", "relay", url)
+	clog().Debug("Connecting to relay", "relay", url)
 
 	// Create relay connection
 	relayConn := &RelayConnection{
@@ -250,7 +249,7 @@ func (rp *RelayPool) Connect(url string) error {
 	config, err := websocket.NewConfig(url, origin)
 	if err != nil {
 		relayConn.Status = StatusError
-		log.ClientCore().Error("Failed to create WebSocket config", "relay", url, "error", err)
+		clog().Error("Failed to create WebSocket config", "relay", url, "error", err)
 		return fmt.Errorf("failed to create config for relay %s: %w", url, err)
 	}
 
@@ -262,7 +261,7 @@ func (rp *RelayPool) Connect(url string) error {
 	conn, err := websocket.DialConfig(config)
 	if err != nil {
 		relayConn.Status = StatusError
-		log.ClientCore().Error("Failed to connect to relay", "relay", url, "error", err)
+		clog().Error("Failed to connect to relay", "relay", url, "error", err)
 		return fmt.Errorf("failed to connect to relay %s: %w", url, err)
 	}
 
@@ -277,7 +276,7 @@ func (rp *RelayPool) Connect(url string) error {
 	go relayConn.writeHandler()
 	go relayConn.readHandler()
 
-	log.ClientCore().Info("Connected to relay", "relay", url)
+	clog().Info("Connected to relay", "relay", url)
 	return nil
 }
 
@@ -298,7 +297,7 @@ func (rp *RelayPool) SendMessage(url string, message interface{}) error {
 
 	select {
 	case conn.writeChan <- data:
-		log.ClientCore().Debug("Message queued for relay", "relay", url)
+		clog().Debug("Message queued for relay", "relay", url)
 		return nil
 	case <-time.After(rp.config.WriteTimeout):
 		return fmt.Errorf("timeout sending message to relay %s", url)
@@ -312,7 +311,7 @@ func (rp *RelayPool) BroadcastMessage(message interface{}, urls []string) error 
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	log.ClientCore().Debug("Broadcasting message", "relay_count", len(urls))
+	clog().Debug("Broadcasting message", "relay_count", len(urls))
 
 	var lastErr error
 	sent := 0
@@ -339,7 +338,7 @@ func (rp *RelayPool) BroadcastMessage(message interface{}, urls []string) error 
 		return lastErr
 	}
 
-	log.ClientCore().Debug("Message broadcast complete", "sent", sent, "total", len(urls))
+	clog().Debug("Message broadcast complete", "sent", sent, "total", len(urls))
 	return nil
 }
 
@@ -399,11 +398,11 @@ func (rp *RelayPool) Close() error {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 
-	log.ClientCore().Info("Closing relay pool", "connection_count", len(rp.connections))
+	clog().Info("Closing relay pool", "connection_count", len(rp.connections))
 
 	for url, conn := range rp.connections {
 		if err := conn.close(); err != nil {
-			log.ClientCore().Error("Error closing relay connection", "relay", url, "error", err)
+			clog().Error("Error closing relay connection", "relay", url, "error", err)
 		}
 	}
 
@@ -427,14 +426,14 @@ func (rc *RelayConnection) writeHandler() {
 		select {
 		case data := <-rc.writeChan:
 			if err := websocket.Message.Send(rc.Conn, string(data)); err != nil {
-				log.ClientCore().Error("Failed to send message to relay", "relay", rc.URL, "error", err)
+				clog().Error("Failed to send message to relay", "relay", rc.URL, "error", err)
 				rc.setStatus(StatusError)
 				return
 			}
-			log.ClientCore().Debug("Message sent to relay", "relay", rc.URL)
+			clog().Debug("Message sent to relay", "relay", rc.URL)
 
 		case <-rc.done:
-			log.ClientCore().Debug("Write handler stopped", "relay", rc.URL)
+			clog().Debug("Write handler stopped", "relay", rc.URL)
 			return
 		}
 	}
@@ -451,13 +450,13 @@ func (rc *RelayConnection) readHandler() {
 		if rc.Conn != nil {
 			rc.Conn.Close()
 		}
-		log.ClientCore().Debug("Read handler terminated", "relay", rc.URL)
+		clog().Debug("Read handler terminated", "relay", rc.URL)
 	}()
 
 	for {
 		select {
 		case <-rc.done:
-			log.ClientCore().Debug("Read handler stopped", "relay", rc.URL)
+			clog().Debug("Read handler stopped", "relay", rc.URL)
 			return
 		default:
 			// Set a longer read timeout to avoid frequent timeouts
@@ -467,7 +466,7 @@ func (rc *RelayConnection) readHandler() {
 			if err := websocket.Message.Receive(rc.Conn, &message); err != nil {
 				// Don't log timeout errors as errors - they're normal for keep-alive
 				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-					log.ClientCore().Debug("Read timeout from relay (normal keep-alive)", "relay", rc.URL)
+					clog().Debug("Read timeout from relay (normal keep-alive)", "relay", rc.URL)
 					continue // Continue loop, don't terminate connection
 				}
 
@@ -475,7 +474,7 @@ func (rc *RelayConnection) readHandler() {
 				// network read errors are normal flakiness for third-party
 				// relays we have no control over, not grain bugs. Operators
 				// can opt in by lowering the log level when diagnosing.
-				log.ClientCore().Debug("Failed to read message from relay", "relay", rc.URL, "error", err)
+				clog().Debug("Failed to read message from relay", "relay", rc.URL, "error", err)
 				rc.setStatus(StatusError)
 				return
 			}
@@ -485,7 +484,7 @@ func (rc *RelayConnection) readHandler() {
 			// strings) that fail our parser. Logging at WARN drowned the
 			// real signal in the v0.5.0 RC.
 			if err := rc.processMessage(message); err != nil {
-				log.ClientCore().Debug("Failed to process message from relay", "relay", rc.URL, "error", err)
+				clog().Debug("Failed to process message from relay", "relay", rc.URL, "error", err)
 			}
 		}
 	}
@@ -533,22 +532,22 @@ func (rc *RelayConnection) close() error {
 		return nil
 	}
 
-	log.ClientCore().Debug("Closing relay connection", "relay", rc.URL)
+	clog().Debug("Closing relay connection", "relay", rc.URL)
 	if conn != nil {
 		// The handler defers may also close the socket; a double close is
 		// benign, so log it at debug rather than failing the close.
 		if err := conn.Close(); err != nil {
-			log.ClientCore().Debug("Relay socket close returned error (likely already closed)",
+			clog().Debug("Relay socket close returned error (likely already closed)",
 				"relay", rc.URL, "error", err)
 		}
 	}
-	log.ClientCore().Debug("Relay connection closed", "relay", rc.URL)
+	clog().Debug("Relay connection closed", "relay", rc.URL)
 	return nil
 }
 
 // Also update processMessage in relays.go to pass relay URL:
 func (rc *RelayConnection) processMessage(message string) error {
-	log.ClientCore().Debug("Processing message from relay", "relay", rc.URL, "message_length", len(message))
+	clog().Debug("Processing message from relay", "relay", rc.URL, "message_length", len(message))
 
 	// Parse the message as JSON array
 	var messageArray []interface{}
@@ -578,7 +577,7 @@ func (rc *RelayConnection) processMessage(message string) error {
 				return fmt.Errorf("invalid event data in EVENT")
 			}
 
-			log.ClientCore().Debug("Received EVENT message", "relay", rc.URL, "sub_id", subID)
+			clog().Debug("Received EVENT message", "relay", rc.URL, "sub_id", subID)
 			rc.messageRouter.RouteMessage(subID, "EVENT", eventData, rc.URL) // Pass relay URL
 		}
 	case "EOSE":
@@ -588,7 +587,7 @@ func (rc *RelayConnection) processMessage(message string) error {
 				return fmt.Errorf("invalid subscription ID in EOSE")
 			}
 
-			log.ClientCore().Debug("Received EOSE message", "relay", rc.URL, "sub_id", subID)
+			clog().Debug("Received EOSE message", "relay", rc.URL, "sub_id", subID)
 			rc.messageRouter.RouteMessage(subID, "EOSE", nil, rc.URL) // Pass relay URL
 		}
 	case "CLOSED":
@@ -598,7 +597,7 @@ func (rc *RelayConnection) processMessage(message string) error {
 				return fmt.Errorf("invalid subscription ID in CLOSED")
 			}
 
-			log.ClientCore().Debug("Received CLOSED message", "relay", rc.URL, "sub_id", subID)
+			clog().Debug("Received CLOSED message", "relay", rc.URL, "sub_id", subID)
 			rc.messageRouter.RouteMessage(subID, "CLOSED", nil, rc.URL) // Pass relay URL
 		}
 	case "NOTICE":
@@ -607,7 +606,7 @@ func (rc *RelayConnection) processMessage(message string) error {
 			if !ok {
 				notice = "unknown notice"
 			}
-			log.ClientCore().Info("Relay notice", "relay", rc.URL, "notice", notice)
+			clog().Info("Relay notice", "relay", rc.URL, "notice", notice)
 		}
 	case "OK":
 		// NIP-20: ["OK", <event-id>, <accepted bool>, <reason string>]
@@ -618,7 +617,7 @@ func (rc *RelayConnection) processMessage(message string) error {
 			if len(messageArray) >= 4 {
 				reason, _ = messageArray[3].(string)
 			}
-			log.ClientCore().Debug("Received OK message", "relay", rc.URL, "accepted", accepted, "reason", reason)
+			clog().Debug("Received OK message", "relay", rc.URL, "accepted", accepted, "reason", reason)
 			rc.messageRouter.RouteOK(eventID, OKResult{Relay: rc.URL, Accepted: accepted, Reason: reason})
 		}
 	case "AUTH":
@@ -626,12 +625,12 @@ func (rc *RelayConnection) processMessage(message string) error {
 		// the relay manager can surface it and the browser signer can answer it.
 		if len(messageArray) >= 2 {
 			if challenge, ok := messageArray[1].(string); ok && challenge != "" {
-				log.ClientCore().Debug("Received AUTH challenge", "relay", rc.URL)
+				clog().Debug("Received AUTH challenge", "relay", rc.URL)
 				rc.messageRouter.RouteAuth(rc.URL, challenge)
 			}
 		}
 	default:
-		log.ClientCore().Debug("Unknown message type", "relay", rc.URL, "type", messageType)
+		clog().Debug("Unknown message type", "relay", rc.URL, "type", messageType)
 	}
 
 	return nil
@@ -642,13 +641,13 @@ func parseEventFromData(data map[string]interface{}) *nostr.Event {
 	// Convert the map to JSON and back to parse properly
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		log.ClientCore().Error("Failed to marshal event data", "error", err)
+		clog().Error("Failed to marshal event data", "error", err)
 		return nil
 	}
 
 	var event nostr.Event
 	if err := json.Unmarshal(jsonData, &event); err != nil {
-		log.ClientCore().Error("Failed to unmarshal event", "error", err)
+		clog().Error("Failed to unmarshal event", "error", err)
 		return nil
 	}
 

--- a/client/core/relays.go
+++ b/client/core/relays.go
@@ -28,6 +28,17 @@ type RelayPool struct {
 	mu            sync.RWMutex
 	config        *Config
 	messageRouter *MessageRouter
+
+	// Outbox-pool lifecycle (#56). All guarded by mu except dialSem.
+	pinned    map[string]bool          // never idle-evicted (index/seed relays)
+	backoff   map[string]time.Time     // url -> earliest next dial attempt
+	failCount map[string]int           // url -> consecutive dial failures
+	dialing   map[string]chan struct{} // single-flight: in-progress dials, closed on completion
+	dialSem   chan struct{}            // bounds concurrent dials (held without mu)
+
+	// Test seams; NewRelayPool wires the real implementations.
+	dialFn      func(url string, timeout time.Duration) (*websocket.Conn, error)
+	startReader func(rc *RelayConnection)
 }
 
 // RelayConnection represents a single relay connection
@@ -42,6 +53,12 @@ type RelayConnection struct {
 	done          chan struct{}
 	closeOnce     sync.Once      // guards exactly-one close of done (#94)
 	messageRouter *MessageRouter // Add message router
+
+	// Lease accounting for the outbox pool (#56), guarded by mu. leases is the
+	// number of active Acquire holders; at zero the connection is idle-evictable
+	// and idleAt marks when it went idle.
+	leases int
+	idleAt time.Time
 }
 
 // MessageRouter handles routing messages to subscriptions
@@ -115,11 +132,28 @@ func (mr *MessageRouter) RouteMessage(subID string, messageType string, data int
 
 // NewRelayPool creates a new relay pool
 func NewRelayPool(config *Config) *RelayPool {
-	return &RelayPool{
+	dialConcurrency := config.DialConcurrency
+	if dialConcurrency <= 0 {
+		dialConcurrency = 16
+	}
+
+	rp := &RelayPool{
 		connections:   make(map[string]*RelayConnection),
 		config:        config,
 		messageRouter: NewMessageRouter(),
+		pinned:        make(map[string]bool),
+		backoff:       make(map[string]time.Time),
+		failCount:     make(map[string]int),
+		dialing:       make(map[string]chan struct{}),
+		dialSem:       make(chan struct{}, dialConcurrency),
 	}
+	// Real implementations; tests overwrite these seams before calling Acquire.
+	rp.dialFn = realDial
+	rp.startReader = func(rc *RelayConnection) {
+		go rc.writeHandler()
+		go rc.readHandler()
+	}
+	return rp
 }
 
 // Connect establishes a connection to a relay

--- a/client/core/relayurl.go
+++ b/client/core/relayurl.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"net/url"
+	"strings"
+)
+
+// normalizeRelayURL canonicalises a relay URL for deduplication. It repairs and
+// normalises the scheme (bare hosts default to wss; http(s)→ws(s); single-slash
+// typos like "ws:/host" are fixed), lowercases the host, and strips a trailing
+// slash. ws and wss are kept distinct — they are different transports, not typos
+// of each other. Returns ("", false) for input with no usable host.
+//
+// Relay lists in the wild are messy (mistyped schemes, trailing slashes, mixed
+// case), so every relay URL entering the directory or the pool goes through here
+// to keep the "known" / connection sets free of near-duplicates.
+func normalizeRelayURL(raw string) (string, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", false
+	}
+
+	scheme := "wss"
+	lower := strings.ToLower(s)
+	// Longest / most-specific prefixes first so "wss://" wins over "wss:".
+	for _, p := range []struct{ prefix, sch string }{
+		{"wss://", "wss"}, {"ws://", "ws"},
+		{"https://", "wss"}, {"http://", "ws"},
+		{"wss:/", "wss"}, {"ws:/", "ws"},
+		{"wss:", "wss"}, {"ws:", "ws"},
+	} {
+		if strings.HasPrefix(lower, p.prefix) {
+			scheme = p.sch
+			s = s[len(p.prefix):]
+			break
+		}
+	}
+	s = strings.TrimLeft(s, "/") // drop any stray leading slashes left by a typo
+
+	u, err := url.Parse(scheme + "://" + s)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.Fragment = ""
+	return u.String(), true
+}
+
+// normalizeRelayURLs normalises a list, dropping invalid entries and duplicates
+// while preserving first-seen order.
+func normalizeRelayURLs(raw []string) []string {
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		n, ok := normalizeRelayURL(r)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}

--- a/client/core/relayurl_test.go
+++ b/client/core/relayurl_test.go
@@ -1,0 +1,48 @@
+package core
+
+import "testing"
+
+func TestNormalizeRelayURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"wss://relay.example.com", "wss://relay.example.com", true},
+		{"wss://relay.example.com/", "wss://relay.example.com", true},  // trailing slash
+		{"relay.example.com", "wss://relay.example.com", true},         // bare host → wss
+		{"WSS://Relay.Example.COM/", "wss://relay.example.com", true},  // case
+		{"ws://localhost:8080", "ws://localhost:8080", true},           // ws preserved
+		{"ws:/relay.example.com", "ws://relay.example.com", true},      // single-slash typo
+		{"https://relay.example.com", "wss://relay.example.com", true}, // http(s)→ws(s)
+		{"http://localhost:7777", "ws://localhost:7777", true},
+		{"  wss://relay.example.com  ", "wss://relay.example.com", true},          // whitespace
+		{"wss://relay.example.com/nostr/", "wss://relay.example.com/nostr", true}, // keep path
+		{"", "", false},
+		{"wss://", "", false}, // no host
+	}
+	for _, c := range cases {
+		got, ok := normalizeRelayURL(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("normalizeRelayURL(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// The same relay written three ways collapses to one.
+func TestNormalizeRelayURLsDedupes(t *testing.T) {
+	got := normalizeRelayURLs([]string{
+		"wss://relay.example.com",
+		"wss://relay.example.com/",
+		"relay.example.com",
+		"WSS://RELAY.EXAMPLE.COM",
+		"", // dropped
+		"ws://other.example.com",
+	})
+	if len(got) != 2 {
+		t.Fatalf("want 2 distinct relays, got %v", got)
+	}
+	if got[0] != "wss://relay.example.com" || got[1] != "ws://other.example.com" {
+		t.Fatalf("unexpected normalization/order: %v", got)
+	}
+}

--- a/client/core/role.go
+++ b/client/core/role.go
@@ -1,0 +1,137 @@
+package core
+
+import "strings"
+
+// Role identifies the function a relay serves for a user under the outbox model.
+// Roles fall into three classes (see docs/design/outbox-relay-pool.md §3):
+//
+//   - Per-target, event-derived: [RoleOutbox], [RoleInbox], [RoleDMInbox] —
+//     resolved from the *target* user's published NIP-65 / NIP-17 lists.
+//   - Self-only, event-derived: [RoleSearch], [RoleBlocked], [RoleFavorite],
+//     [RolePrivateHome] — the logged-in user's own NIP-51 / NIP-37 lists.
+//   - Locally configured: [RoleIndexer], [RoleBroadcast], [RoleProxy],
+//     [RoleLocal], [RoleTrusted] — app config, applied across every user you
+//     interact with.
+//
+// A relay may hold several roles at once (a relay can be both your outbox and
+// your inbox), so Role is a bitmask: combine with | and test with [Role.Has].
+type Role uint16
+
+const (
+	RoleOutbox      Role = 1 << iota // NIP-65 write (10002): you publish here; others fetch your notes here
+	RoleInbox                        // NIP-65 read (10002): replies, mentions, and zaps reach you here
+	RoleDMInbox                      // NIP-17 (10050): encrypted direct messages are delivered here
+	RoleSearch                       // NIP-51 (10007): relays queried for NIP-50 search
+	RoleBlocked                      // NIP-51 (10006): never dialed
+	RoleFavorite                     // NIP-51 (10012): surfaced in UI; no routing effect
+	RolePrivateHome                  // NIP-37 (10013, NIP-44 encrypted): relays for private content
+	RoleIndexer                      // local config: seeds for resolving anyone's metadata / relay lists
+	RoleBroadcast                    // local config: fan-out relays ("event blasters"); writes mirror here
+	RoleProxy                        // local config: aggregator; when set, short-circuits outbox routing
+	RoleLocal                        // local config: same-device / LAN relays, preferred for latency
+	RoleTrusted                      // local config: relays the client will sign NIP-42 AUTH challenges for
+)
+
+// roleNames pairs each single-bit role with a stable lowercase name, in bit
+// order, for [Role.String].
+var roleNames = []struct {
+	role Role
+	name string
+}{
+	{RoleOutbox, "outbox"},
+	{RoleInbox, "inbox"},
+	{RoleDMInbox, "dm-inbox"},
+	{RoleSearch, "search"},
+	{RoleBlocked, "blocked"},
+	{RoleFavorite, "favorite"},
+	{RolePrivateHome, "private-home"},
+	{RoleIndexer, "indexer"},
+	{RoleBroadcast, "broadcast"},
+	{RoleProxy, "proxy"},
+	{RoleLocal, "local"},
+	{RoleTrusted, "trusted"},
+}
+
+// Has reports whether r includes every bit of x (and x is non-zero). For a
+// single-bit role this is a plain membership test; for a combination it checks
+// that all of x's roles are present.
+func (r Role) Has(x Role) bool { return x != 0 && r&x == x }
+
+// String renders the set roles as a "|"-joined list (e.g. "outbox|inbox"), or
+// "none" when no bits are set. Intended for logs and inspection, not parsing.
+func (r Role) String() string {
+	if r == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(roleNames))
+	for _, rn := range roleNames {
+		if r&rn.role != 0 {
+			parts = append(parts, rn.name)
+		}
+	}
+	return strings.Join(parts, "|")
+}
+
+// RoleForListKind maps a replaceable relay-list event kind to the role(s) its
+// `relay`/`r` entries carry — e.g. 10002 → RoleOutbox|RoleInbox (the read/write
+// split is per-entry markers), 10050 → RoleDMInbox. ok is false for kinds that
+// are not relay lists.
+func RoleForListKind(kind int) (role Role, ok bool) {
+	switch kind {
+	case 10002:
+		return RoleOutbox | RoleInbox, true
+	case 10050:
+		return RoleDMInbox, true
+	case 10006:
+		return RoleBlocked, true
+	case 10007:
+		return RoleSearch, true
+	case 10012:
+		return RoleFavorite, true
+	case 10013:
+		return RolePrivateHome, true
+	}
+	return 0, false
+}
+
+// ForRole returns the resolved per-target relays carrying the given role:
+// [RoleOutbox], [RoleInbox], or [RoleDMInbox]. Any other role returns nil — the
+// rest are self-only or locally configured, not part of a per-target resolution.
+func (ur *UserRelays) ForRole(role Role) []string {
+	if ur == nil {
+		return nil
+	}
+	switch role {
+	case RoleOutbox:
+		return ur.Outbox
+	case RoleInbox:
+		return ur.Inbox
+	case RoleDMInbox:
+		return ur.DMInbox
+	}
+	return nil
+}
+
+// RouteOp names a read-routing intent so a caller can inspect which relays an
+// operation would use, via [Client.Route], without performing it.
+type RouteOp int
+
+const (
+	OpFetchNotes    RouteOp = iota // a user's authored events → their outbox (NIP-65 write)
+	OpFetchMetadata                // profile / relay lists → indexers (+ cached outbox)
+)
+
+// Route returns the relays a read operation against target would use under the
+// current routing, honouring the fixed-relay override. It is a thin, inspectable
+// facade over [Client.RouteFetch] / [Client.RouteMetadata].
+//
+// Publishing is intentionally not covered here: it routes per-event (author
+// outbox ∪ each recipient's inbox), so use [Client.RoutePublish] with the event.
+func (c *Client) Route(op RouteOp, target string) []string {
+	switch op {
+	case OpFetchMetadata:
+		return c.RouteMetadata(target)
+	default:
+		return c.RouteFetch(target)
+	}
+}

--- a/client/core/role_test.go
+++ b/client/core/role_test.go
@@ -1,0 +1,96 @@
+package core
+
+import "testing"
+
+func TestRoleHas(t *testing.T) {
+	combo := RoleOutbox | RoleInbox
+	if !combo.Has(RoleOutbox) {
+		t.Error("combo should have RoleOutbox")
+	}
+	if !combo.Has(RoleInbox) {
+		t.Error("combo should have RoleInbox")
+	}
+	if !combo.Has(RoleOutbox | RoleInbox) {
+		t.Error("combo should have both bits")
+	}
+	if combo.Has(RoleDMInbox) {
+		t.Error("combo should not have RoleDMInbox")
+	}
+	if combo.Has(RoleOutbox | RoleDMInbox) {
+		t.Error("Has must require ALL bits, not any")
+	}
+	if (RoleOutbox).Has(0) {
+		t.Error("Has(0) must be false")
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	cases := map[Role]string{
+		0:                        "none",
+		RoleOutbox:               "outbox",
+		RoleOutbox | RoleInbox:   "outbox|inbox",
+		RoleDMInbox:              "dm-inbox",
+		RoleTrusted:              "trusted",
+		RoleSearch | RoleProxy:   "search|proxy",
+		RoleOutbox | RoleTrusted: "outbox|trusted",
+	}
+	for r, want := range cases {
+		if got := r.String(); got != want {
+			t.Errorf("Role(%d).String() = %q, want %q", uint16(r), got, want)
+		}
+	}
+	// String renders in bit order regardless of how the mask was composed.
+	if got := (RoleInbox | RoleOutbox).String(); got != "outbox|inbox" {
+		t.Errorf("bit-order render = %q, want %q", got, "outbox|inbox")
+	}
+}
+
+func TestRoleForListKind(t *testing.T) {
+	cases := []struct {
+		kind int
+		want Role
+		ok   bool
+	}{
+		{10002, RoleOutbox | RoleInbox, true},
+		{10050, RoleDMInbox, true},
+		{10006, RoleBlocked, true},
+		{10007, RoleSearch, true},
+		{10012, RoleFavorite, true},
+		{10013, RolePrivateHome, true},
+		{0, 0, false},
+		{1, 0, false},
+		{30002, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := RoleForListKind(c.kind)
+		if ok != c.ok || got != c.want {
+			t.Errorf("RoleForListKind(%d) = (%v, %v), want (%v, %v)", c.kind, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestUserRelaysForRole(t *testing.T) {
+	ur := &UserRelays{
+		Outbox:  []string{"wss://out"},
+		Inbox:   []string{"wss://in"},
+		DMInbox: []string{"wss://dm"},
+	}
+	if got := ur.ForRole(RoleOutbox); len(got) != 1 || got[0] != "wss://out" {
+		t.Errorf("ForRole(RoleOutbox) = %v", got)
+	}
+	if got := ur.ForRole(RoleInbox); len(got) != 1 || got[0] != "wss://in" {
+		t.Errorf("ForRole(RoleInbox) = %v", got)
+	}
+	if got := ur.ForRole(RoleDMInbox); len(got) != 1 || got[0] != "wss://dm" {
+		t.Errorf("ForRole(RoleDMInbox) = %v", got)
+	}
+	// Self-only / local roles aren't part of a per-target resolution.
+	if got := ur.ForRole(RoleSearch); got != nil {
+		t.Errorf("ForRole(RoleSearch) = %v, want nil", got)
+	}
+	// nil receiver is safe.
+	var nilUR *UserRelays
+	if got := nilUR.ForRole(RoleOutbox); got != nil {
+		t.Errorf("nil.ForRole = %v, want nil", got)
+	}
+}

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -5,6 +5,13 @@ import (
 	"github.com/0ceanslim/grain/server/utils/log"
 )
 
+// isMetadataKind reports whether an event kind is the sort that lives on the
+// indexer relays for everyone to fetch: profile metadata (NIP-01 kind 0) and
+// the relay-list events (NIP-65 10002, NIP-17 10050).
+func isMetadataKind(kind int) bool {
+	return kind == 0 || kind == 10002 || kind == 10050
+}
+
 // pTaggedPubkeys returns the distinct pubkeys referenced by the event's `p`
 // tags, in order — the recipients a reply / mention / DM is directed at.
 func pTaggedPubkeys(event *nostr.Event) []string {
@@ -68,6 +75,13 @@ func (c *Client) RoutePublish(event *nostr.Event) []string {
 	}
 
 	relays := append([]string(nil), c.ResolveRelays(event.PubKey).Outbox...)
+
+	// Profile metadata (kind 0) and relay lists (10002 / 10050) belong on the
+	// indexer relays too — that's where clients fetch them for arbitrary users,
+	// so a profile update must reach the indexers, not just the author's outbox.
+	if isMetadataKind(event.Kind) {
+		relays = appendUnique(relays, c.config.IndexRelays)
+	}
 
 	for _, pk := range pTaggedPubkeys(event) {
 		if pk == event.PubKey {

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -40,7 +40,7 @@ func (c *Client) RouteFetch(pubkey string) []string {
 	if ur := c.ResolveRelays(pubkey); len(ur.Outbox) > 0 {
 		return ur.Outbox
 	}
-	return c.config.IndexRelays
+	return c.indexRelays()
 }
 
 // RouteMetadata returns the relays to fetch a user's profile/metadata (kind 0)
@@ -57,7 +57,7 @@ func (c *Client) RouteMetadata(pubkey string) []string {
 	if fixed, read := c.fixedReads(); fixed {
 		return read
 	}
-	relays := append([]string(nil), c.config.IndexRelays...)
+	relays := append([]string(nil), c.indexRelays()...)
 	if ur, ok := c.directory.Cached(pubkey); ok {
 		relays = appendUnique(relays, ur.Outbox)
 	}
@@ -80,7 +80,7 @@ func (c *Client) RoutePublish(event *nostr.Event) []string {
 	// indexer relays too — that's where clients fetch them for arbitrary users,
 	// so a profile update must reach the indexers, not just the author's outbox.
 	if isMetadataKind(event.Kind) {
-		relays = appendUnique(relays, c.config.IndexRelays)
+		relays = appendUnique(relays, c.indexRelays())
 	}
 
 	for _, pk := range pTaggedPubkeys(event) {
@@ -95,8 +95,12 @@ func (c *Client) RoutePublish(event *nostr.Event) []string {
 		relays = appendUnique(relays, inbox)
 	}
 
+	// Mirror writes to the session's broadcast relays ("event blasters"), if set,
+	// so a post fans out beyond the author's own outbox.
+	relays = appendUnique(relays, c.AppRelays(RoleBroadcast))
+
 	if len(relays) == 0 {
-		relays = c.config.IndexRelays
+		relays = c.indexRelays()
 	}
 	return relays
 }
@@ -147,7 +151,7 @@ func (c *Client) fixedReads() (bool, []string) {
 	if len(c.fixedRead) > 0 {
 		return true, append([]string(nil), c.fixedRead...)
 	}
-	return true, append([]string(nil), c.config.IndexRelays...)
+	return true, append([]string(nil), c.indexRelays()...)
 }
 
 // fixedWrites is the write-side counterpart of fixedReads.
@@ -160,5 +164,5 @@ func (c *Client) fixedWrites() (bool, []string) {
 	if len(c.fixedWrite) > 0 {
 		return true, append([]string(nil), c.fixedWrite...)
 	}
-	return true, append([]string(nil), c.config.IndexRelays...)
+	return true, append([]string(nil), c.indexRelays()...)
 }

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// pTaggedPubkeys returns the distinct pubkeys referenced by the event's `p`
+// tags, in order — the recipients a reply / mention / DM is directed at.
+func pTaggedPubkeys(event *nostr.Event) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, tag := range event.Tags {
+		if len(tag) >= 2 && tag[0] == "p" && tag[1] != "" {
+			if _, ok := seen[tag[1]]; ok {
+				continue
+			}
+			seen[tag[1]] = struct{}{}
+			out = append(out, tag[1])
+		}
+	}
+	return out
+}
+
+// RouteFetch returns the relays to read a user's authored events from: their
+// outbox (NIP-65 write) relays, falling back to the index/seed relays when the
+// user has no published list.
+func (c *Client) RouteFetch(pubkey string) []string {
+	if ur := c.ResolveRelays(pubkey); len(ur.Outbox) > 0 {
+		return ur.Outbox
+	}
+	return c.config.IndexRelays
+}
+
+// RoutePublish returns the relays an event should be published to under the
+// outbox model: the author's own outbox PLUS every p-tagged recipient's inbox
+// (their DM inbox for NIP-17 gift wraps), so the event reaches both the
+// author's audience and its intended recipients. Falls back to the index/seed
+// relays when nothing resolves.
+func (c *Client) RoutePublish(event *nostr.Event) []string {
+	relays := append([]string(nil), c.ResolveRelays(event.PubKey).Outbox...)
+
+	for _, pk := range pTaggedPubkeys(event) {
+		if pk == event.PubKey {
+			continue
+		}
+		ur := c.ResolveRelays(pk)
+		inbox := ur.Inbox
+		if event.Kind == 1059 && len(ur.DMInbox) > 0 { // NIP-17 gift wrap → DM inbox
+			inbox = ur.DMInbox
+		}
+		relays = appendUnique(relays, inbox)
+	}
+
+	if len(relays) == 0 {
+		relays = c.config.IndexRelays
+	}
+	return relays
+}

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // isMetadataKind reports whether an event kind is the sort that lives on the
@@ -117,7 +116,7 @@ func (c *Client) SetFixedRelays(readRelays, writeRelays []string) {
 	c.fixedRead = append([]string(nil), readRelays...)
 	c.fixedWrite = append([]string(nil), writeRelays...)
 	c.mu.Unlock()
-	log.ClientCore().Warn("Fixed-relay override enabled — outbox routing disabled for this client",
+	clog().Warn("Fixed-relay override enabled — outbox routing disabled for this client",
 		"read_relays", len(readRelays), "write_relays", len(writeRelays))
 }
 
@@ -128,7 +127,7 @@ func (c *Client) ClearFixedRelays() {
 	c.fixedRead = nil
 	c.fixedWrite = nil
 	c.mu.Unlock()
-	log.ClientCore().Info("Fixed-relay override cleared — outbox routing restored")
+	clog().Info("Fixed-relay override cleared — outbox routing restored")
 }
 
 // FixedRelaysEnabled reports whether the fixed-relay override is active.

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -36,6 +36,27 @@ func (c *Client) RouteFetch(pubkey string) []string {
 	return c.config.IndexRelays
 }
 
+// RouteMetadata returns the relays to fetch a user's profile/metadata (kind 0)
+// and replaceable lists from.
+//
+// Flow: the index/profile-indexer relays aggregate everyone's metadata and are
+// already connected, so they are always queried (fast, reliable). The user's
+// own outbox often carries a fresher copy, so it is added too — but only when
+// it is ALREADY cached, never via a blocking resolve. Resolving every profile
+// view synchronously is what made the dashboard crawl; the cache is warmed by
+// the relay-list lookups that happen anyway, so subsequent views include the
+// outbox for free. Honours the fixed-relay override.
+func (c *Client) RouteMetadata(pubkey string) []string {
+	if fixed, read := c.fixedReads(); fixed {
+		return read
+	}
+	relays := append([]string(nil), c.config.IndexRelays...)
+	if ur, ok := c.directory.Cached(pubkey); ok {
+		relays = appendUnique(relays, ur.Outbox)
+	}
+	return relays
+}
+
 // RoutePublish returns the relays an event should be published to under the
 // outbox model: the author's own outbox PLUS every p-tagged recipient's inbox
 // (their DM inbox for NIP-17 gift wraps), so the event reaches both the

--- a/client/core/routing.go
+++ b/client/core/routing.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // pTaggedPubkeys returns the distinct pubkeys referenced by the event's `p`
@@ -23,8 +24,12 @@ func pTaggedPubkeys(event *nostr.Event) []string {
 
 // RouteFetch returns the relays to read a user's authored events from: their
 // outbox (NIP-65 write) relays, falling back to the index/seed relays when the
-// user has no published list.
+// user has no published list. If the fixed-relay override is enabled, the
+// pinned read set is used instead (outbox routing off).
 func (c *Client) RouteFetch(pubkey string) []string {
+	if fixed, read := c.fixedReads(); fixed {
+		return read
+	}
 	if ur := c.ResolveRelays(pubkey); len(ur.Outbox) > 0 {
 		return ur.Outbox
 	}
@@ -37,6 +42,10 @@ func (c *Client) RouteFetch(pubkey string) []string {
 // author's audience and its intended recipients. Falls back to the index/seed
 // relays when nothing resolves.
 func (c *Client) RoutePublish(event *nostr.Event) []string {
+	if fixed, write := c.fixedWrites(); fixed {
+		return write
+	}
+
 	relays := append([]string(nil), c.ResolveRelays(event.PubKey).Outbox...)
 
 	for _, pk := range pTaggedPubkeys(event) {
@@ -55,4 +64,66 @@ func (c *Client) RoutePublish(event *nostr.Event) []string {
 		relays = c.config.IndexRelays
 	}
 	return relays
+}
+
+// SetFixedRelays enables the fixed-relay override: every read uses readRelays
+// and every write uses writeRelays, bypassing outbox routing entirely.
+//
+// This DISABLES the outbox model — replies will not reach other users' inbox
+// relays — and is intended only for users who explicitly want a fixed- or
+// single-relay client. It is off by default and not recommended.
+func (c *Client) SetFixedRelays(readRelays, writeRelays []string) {
+	c.mu.Lock()
+	c.fixedMode = true
+	c.fixedRead = append([]string(nil), readRelays...)
+	c.fixedWrite = append([]string(nil), writeRelays...)
+	c.mu.Unlock()
+	log.ClientCore().Warn("Fixed-relay override enabled — outbox routing disabled for this client",
+		"read_relays", len(readRelays), "write_relays", len(writeRelays))
+}
+
+// ClearFixedRelays disables the override and restores default outbox routing.
+func (c *Client) ClearFixedRelays() {
+	c.mu.Lock()
+	c.fixedMode = false
+	c.fixedRead = nil
+	c.fixedWrite = nil
+	c.mu.Unlock()
+	log.ClientCore().Info("Fixed-relay override cleared — outbox routing restored")
+}
+
+// FixedRelaysEnabled reports whether the fixed-relay override is active.
+func (c *Client) FixedRelaysEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.fixedMode
+}
+
+// fixedReads returns the pinned read set when the override is on (a copy, so the
+// lock isn't held during routing). The boolean reports whether the override is
+// active. An empty pinned set falls back to index relays — never to outbox,
+// since the whole point of the override is to stay off the outbox model.
+func (c *Client) fixedReads() (bool, []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.fixedMode {
+		return false, nil
+	}
+	if len(c.fixedRead) > 0 {
+		return true, append([]string(nil), c.fixedRead...)
+	}
+	return true, append([]string(nil), c.config.IndexRelays...)
+}
+
+// fixedWrites is the write-side counterpart of fixedReads.
+func (c *Client) fixedWrites() (bool, []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.fixedMode {
+		return false, nil
+	}
+	if len(c.fixedWrite) > 0 {
+		return true, append([]string(nil), c.fixedWrite...)
+	}
+	return true, append([]string(nil), c.config.IndexRelays...)
 }

--- a/client/core/routing_test.go
+++ b/client/core/routing_test.go
@@ -124,6 +124,22 @@ func TestFixedRelaysOverrideRouting(t *testing.T) {
 // outbox when it's already cached — never a blocking resolve (the dashboard
 // slowdown). This keeps profile views fast while still preferring the user's
 // own relays once we know them.
+// Publishing a profile (kind 0) must reach the indexers in addition to the
+// author's own outbox; a plain note (kind 1) must not blanket the indexers.
+func TestRoutePublishMetadataHitsIndexers(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"me": {Outbox: []string{"wss://my-out"}},
+	})
+
+	profile := c.RoutePublish(&nostr.Event{PubKey: "me", Kind: 0})
+	assertHasRelay(t, profile, "wss://my-out")
+	assertHasRelay(t, profile, c.config.IndexRelays[0])
+
+	note := c.RoutePublish(&nostr.Event{PubKey: "me", Kind: 1})
+	assertHasRelay(t, note, "wss://my-out")
+	assertNotContains(t, note, c.config.IndexRelays[0])
+}
+
 func TestRouteMetadataIndexPlusCachedOutbox(t *testing.T) {
 	c := newClientWithStubDirectory(map[string]*UserRelays{
 		"known": {Outbox: []string{"wss://known-out"}},

--- a/client/core/routing_test.go
+++ b/client/core/routing_test.go
@@ -119,3 +119,24 @@ func TestFixedRelaysOverrideRouting(t *testing.T) {
 	assertHasRelay(t, got, "wss://my-out")
 	assertHasRelay(t, got, "wss://your-in")
 }
+
+// Profile/metadata routing queries the index relays and only adds a user's
+// outbox when it's already cached — never a blocking resolve (the dashboard
+// slowdown). This keeps profile views fast while still preferring the user's
+// own relays once we know them.
+func TestRouteMetadataIndexPlusCachedOutbox(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"known": {Outbox: []string{"wss://known-out"}},
+	})
+
+	// Uncached user → index relays only, outbox not pulled in (no resolve).
+	got := c.RouteMetadata("stranger")
+	assertHasRelay(t, got, c.config.IndexRelays[0])
+	assertNotContains(t, got, "wss://known-out")
+
+	// Warm the cache, then the outbox is included alongside the indexers.
+	c.directory.Lookup("known")
+	got = c.RouteMetadata("known")
+	assertHasRelay(t, got, c.config.IndexRelays[0])
+	assertHasRelay(t, got, "wss://known-out")
+}

--- a/client/core/routing_test.go
+++ b/client/core/routing_test.go
@@ -82,3 +82,40 @@ func TestRoutePublishFallsBackToIndex(t *testing.T) {
 		t.Fatalf("RoutePublish with nothing resolved should fall back to index, got %v", got)
 	}
 }
+
+func TestFixedRelaysOffByDefault(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{})
+	if c.FixedRelaysEnabled() {
+		t.Fatal("fixed-relay override must be OFF by default")
+	}
+}
+
+// The fixed-relay opt-out replaces outbox routing entirely: reads use the
+// pinned read set and writes use the pinned write set, ignoring the directory.
+func TestFixedRelaysOverrideRouting(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"me":  {Outbox: []string{"wss://my-out"}},
+		"you": {Inbox: []string{"wss://your-in"}},
+	})
+
+	c.SetFixedRelays([]string{"wss://only-read"}, []string{"wss://only-write"})
+
+	if got := c.RouteFetch("you"); len(got) != 1 || got[0] != "wss://only-read" {
+		t.Fatalf("fixed RouteFetch = %v, want [wss://only-read]", got)
+	}
+	reply := &nostr.Event{PubKey: "me", Kind: 1, Tags: [][]string{{"p", "you"}}}
+	got := c.RoutePublish(reply)
+	if len(got) != 1 || got[0] != "wss://only-write" {
+		t.Fatalf("fixed RoutePublish = %v, want [wss://only-write] (outbox disabled)", got)
+	}
+	assertNotContains(t, got, "wss://your-in") // outbox is OFF — recipient inbox not used
+
+	// Clearing restores outbox routing.
+	c.ClearFixedRelays()
+	if c.FixedRelaysEnabled() {
+		t.Fatal("override should be cleared")
+	}
+	got = c.RoutePublish(reply)
+	assertHasRelay(t, got, "wss://my-out")
+	assertHasRelay(t, got, "wss://your-in")
+}

--- a/client/core/routing_test.go
+++ b/client/core/routing_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// newClientWithStubDirectory builds a Client whose relay directory returns
+// canned UserRelays, so routing can be tested without any network.
+func newClientWithStubDirectory(relays map[string]*UserRelays) *Client {
+	c := NewClient(DefaultConfig())
+	c.directory = newRelayDirectory(time.Hour, time.Minute, func(pk string) *UserRelays {
+		if ur, ok := relays[pk]; ok {
+			return ur
+		}
+		return nil
+	})
+	return c
+}
+
+func assertNotContains(t *testing.T, urls []string, unwanted string) {
+	t.Helper()
+	for _, u := range urls {
+		if u == unwanted {
+			t.Fatalf("did not expect %q in %v", unwanted, urls)
+		}
+	}
+}
+
+func TestPTaggedPubkeys(t *testing.T) {
+	ev := &nostr.Event{Tags: [][]string{{"p", "a"}, {"e", "x"}, {"p", "b"}, {"p", "a"}}}
+	got := pTaggedPubkeys(ev)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("pTaggedPubkeys = %v, want [a b]", got)
+	}
+}
+
+func TestRouteFetchUsesOutboxThenIndex(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"author": {Outbox: []string{"wss://a-out"}},
+	})
+	if got := c.RouteFetch("author"); len(got) != 1 || got[0] != "wss://a-out" {
+		t.Fatalf("RouteFetch(author) = %v, want [wss://a-out]", got)
+	}
+	// Unknown user → index-relay fallback.
+	if got := c.RouteFetch("nobody"); len(got) == 0 || got[0] != c.config.IndexRelays[0] {
+		t.Fatalf("RouteFetch(nobody) should fall back to index relays, got %v", got)
+	}
+}
+
+// The crux of the outbox model: a reply goes to MY outbox AND the recipient's
+// inbox — so it both reaches my audience and lands where they read.
+func TestRoutePublishReplyHitsOwnOutboxAndTargetInbox(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"me":  {Outbox: []string{"wss://my-out"}},
+		"you": {Inbox: []string{"wss://your-in"}, Outbox: []string{"wss://your-out"}},
+	})
+	reply := &nostr.Event{PubKey: "me", Kind: 1, Tags: [][]string{{"p", "you"}}}
+	got := c.RoutePublish(reply)
+	assertHasRelay(t, got, "wss://my-out")      // my outbox
+	assertHasRelay(t, got, "wss://your-in")     // recipient's inbox
+	assertNotContains(t, got, "wss://your-out") // not their outbox
+}
+
+func TestRoutePublishGiftWrapHitsDMInbox(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{
+		"me":  {Outbox: []string{"wss://my-out"}},
+		"you": {Inbox: []string{"wss://your-in"}, DMInbox: []string{"wss://your-dm"}},
+	})
+	wrap := &nostr.Event{PubKey: "me", Kind: 1059, Tags: [][]string{{"p", "you"}}}
+	got := c.RoutePublish(wrap)
+	assertHasRelay(t, got, "wss://your-dm")    // NIP-17 → DM inbox
+	assertNotContains(t, got, "wss://your-in") // not the public inbox
+}
+
+func TestRoutePublishFallsBackToIndex(t *testing.T) {
+	c := newClientWithStubDirectory(map[string]*UserRelays{})
+	ev := &nostr.Event{PubKey: "me", Kind: 1}
+	if got := c.RoutePublish(ev); len(got) == 0 || got[0] != c.config.IndexRelays[0] {
+		t.Fatalf("RoutePublish with nothing resolved should fall back to index, got %v", got)
+	}
+}

--- a/client/core/seed.go
+++ b/client/core/seed.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+	"github.com/0ceanslim/grain/server/utils/log"
+)
+
+// FetchEvents collects up to limit distinct events (deduped by id) matching
+// filters from the given relays, returning when every relay has sent EOSE, the
+// limit is reached, or the timeout elapses. Unlike collectLatestReplaceable
+// (which keeps only the single newest), this gathers a batch — used for bulk
+// queries like relay-list seeding.
+func (c *Client) FetchEvents(filters []nostr.Filter, relays []string, limit int, timeout time.Duration) []*nostr.Event {
+	if len(relays) == 0 {
+		return nil
+	}
+
+	sub, err := c.Subscribe(filters, relays)
+	if err != nil {
+		log.ClientCore().Debug("FetchEvents subscribe failed", "error", err)
+		return nil
+	}
+	defer sub.Close()
+
+	seen := make(map[string]struct{})
+	eose := make(map[string]bool)
+	var events []*nostr.Event
+	deadline := time.After(timeout)
+
+	for {
+		select {
+		case ev := <-sub.Events:
+			if ev == nil {
+				continue
+			}
+			if _, dup := seen[ev.ID]; dup {
+				continue
+			}
+			seen[ev.ID] = struct{}{}
+			events = append(events, ev)
+			if limit > 0 && len(events) >= limit {
+				return events
+			}
+
+		case relayURL := <-sub.EOSE:
+			eose[relayURL] = true
+			if len(eose) >= len(relays) {
+				return events
+			}
+
+		case <-sub.Errors:
+			// One relay failing isn't fatal; keep collecting from the rest.
+
+		case <-deadline:
+			return events
+		}
+	}
+}
+
+// SeedKnownRelays bulk-fetches recent relay-list events (NIP-65 kind 10002 and
+// NIP-17 kind 10050) from the index relays and folds every advertised relay
+// into the directory, so the "known" set starts broad immediately instead of
+// growing only as the user browses. Runs once at startup; safe to re-run to
+// refresh. All relay URLs are normalised on the way in (see normalizeRelayURL),
+// so near-duplicates collapse.
+func (c *Client) SeedKnownRelays() {
+	relays := c.config.IndexRelays
+	if len(relays) == 0 {
+		return
+	}
+
+	const limit = 500
+	lim := limit
+	events := c.FetchEvents(
+		[]nostr.Filter{{Kinds: []int{10002, 10050}, Limit: &lim}},
+		relays, limit, 8*time.Second,
+	)
+
+	stored := 0
+	for _, ev := range events {
+		switch ev.Kind {
+		case 10002:
+			mb := parseMailboxEvent(ev)
+			c.directory.Store(ev.PubKey, &UserRelays{
+				Outbox: appendUnique(mb.Write, mb.Both),
+				Inbox:  appendUnique(mb.Read, mb.Both),
+			})
+			stored++
+		case 10050:
+			c.directory.Store(ev.PubKey, &UserRelays{DMInbox: parseDMRelays(ev)})
+			stored++
+		}
+	}
+
+	log.ClientCore().Info("Seeded known relays from indexers",
+		"events", len(events), "stored", stored, "known", c.PoolStats().Known)
+}

--- a/client/core/seed.go
+++ b/client/core/seed.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // FetchEvents collects up to limit distinct events (deduped by id) matching
@@ -20,7 +19,7 @@ func (c *Client) FetchEvents(ctx context.Context, filters []nostr.Filter, relays
 
 	sub, err := c.Subscribe(ctx, filters, relays)
 	if err != nil {
-		log.ClientCore().Debug("FetchEvents subscribe failed", "error", err)
+		clog().Debug("FetchEvents subscribe failed", "error", err)
 		return nil
 	}
 	defer sub.Close()
@@ -98,6 +97,6 @@ func (c *Client) SeedKnownRelays() {
 		}
 	}
 
-	log.ClientCore().Info("Seeded known relays from indexers",
+	clog().Info("Seeded known relays from indexers",
 		"events", len(events), "stored", stored, "known", c.PoolStats().Known)
 }

--- a/client/core/seed.go
+++ b/client/core/seed.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
@@ -12,12 +13,12 @@ import (
 // limit is reached, or the timeout elapses. Unlike collectLatestReplaceable
 // (which keeps only the single newest), this gathers a batch — used for bulk
 // queries like relay-list seeding.
-func (c *Client) FetchEvents(filters []nostr.Filter, relays []string, limit int, timeout time.Duration) []*nostr.Event {
+func (c *Client) FetchEvents(ctx context.Context, filters []nostr.Filter, relays []string, limit int, timeout time.Duration) []*nostr.Event {
 	if len(relays) == 0 {
 		return nil
 	}
 
-	sub, err := c.Subscribe(filters, relays)
+	sub, err := c.Subscribe(ctx, filters, relays)
 	if err != nil {
 		log.ClientCore().Debug("FetchEvents subscribe failed", "error", err)
 		return nil
@@ -53,6 +54,8 @@ func (c *Client) FetchEvents(filters []nostr.Filter, relays []string, limit int,
 		case <-sub.Errors:
 			// One relay failing isn't fatal; keep collecting from the rest.
 
+		case <-ctx.Done():
+			return events
 		case <-deadline:
 			return events
 		}
@@ -74,6 +77,7 @@ func (c *Client) SeedKnownRelays() {
 	const limit = 500
 	lim := limit
 	events := c.FetchEvents(
+		context.Background(),
 		[]nostr.Filter{{Kinds: []int{10002, 10050}, Limit: &lim}},
 		relays, limit, 8*time.Second,
 	)

--- a/client/core/seed.go
+++ b/client/core/seed.go
@@ -69,7 +69,7 @@ func (c *Client) FetchEvents(ctx context.Context, filters []nostr.Filter, relays
 // refresh. All relay URLs are normalised on the way in (see normalizeRelayURL),
 // so near-duplicates collapse.
 func (c *Client) SeedKnownRelays() {
-	relays := c.config.IndexRelays
+	relays := c.indexRelays()
 	if len(relays) == 0 {
 		return
 	}

--- a/client/core/sessionrelays.go
+++ b/client/core/sessionrelays.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"sort"
+	"sync"
+)
+
+// SessionRelays is a user's editable, role-tagged relay configuration for one
+// session — the set a downstream app reads and edits to inspect or steer
+// routing (design §4.3 / §11, "expose the pool + role assignments so callers
+// can read/edit them"). Each relay URL carries a [Role] bitmask. Safe for
+// concurrent use.
+//
+// It is a plain, in-memory container: a consumer seeds it from a user's
+// resolved event-derived roles and layers local overrides on top. Wiring edits
+// back into live routing is incremental — today the one override that affects
+// routing is the fixed-relay pin, exposed via [UserContext.PinFixedRelays].
+type SessionRelays struct {
+	mu    sync.RWMutex
+	roles map[string]Role
+}
+
+func newSessionRelays() *SessionRelays {
+	return &SessionRelays{roles: make(map[string]Role)}
+}
+
+// Set replaces the roles assigned to url. Passing the zero Role removes it.
+func (s *SessionRelays) Set(url string, roles Role) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if roles == 0 {
+		delete(s.roles, url)
+		return
+	}
+	s.roles[url] = roles
+}
+
+// Add OR-s roles onto url, keeping any it already holds.
+func (s *SessionRelays) Add(url string, roles Role) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.roles[url] |= roles
+}
+
+// Remove drops url and all of its roles.
+func (s *SessionRelays) Remove(url string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.roles, url)
+}
+
+// Get returns the roles assigned to url (the zero Role if absent).
+func (s *SessionRelays) Get(url string) Role {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.roles[url]
+}
+
+// ByRole returns the relay URLs carrying the given role, sorted for stability.
+func (s *SessionRelays) ByRole(role Role) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []string
+	for url, r := range s.roles {
+		if r&role != 0 {
+			out = append(out, url)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// All returns a snapshot copy of the full url→roles map.
+func (s *SessionRelays) All() map[string]Role {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]Role, len(s.roles))
+	for url, r := range s.roles {
+		out[url] = r
+	}
+	return out
+}

--- a/client/core/signer.go
+++ b/client/core/signer.go
@@ -37,8 +37,19 @@ type Encrypter interface {
 	NIP44Decrypt(peerPubKey, payload string) (string, error)
 }
 
-// The built-in local-key signer satisfies both seams.
+// EncrypterV3 is the optional NIP-44 v3 capability: encryption that additionally
+// binds an event kind and a scope string (cross-context replay protection +
+// signer access control). v3 is a draft proposal with few deployed peers, so
+// prefer [Encrypter] (v2) for interop; this exists so downstream consumers can
+// opt in. kind is a uint32; scope is a UTF-8 byte string (may be empty).
+type EncrypterV3 interface {
+	NIP44V3Encrypt(peerPubKey string, kind uint32, scope, plaintext []byte) (string, error)
+	NIP44V3Decrypt(peerPubKey string, expectedKind uint32, expectedScope []byte, payload string) ([]byte, error)
+}
+
+// The built-in local-key signer satisfies the seams.
 var (
-	_ Signer    = (*EventSigner)(nil)
-	_ Encrypter = (*EventSigner)(nil)
+	_ Signer      = (*EventSigner)(nil)
+	_ Encrypter   = (*EventSigner)(nil)
+	_ EncrypterV3 = (*EventSigner)(nil)
 )

--- a/client/core/signer.go
+++ b/client/core/signer.go
@@ -19,5 +19,26 @@ type Signer interface {
 	SignEvent(event *nostr.Event) error
 }
 
-// The built-in local-key signer satisfies the seam.
-var _ Signer = (*EventSigner)(nil)
+// Encrypter is an optional capability a Signer may also implement: NIP-44
+// payload encryption between the signer's key and a peer pubkey, used for
+// NIP-51 private list content, NIP-17 DMs, and similar. It mirrors the
+// nip44Encrypt/nip44Decrypt methods a NIP-07/NIP-46 browser signer exposes, so
+// the same calling code works whether the key lives in the browser or in a
+// downstream Go consumer's [EventSigner].
+//
+// peerPubKey is 64-char lowercase hex (x-only). For self-encryption (NIP-51
+// lists are encrypted to the author themselves) pass the signer's own pubkey.
+type Encrypter interface {
+	// NIP44Encrypt encrypts plaintext to peerPubKey, returning a base64 NIP-44
+	// payload (v2, the deployed standard).
+	NIP44Encrypt(peerPubKey, plaintext string) (string, error)
+	// NIP44Decrypt decrypts a base64 NIP-44 payload from peerPubKey, accepting
+	// any supported version.
+	NIP44Decrypt(peerPubKey, payload string) (string, error)
+}
+
+// The built-in local-key signer satisfies both seams.
+var (
+	_ Signer    = (*EventSigner)(nil)
+	_ Encrypter = (*EventSigner)(nil)
+)

--- a/client/core/signer.go
+++ b/client/core/signer.go
@@ -1,0 +1,23 @@
+package core
+
+import nostr "github.com/0ceanslim/grain/server/types"
+
+// Signer produces signatures for Nostr events on behalf of one pubkey. A library
+// consumer supplies a Signer to publish — a local key via [EventSigner], or their
+// own implementation (NIP-46 remote signer, hardware, HSM). Read-only callers
+// supply none.
+//
+// grain's own web client signs in the browser with the user's NIP-07 / NIP-46
+// signer, so grain's server side carries no Signer; this seam exists for
+// downstream Go consumers building a client on the library.
+type Signer interface {
+	// PublicKey returns the signer's public key as 64-char lowercase hex.
+	PublicKey() string
+	// SignEvent fills the event's PubKey, ID, and Sig fields in place: PubKey is
+	// set to PublicKey(), and Sig is a Schnorr signature over the NIP-01 id
+	// computed from the serialized event.
+	SignEvent(event *nostr.Event) error
+}
+
+// The built-in local-key signer satisfies the seam.
+var _ Signer = (*EventSigner)(nil)

--- a/client/core/signer_test.go
+++ b/client/core/signer_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"testing"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// Exercise EventSigner purely through the Signer seam: sign an event, then
+// verify it — the round-trip a library consumer relies on.
+func TestEventSignerSatisfiesSigner(t *testing.T) {
+	es, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatalf("NewEventSignerFromRandom: %v", err)
+	}
+
+	var s Signer = es // compile-time + runtime: EventSigner is a Signer
+
+	if len(s.PublicKey()) != 64 {
+		t.Fatalf("PublicKey() = %q, want 64 hex chars", s.PublicKey())
+	}
+
+	evt := &nostr.Event{Kind: 1, Content: "hello", CreatedAt: 1700000000}
+	if err := s.SignEvent(evt); err != nil {
+		t.Fatalf("SignEvent: %v", err)
+	}
+	if evt.PubKey != s.PublicKey() {
+		t.Errorf("SignEvent left PubKey = %q, want %q", evt.PubKey, s.PublicKey())
+	}
+	if evt.ID == "" || evt.Sig == "" {
+		t.Fatalf("SignEvent left ID=%q Sig=%q", evt.ID, evt.Sig)
+	}
+	if !VerifyEventSignature(evt) {
+		t.Error("VerifyEventSignature failed on a freshly signed event")
+	}
+}

--- a/client/core/subscribe_concurrency_test.go
+++ b/client/core/subscribe_concurrency_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestSubscribeDialsRelaysConcurrently(t *testing.T) {
 	relays := []string{"wss://r1", "wss://r2", "wss://r3", "wss://r4"}
 
 	start := time.Now()
-	sub, err := c.Subscribe([]nostr.Filter{{Kinds: []int{0}}}, relays)
+	sub, err := c.Subscribe(context.Background(), []nostr.Filter{{Kinds: []int{0}}}, relays)
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}

--- a/client/core/subscribe_concurrency_test.go
+++ b/client/core/subscribe_concurrency_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+	"golang.org/x/net/websocket"
+)
+
+// Subscribe must dial its target relays concurrently, so a handful of relays
+// (e.g. an author's outbox) come up in roughly one dial's time, not the sum —
+// and a slow/dead relay can't stall the others. Also asserts leases are taken
+// while active and fully released on Close.
+func TestSubscribeDialsRelaysConcurrently(t *testing.T) {
+	c := NewClient(DefaultConfig())
+	c.relayPool.dialFn = func(string, time.Duration) (*websocket.Conn, error) {
+		time.Sleep(150 * time.Millisecond) // simulate dial latency
+		return nil, nil
+	}
+	c.relayPool.startReader = func(*RelayConnection) {}
+
+	relays := []string{"wss://r1", "wss://r2", "wss://r3", "wss://r4"}
+
+	start := time.Now()
+	sub, err := c.Subscribe([]nostr.Filter{{Kinds: []int{0}}}, relays)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 450*time.Millisecond {
+		t.Fatalf("Subscribe took %s — dials look serial (4x150ms); should be concurrent (~150ms)", elapsed)
+	}
+
+	for _, r := range relays {
+		if l := leasesOf(c.relayPool, r); l != 1 {
+			t.Fatalf("relay %s leases = %d while active, want 1", r, l)
+		}
+	}
+
+	if err := sub.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	for _, r := range relays {
+		if l := leasesOf(c.relayPool, r); l != 0 {
+			t.Fatalf("relay %s leases after Close = %d, want 0", r, l)
+		}
+	}
+}

--- a/client/core/subscriptions.go
+++ b/client/core/subscriptions.go
@@ -60,23 +60,39 @@ func (s *Subscription) Start() error {
 		reqMessage = append(reqMessage, filter)
 	}
 
+	// Connect to all target relays CONCURRENTLY (bounded by the pool's dial
+	// semaphore) rather than one at a time, so a slow or dead relay in someone's
+	// outbox only costs its own dial timeout instead of stacking up serially
+	// behind the others. Each goroutine writes its own index, so no shared-write
+	// race; wg.Wait synchronises before we read the results.
+	connected := make([]bool, len(s.Relays))
+	var wg sync.WaitGroup
+	for i, relayURL := range s.Relays {
+		wg.Add(1)
+		go func(i int, url string) {
+			defer wg.Done()
+			if _, err := s.client.relayPool.Acquire(url); err != nil {
+				log.ClientCore().Debug("Failed to acquire relay for subscription", "relay", url, "sub_id", s.ID, "error", err)
+				return
+			}
+			connected[i] = true
+		}(i, relayURL)
+	}
+	wg.Wait()
+
+	// Fire the REQ to every relay that came up, holding its lease for the
+	// subscription's lifetime so it isn't idle-evicted out from under us.
 	var lastErr error
 	sent := 0
-
-	for _, relayURL := range s.Relays {
-		// Connect-on-demand and hold a lease for the subscription's lifetime so
-		// the connection isn't idle-evicted out from under an active sub.
-		if _, err := s.client.relayPool.Acquire(relayURL); err != nil {
-			log.ClientCore().Debug("Failed to acquire relay for subscription", "relay", relayURL, "sub_id", s.ID, "error", err)
-			lastErr = err
+	for i, relayURL := range s.Relays {
+		if !connected[i] {
 			continue
 		}
 		s.acquired = append(s.acquired, relayURL)
 
 		if err := s.client.relayPool.SendMessage(relayURL, reqMessage); err != nil {
-			// Demoted to Debug: races with upstream disconnect are
-			// normal flakiness, not grain bugs. The subscription's
-			// caller still sees the failure via the lastErr return.
+			// Demoted to Debug: races with upstream disconnect are normal
+			// flakiness, not grain bugs.
 			log.ClientCore().Debug("Failed to send subscription to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
 			lastErr = err
 			continue
@@ -124,27 +140,21 @@ func (s *Subscription) Close() error {
 	// Unregister from relay pool
 	s.client.relayPool.UnregisterSubscription(s.ID)
 
-	// Send CLOSE message to all relays
+	// Send CLOSE to, and release the lease on, each relay this subscription
+	// actually acquired (the connected subset — others never got a REQ). This
+	// also lets the connections be idle-evicted once nothing else needs them.
 	closeMessage := []interface{}{"CLOSE", s.ID}
-
-	for _, relayURL := range s.Relays {
+	for _, relayURL := range s.acquired {
 		if err := s.client.relayPool.SendMessage(relayURL, closeMessage); err != nil {
-			// Demoted to Debug: closing a sub on an already-disconnected
-			// relay is expected during teardown, not a problem.
+			// Demoted to Debug: closing a sub on an already-disconnected relay
+			// is expected during teardown, not a problem.
 			log.ClientCore().Debug("Failed to send close to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
 		}
-
-		// Remove subscription from relay
 		if conn, err := s.client.relayPool.GetConnection(relayURL); err == nil {
 			conn.mu.Lock()
 			delete(conn.Subscriptions, s.ID)
 			conn.mu.Unlock()
 		}
-	}
-
-	// Release the pool leases this subscription held so the connections can be
-	// idle-evicted once nothing else needs them.
-	for _, relayURL := range s.acquired {
 		s.client.relayPool.Release(relayURL)
 	}
 	s.acquired = nil

--- a/client/core/subscriptions.go
+++ b/client/core/subscriptions.go
@@ -5,7 +5,6 @@ import (
 	//"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
-	"github.com/0ceanslim/grain/server/utils/log"
 )
 
 // Subscription manages a Nostr subscription across multiple relays
@@ -49,7 +48,7 @@ func (s *Subscription) Start() error {
 		return &ClientError{Message: "subscription already active"}
 	}
 
-	log.ClientCore().Debug("Starting subscription", "sub_id", s.ID, "relay_count", len(s.Relays))
+	clog().Debug("Starting subscription", "sub_id", s.ID, "relay_count", len(s.Relays))
 
 	// Register with relay pool for message routing
 	s.client.relayPool.RegisterSubscription(s.ID, s)
@@ -72,7 +71,7 @@ func (s *Subscription) Start() error {
 		go func(i int, url string) {
 			defer wg.Done()
 			if _, err := s.client.relayPool.Acquire(url); err != nil {
-				log.ClientCore().Debug("Failed to acquire relay for subscription", "relay", url, "sub_id", s.ID, "error", err)
+				clog().Debug("Failed to acquire relay for subscription", "relay", url, "sub_id", s.ID, "error", err)
 				return
 			}
 			connected[i] = true
@@ -93,7 +92,7 @@ func (s *Subscription) Start() error {
 		if err := s.client.relayPool.SendMessage(relayURL, reqMessage); err != nil {
 			// Demoted to Debug: races with upstream disconnect are normal
 			// flakiness, not grain bugs.
-			log.ClientCore().Debug("Failed to send subscription to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
+			clog().Debug("Failed to send subscription to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
 			lastErr = err
 			continue
 		}
@@ -122,7 +121,7 @@ func (s *Subscription) Start() error {
 
 	// No need for processMessages goroutine - routing happens directly from readHandler
 
-	log.ClientCore().Info("Subscription started", "sub_id", s.ID, "sent_to", sent, "total_relays", len(s.Relays))
+	clog().Info("Subscription started", "sub_id", s.ID, "sent_to", sent, "total_relays", len(s.Relays))
 	return nil
 }
 
@@ -135,7 +134,7 @@ func (s *Subscription) Close() error {
 		return nil
 	}
 
-	log.ClientCore().Debug("Closing subscription", "sub_id", s.ID)
+	clog().Debug("Closing subscription", "sub_id", s.ID)
 
 	// Unregister from relay pool
 	s.client.relayPool.UnregisterSubscription(s.ID)
@@ -148,7 +147,7 @@ func (s *Subscription) Close() error {
 		if err := s.client.relayPool.SendMessage(relayURL, closeMessage); err != nil {
 			// Demoted to Debug: closing a sub on an already-disconnected relay
 			// is expected during teardown, not a problem.
-			log.ClientCore().Debug("Failed to send close to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
+			clog().Debug("Failed to send close to relay", "relay", relayURL, "sub_id", s.ID, "error", err)
 		}
 		if conn, err := s.client.relayPool.GetConnection(relayURL); err == nil {
 			conn.mu.Lock()
@@ -165,7 +164,7 @@ func (s *Subscription) Close() error {
 	close(s.Errors)
 	close(s.EOSE) // NEW: Close EOSE channel
 
-	log.ClientCore().Debug("Subscription closed", "sub_id", s.ID)
+	clog().Debug("Subscription closed", "sub_id", s.ID)
 	return nil
 }
 
@@ -214,7 +213,7 @@ func (s *Subscription) AddRelay(url string) error {
 		}
 	}
 
-	log.ClientCore().Debug("Relay added to subscription", "sub_id", s.ID, "relay", url)
+	clog().Debug("Relay added to subscription", "sub_id", s.ID, "relay", url)
 	return nil
 }
 
@@ -241,7 +240,7 @@ func (s *Subscription) RemoveRelay(url string) error {
 	if s.active {
 		closeMessage := []interface{}{"CLOSE", s.ID}
 		if err := s.client.relayPool.SendMessage(url, closeMessage); err != nil {
-			log.ClientCore().Warn("Failed to send close to removed relay", "relay", url, "sub_id", s.ID, "error", err)
+			clog().Warn("Failed to send close to removed relay", "relay", url, "sub_id", s.ID, "error", err)
 		}
 
 		// Remove subscription from relay
@@ -261,7 +260,7 @@ func (s *Subscription) RemoveRelay(url string) error {
 		}
 	}
 
-	log.ClientCore().Debug("Relay removed from subscription", "sub_id", s.ID, "relay", url)
+	clog().Debug("Relay removed from subscription", "sub_id", s.ID, "relay", url)
 	return nil
 }
 
@@ -276,11 +275,11 @@ func (s *Subscription) RemoveRelay(url string) error {
 //	for {
 //		select {
 //		case <-s.Done:
-//			log.ClientCore().Debug("Message processor stopped", "sub_id", s.ID)
+//			clog().Debug("Message processor stopped", "sub_id", s.ID)
 //			return
 //		case <-ticker.C:
 //			// Periodic heartbeat - could be used for subscription health checks
-//			log.ClientCore().Debug("Subscription heartbeat", "sub_id", s.ID)
+//			clog().Debug("Subscription heartbeat", "sub_id", s.ID)
 //		}
 //	}
 //}

--- a/client/core/subscriptions.go
+++ b/client/core/subscriptions.go
@@ -21,6 +21,7 @@ type Subscription struct {
 	mu         sync.RWMutex
 	active     bool
 	eoseRelays map[string]bool // NEW: Track which relays sent EOSE
+	acquired   []string        // relays this sub holds a pool lease on (released on Close)
 }
 
 // NewSubscription creates a new subscription instance
@@ -63,6 +64,15 @@ func (s *Subscription) Start() error {
 	sent := 0
 
 	for _, relayURL := range s.Relays {
+		// Connect-on-demand and hold a lease for the subscription's lifetime so
+		// the connection isn't idle-evicted out from under an active sub.
+		if _, err := s.client.relayPool.Acquire(relayURL); err != nil {
+			log.ClientCore().Debug("Failed to acquire relay for subscription", "relay", relayURL, "sub_id", s.ID, "error", err)
+			lastErr = err
+			continue
+		}
+		s.acquired = append(s.acquired, relayURL)
+
 		if err := s.client.relayPool.SendMessage(relayURL, reqMessage); err != nil {
 			// Demoted to Debug: races with upstream disconnect are
 			// normal flakiness, not grain bugs. The subscription's
@@ -83,8 +93,12 @@ func (s *Subscription) Start() error {
 	}
 
 	if sent == 0 && lastErr != nil {
-		// Unregister since we failed to start
+		// Unregister and release any leases taken before bailing out.
 		s.client.relayPool.UnregisterSubscription(s.ID)
+		for _, relayURL := range s.acquired {
+			s.client.relayPool.Release(relayURL)
+		}
+		s.acquired = nil
 		return lastErr
 	}
 
@@ -128,6 +142,13 @@ func (s *Subscription) Close() error {
 		}
 	}
 
+	// Release the pool leases this subscription held so the connections can be
+	// idle-evicted once nothing else needs them.
+	for _, relayURL := range s.acquired {
+		s.client.relayPool.Release(relayURL)
+	}
+	s.acquired = nil
+
 	s.active = false
 	close(s.Done)
 	close(s.Events)
@@ -155,14 +176,23 @@ func (s *Subscription) AddRelay(url string) error {
 
 	// If subscription is active, send REQ to new relay
 	if s.active {
+		// Connect-on-demand and hold a lease, mirroring Start.
+		if _, err := s.client.relayPool.Acquire(url); err != nil {
+			s.Relays = s.Relays[:len(s.Relays)-1]
+			return err
+		}
+		s.acquired = append(s.acquired, url)
+
 		reqMessage := []interface{}{"REQ", s.ID}
 		for _, filter := range s.Filters {
 			reqMessage = append(reqMessage, filter)
 		}
 
 		if err := s.client.relayPool.SendMessage(url, reqMessage); err != nil {
-			// Remove from list if send failed
+			// Remove from list and drop the lease if send failed
 			s.Relays = s.Relays[:len(s.Relays)-1]
+			s.acquired = s.acquired[:len(s.acquired)-1]
+			s.client.relayPool.Release(url)
 			return err
 		}
 
@@ -209,6 +239,15 @@ func (s *Subscription) RemoveRelay(url string) error {
 			conn.mu.Lock()
 			delete(conn.Subscriptions, s.ID)
 			conn.mu.Unlock()
+		}
+	}
+
+	// Drop the lease if this sub was holding one for the removed relay.
+	for i, u := range s.acquired {
+		if u == url {
+			s.acquired = append(s.acquired[:i], s.acquired[i+1:]...)
+			s.client.relayPool.Release(url)
+			break
 		}
 	}
 

--- a/client/core/testdata/nip44.vectors.json
+++ b/client/core/testdata/nip44.vectors.json
@@ -1,0 +1,648 @@
+{
+  "v2": {
+    "valid": {
+      "get_conversation_key": [
+        {
+          "sec1": "315e59ff51cb9209768cf7da80791ddcaae56ac9775eb25b6dee1234bc5d2268",
+          "pub2": "c2f9d9948dc8c7c38321e4b85c8558872eafa0641cd269db76848a6073e69133",
+          "conversation_key": "3dfef0ce2a4d80a25e7a328accf73448ef67096f65f79588e358d9a0eb9013f1"
+        },
+        {
+          "sec1": "a1e37752c9fdc1273be53f68c5f74be7c8905728e8de75800b94262f9497c86e",
+          "pub2": "03bb7947065dde12ba991ea045132581d0954f042c84e06d8c00066e23c1a800",
+          "conversation_key": "4d14f36e81b8452128da64fe6f1eae873baae2f444b02c950b90e43553f2178b"
+        },
+        {
+          "sec1": "98a5902fd67518a0c900f0fb62158f278f94a21d6f9d33d30cd3091195500311",
+          "pub2": "aae65c15f98e5e677b5050de82e3aba47a6fe49b3dab7863cf35d9478ba9f7d1",
+          "conversation_key": "9c00b769d5f54d02bf175b7284a1cbd28b6911b06cda6666b2243561ac96bad7"
+        },
+        {
+          "sec1": "86ae5ac8034eb2542ce23ec2f84375655dab7f836836bbd3c54cefe9fdc9c19f",
+          "pub2": "59f90272378089d73f1339710c02e2be6db584e9cdbe86eed3578f0c67c23585",
+          "conversation_key": "19f934aafd3324e8415299b64df42049afaa051c71c98d0aa10e1081f2e3e2ba"
+        },
+        {
+          "sec1": "2528c287fe822421bc0dc4c3615878eb98e8a8c31657616d08b29c00ce209e34",
+          "pub2": "f66ea16104c01a1c532e03f166c5370a22a5505753005a566366097150c6df60",
+          "conversation_key": "c833bbb292956c43366145326d53b955ffb5da4e4998a2d853611841903f5442"
+        },
+        {
+          "sec1": "49808637b2d21129478041813aceb6f2c9d4929cd1303cdaf4fbdbd690905ff2",
+          "pub2": "74d2aab13e97827ea21baf253ad7e39b974bb2498cc747cdb168582a11847b65",
+          "conversation_key": "4bf304d3c8c4608864c0fe03890b90279328cd24a018ffa9eb8f8ccec06b505d"
+        },
+        {
+          "sec1": "af67c382106242c5baabf856efdc0629cc1c5b4061f85b8ceaba52aa7e4b4082",
+          "pub2": "bdaf0001d63e7ec994fad736eab178ee3c2d7cfc925ae29f37d19224486db57b",
+          "conversation_key": "a3a575dd66d45e9379904047ebfb9a7873c471687d0535db00ef2daa24b391db"
+        },
+        {
+          "sec1": "0e44e2d1db3c1717b05ffa0f08d102a09c554a1cbbf678ab158b259a44e682f1",
+          "pub2": "1ffa76c5cc7a836af6914b840483726207cb750889753d7499fb8b76aa8fe0de",
+          "conversation_key": "a39970a667b7f861f100e3827f4adbf6f464e2697686fe1a81aeda817d6b8bdf"
+        },
+        {
+          "sec1": "5fc0070dbd0666dbddc21d788db04050b86ed8b456b080794c2a0c8e33287bb6",
+          "pub2": "31990752f296dd22e146c9e6f152a269d84b241cc95bb3ff8ec341628a54caf0",
+          "conversation_key": "72c21075f4b2349ce01a3e604e02a9ab9f07e35dd07eff746de348b4f3c6365e"
+        },
+        {
+          "sec1": "1b7de0d64d9b12ddbb52ef217a3a7c47c4362ce7ea837d760dad58ab313cba64",
+          "pub2": "24383541dd8083b93d144b431679d70ef4eec10c98fceef1eff08b1d81d4b065",
+          "conversation_key": "dd152a76b44e63d1afd4dfff0785fa07b3e494a9e8401aba31ff925caeb8f5b1"
+        },
+        {
+          "sec1": "df2f560e213ca5fb33b9ecde771c7c0cbd30f1cf43c2c24de54480069d9ab0af",
+          "pub2": "eeea26e552fc8b5e377acaa03e47daa2d7b0c787fac1e0774c9504d9094c430e",
+          "conversation_key": "770519e803b80f411c34aef59c3ca018608842ebf53909c48d35250bd9323af6"
+        },
+        {
+          "sec1": "cffff919fcc07b8003fdc63bc8a00c0f5dc81022c1c927c62c597352190d95b9",
+          "pub2": "eb5c3cca1a968e26684e5b0eb733aecfc844f95a09ac4e126a9e58a4e4902f92",
+          "conversation_key": "46a14ee7e80e439ec75c66f04ad824b53a632b8409a29bbb7c192e43c00bb795"
+        },
+        {
+          "sec1": "64ba5a685e443e881e9094647ddd32db14444bb21aa7986beeba3d1c4673ba0a",
+          "pub2": "50e6a4339fac1f3bf86f2401dd797af43ad45bbf58e0801a7877a3984c77c3c4",
+          "conversation_key": "968b9dbbfcede1664a4ca35a5d3379c064736e87aafbf0b5d114dff710b8a946"
+        },
+        {
+          "sec1": "dd0c31ccce4ec8083f9b75dbf23cc2878e6d1b6baa17713841a2428f69dee91a",
+          "pub2": "b483e84c1339812bed25be55cff959778dfc6edde97ccd9e3649f442472c091b",
+          "conversation_key": "09024503c7bde07eb7865505891c1ea672bf2d9e25e18dd7a7cea6c69bf44b5d"
+        },
+        {
+          "sec1": "af71313b0d95c41e968a172b33ba5ebd19d06cdf8a7a98df80ecf7af4f6f0358",
+          "pub2": "2a5c25266695b461ee2af927a6c44a3c598b8095b0557e9bd7f787067435bc7c",
+          "conversation_key": "fe5155b27c1c4b4e92a933edae23726a04802a7cc354a77ac273c85aa3c97a92"
+        },
+        {
+          "sec1": "6636e8a389f75fe068a03b3edb3ea4a785e2768e3f73f48ffb1fc5e7cb7289dc",
+          "pub2": "514eb2064224b6a5829ea21b6e8f7d3ea15ff8e70e8555010f649eb6e09aec70",
+          "conversation_key": "ff7afacd4d1a6856d37ca5b546890e46e922b508639214991cf8048ddbe9745c"
+        },
+        {
+          "sec1": "94b212f02a3cfb8ad147d52941d3f1dbe1753804458e6645af92c7b2ea791caa",
+          "pub2": "f0cac333231367a04b652a77ab4f8d658b94e86b5a8a0c472c5c7b0d4c6a40cc",
+          "conversation_key": "e292eaf873addfed0a457c6bd16c8effde33d6664265697f69f420ab16f6669b"
+        },
+        {
+          "sec1": "aa61f9734e69ae88e5d4ced5aae881c96f0d7f16cca603d3bed9eec391136da6",
+          "pub2": "4303e5360a884c360221de8606b72dd316da49a37fe51e17ada4f35f671620a6",
+          "conversation_key": "8e7d44fd4767456df1fb61f134092a52fcd6836ebab3b00766e16732683ed848"
+        },
+        {
+          "sec1": "5e914bdac54f3f8e2cba94ee898b33240019297b69e96e70c8a495943a72fc98",
+          "pub2": "5bd097924f606695c59f18ff8fd53c174adbafaaa71b3c0b4144a3e0a474b198",
+          "conversation_key": "f5a0aecf2984bf923c8cd5e7bb8be262d1a8353cb93959434b943a07cf5644bc"
+        },
+        {
+          "sec1": "8b275067add6312ddee064bcdbeb9d17e88aa1df36f430b2cea5cc0413d8278a",
+          "pub2": "65bbbfca819c90c7579f7a82b750a18c858db1afbec8f35b3c1e0e7b5588e9b8",
+          "conversation_key": "2c565e7027eb46038c2263563d7af681697107e975e9914b799d425effd248d6"
+        },
+        {
+          "sec1": "1ac848de312285f85e0f7ec208aac20142a1f453402af9b34ec2ec7a1f9c96fc",
+          "pub2": "45f7318fe96034d23ee3ddc25b77f275cc1dd329664dd51b89f89c4963868e41",
+          "conversation_key": "b56e970e5057a8fd929f8aad9248176b9af87819a708d9ddd56e41d1aec74088"
+        },
+        {
+          "sec1": "295a1cf621de401783d29d0e89036aa1c62d13d9ad307161b4ceb535ba1b40e6",
+          "pub2": "840115ddc7f1034d3b21d8e2103f6cb5ab0b63cf613f4ea6e61ae3d016715cdd",
+          "conversation_key": "b4ee9c0b9b9fef88975773394f0a6f981ca016076143a1bb575b9ff46e804753"
+        },
+        {
+          "sec1": "a28eed0fe977893856ab9667e06ace39f03abbcdb845c329a1981be438ba565d",
+          "pub2": "b0f38b950a5013eba5ab4237f9ed29204a59f3625c71b7e210fec565edfa288c",
+          "conversation_key": "9d3a802b45bc5aeeb3b303e8e18a92ddd353375710a31600d7f5fff8f3a7285b"
+        },
+        {
+          "sec1": "7ab65af72a478c05f5c651bdc4876c74b63d20d04cdbf71741e46978797cd5a4",
+          "pub2": "f1112159161b568a9cb8c9dd6430b526c4204bcc8ce07464b0845b04c041beda",
+          "conversation_key": "943884cddaca5a3fef355e9e7f08a3019b0b66aa63ec90278b0f9fdb64821e79"
+        },
+        {
+          "sec1": "95c79a7b75ba40f2229e85756884c138916f9d103fc8f18acc0877a7cceac9fe",
+          "pub2": "cad76bcbd31ca7bbda184d20cc42f725ed0bb105b13580c41330e03023f0ffb3",
+          "conversation_key": "81c0832a669eea13b4247c40be51ccfd15bb63fcd1bba5b4530ce0e2632f301b"
+        },
+        {
+          "sec1": "baf55cc2febd4d980b4b393972dfc1acf49541e336b56d33d429bce44fa12ec9",
+          "pub2": "0c31cf87fe565766089b64b39460ebbfdedd4a2bc8379be73ad3c0718c912e18",
+          "conversation_key": "37e2344da9ecdf60ae2205d81e89d34b280b0a3f111171af7e4391ded93b8ea6"
+        },
+        {
+          "sec1": "6eeec45acd2ed31693c5256026abf9f072f01c4abb61f51cf64e6956b6dc8907",
+          "pub2": "e501b34ed11f13d816748c0369b0c728e540df3755bab59ed3327339e16ff828",
+          "conversation_key": "afaa141b522ddb27bb880d768903a7f618bb8b6357728cae7fb03af639b946e6"
+        },
+        {
+          "sec1": "261a076a9702af1647fb343c55b3f9a4f1096273002287df0015ba81ce5294df",
+          "pub2": "b2777c863878893ae100fb740c8fab4bebd2bf7be78c761a75593670380a6112",
+          "conversation_key": "76f8d2853de0734e51189ced523c09427c3e46338b9522cd6f74ef5e5b475c74"
+        },
+        {
+          "sec1": "ed3ec71ca406552ea41faec53e19f44b8f90575eda4b7e96380f9cc73c26d6f3",
+          "pub2": "86425951e61f94b62e20cae24184b42e8e17afcf55bafa58645efd0172624fae",
+          "conversation_key": "f7ffc520a3a0e9e9b3c0967325c9bf12707f8e7a03f28b6cd69ae92cf33f7036"
+        },
+        {
+          "sec1": "5a788fc43378d1303ac78639c59a58cb88b08b3859df33193e63a5a3801c722e",
+          "pub2": "a8cba2f87657d229db69bee07850fd6f7a2ed070171a06d006ec3a8ac562cf70",
+          "conversation_key": "7d705a27feeedf78b5c07283362f8e361760d3e9f78adab83e3ae5ce7aeb6409"
+        },
+        {
+          "sec1": "63bffa986e382b0ac8ccc1aa93d18a7aa445116478be6f2453bad1f2d3af2344",
+          "pub2": "b895c70a83e782c1cf84af558d1038e6b211c6f84ede60408f519a293201031d",
+          "conversation_key": "3a3b8f00d4987fc6711d9be64d9c59cf9a709c6c6481c2cde404bcc7a28f174e"
+        },
+        {
+          "sec1": "e4a8bcacbf445fd3721792b939ff58e691cdcba6a8ba67ac3467b45567a03e5c",
+          "pub2": "b54053189e8c9252c6950059c783edb10675d06d20c7b342f73ec9fa6ed39c9d",
+          "conversation_key": "7b3933b4ef8189d347169c7955589fc1cfc01da5239591a08a183ff6694c44ad"
+        },
+        {
+          "sec1": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364139",
+          "pub2": "0000000000000000000000000000000000000000000000000000000000000002",
+          "conversation_key": "8b6392dbf2ec6a2b2d5b1477fc2be84d63ef254b667cadd31bd3f444c44ae6ba",
+          "note": "sec1 = n-2, pub2: random, 0x02"
+        },
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000002",
+          "pub2": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeb",
+          "conversation_key": "be234f46f60a250bef52a5ee34c758800c4ca8e5030bf4cc1a31d37ba2104d43",
+          "note": "sec1 = 2, pub2: rand"
+        },
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000001",
+          "pub2": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          "conversation_key": "3b4610cb7189beb9cc29eb3716ecc6102f1247e8f3101a03a1787d8908aeb54e",
+          "note": "sec1 == pub2"
+        }
+      ],
+      "get_message_keys": {
+        "conversation_key": "a1a3d60f3470a8612633924e91febf96dc5366ce130f658b1f0fc652c20b3b54",
+        "keys": [
+          {
+            "nonce": "e1e6f880560d6d149ed83dcc7e5861ee62a5ee051f7fde9975fe5d25d2a02d72",
+            "chacha_key": "f145f3bed47cb70dbeaac07f3a3fe683e822b3715edb7c4fe310829014ce7d76",
+            "chacha_nonce": "c4ad129bb01180c0933a160c",
+            "hmac_key": "027c1db445f05e2eee864a0975b0ddef5b7110583c8c192de3732571ca5838c4"
+          },
+          {
+            "nonce": "e1d6d28c46de60168b43d79dacc519698512ec35e8ccb12640fc8e9f26121101",
+            "chacha_key": "e35b88f8d4a8f1606c5082f7a64b100e5d85fcdb2e62aeafbec03fb9e860ad92",
+            "chacha_nonce": "22925e920cee4a50a478be90",
+            "hmac_key": "46a7c55d4283cb0df1d5e29540be67abfe709e3b2e14b7bf9976e6df994ded30"
+          },
+          {
+            "nonce": "cfc13bef512ac9c15951ab00030dfaf2626fdca638dedb35f2993a9eeb85d650",
+            "chacha_key": "020783eb35fdf5b80ef8c75377f4e937efb26bcbad0e61b4190e39939860c4bf",
+            "chacha_nonce": "d3594987af769a52904656ac",
+            "hmac_key": "237ec0ccb6ebd53d179fa8fd319e092acff599ef174c1fdafd499ef2b8dee745"
+          },
+          {
+            "nonce": "ea6eb84cac23c5c1607c334e8bdf66f7977a7e374052327ec28c6906cbe25967",
+            "chacha_key": "ff68db24b34fa62c78ac5ffeeaf19533afaedf651fb6a08384e46787f6ce94be",
+            "chacha_nonce": "50bb859aa2dde938cc49ec7a",
+            "hmac_key": "06ff32e1f7b29753a727d7927b25c2dd175aca47751462d37a2039023ec6b5a6"
+          },
+          {
+            "nonce": "8c2e1dd3792802f1f9f7842e0323e5d52ad7472daf360f26e15f97290173605d",
+            "chacha_key": "2f9daeda8683fdeede81adac247c63cc7671fa817a1fd47352e95d9487989d8b",
+            "chacha_nonce": "400224ba67fc2f1b76736916",
+            "hmac_key": "465c05302aeeb514e41c13ed6405297e261048cfb75a6f851ffa5b445b746e4b"
+          },
+          {
+            "nonce": "05c28bf3d834fa4af8143bf5201a856fa5fac1a3aee58f4c93a764fc2f722367",
+            "chacha_key": "1e3d45777025a035be566d80fd580def73ed6f7c043faec2c8c1c690ad31c110",
+            "chacha_nonce": "021905b1ea3afc17cb9bf96f",
+            "hmac_key": "74a6e481a89dcd130aaeb21060d7ec97ad30f0007d2cae7b1b11256cc70dfb81"
+          },
+          {
+            "nonce": "5e043fb153227866e75a06d60185851bc90273bfb93342f6632a728e18a07a17",
+            "chacha_key": "1ea72c9293841e7737c71567d8120145a58991aaa1c436ef77bf7adb83f882f1",
+            "chacha_nonce": "72f69a5a5f795465cee59da8",
+            "hmac_key": "e9daa1a1e9a266ecaa14e970a84bce3fbbf329079bbccda626582b4e66a0d4c9"
+          },
+          {
+            "nonce": "7be7338eaf06a87e274244847fe7a97f5c6a91f44adc18fcc3e411ad6f786dbf",
+            "chacha_key": "881e7968a1f0c2c80742ee03cd49ea587e13f22699730f1075ade01931582bf6",
+            "chacha_nonce": "6e69be92d61c04a276021565",
+            "hmac_key": "901afe79e74b19967c8829af23617d7d0ffbf1b57190c096855c6a03523a971b"
+          },
+          {
+            "nonce": "94571c8d590905bad7becd892832b472f2aa5212894b6ce96e5ba719c178d976",
+            "chacha_key": "f80873dd48466cb12d46364a97b8705c01b9b4230cb3ec3415a6b9551dc42eef",
+            "chacha_nonce": "3dda53569cfcb7fac1805c35",
+            "hmac_key": "e9fc264345e2839a181affebc27d2f528756e66a5f87b04bf6c5f1997047051e"
+          },
+          {
+            "nonce": "13a6ee974b1fd759135a2c2010e3cdda47081c78e771125e4f0c382f0284a8cb",
+            "chacha_key": "bc5fb403b0bed0d84cf1db872b6522072aece00363178c98ad52178d805fca85",
+            "chacha_nonce": "65064239186e50304cc0f156",
+            "hmac_key": "e872d320dde4ed3487958a8e43b48aabd3ced92bc24bb8ff1ccb57b590d9701a"
+          },
+          {
+            "nonce": "082fecdb85f358367b049b08be0e82627ae1d8edb0f27327ccb593aa2613b814",
+            "chacha_key": "1fbdb1cf6f6ea816349baf697932b36107803de98fcd805ebe9849b8ad0e6a45",
+            "chacha_nonce": "2e605e1d825a3eaeb613db9c",
+            "hmac_key": "fae910f591cf3c7eb538c598583abad33bc0a03085a96ca4ea3a08baf17c0eec"
+          },
+          {
+            "nonce": "4c19020c74932c30ec6b2d8cd0d5bb80bd0fc87da3d8b4859d2fb003810afd03",
+            "chacha_key": "1ab9905a0189e01cda82f843d226a82a03c4f5b6dbea9b22eb9bc953ba1370d4",
+            "chacha_nonce": "cbb2530ea653766e5a37a83a",
+            "hmac_key": "267f68acac01ac7b34b675e36c2cef5e7b7a6b697214add62a491bedd6efc178"
+          },
+          {
+            "nonce": "67723a3381497b149ce24814eddd10c4c41a1e37e75af161930e6b9601afd0ff",
+            "chacha_key": "9ecbd25e7e2e6c97b8c27d376dcc8c5679da96578557e4e21dba3a7ef4e4ac07",
+            "chacha_nonce": "ef649fcf335583e8d45e3c2e",
+            "hmac_key": "04dbbd812fa8226fdb45924c521a62e3d40a9e2b5806c1501efdeba75b006bf1"
+          },
+          {
+            "nonce": "42063fe80b093e8619b1610972b4c3ab9e76c14fd908e642cd4997cafb30f36c",
+            "chacha_key": "211c66531bbcc0efcdd0130f9f1ebc12a769105eb39608994bcb188fa6a73a4a",
+            "chacha_nonce": "67803605a7e5010d0f63f8c8",
+            "hmac_key": "e840e4e8921b57647369d121c5a19310648105dbdd008200ebf0d3b668704ff8"
+          },
+          {
+            "nonce": "b5ac382a4be7ac03b554fe5f3043577b47ea2cd7cfc7e9ca010b1ffbb5cf1a58",
+            "chacha_key": "b3b5f14f10074244ee42a3837a54309f33981c7232a8b16921e815e1f7d1bb77",
+            "chacha_nonce": "4e62a0073087ed808be62469",
+            "hmac_key": "c8efa10230b5ea11633816c1230ca05fa602ace80a7598916d83bae3d3d2ccd7"
+          },
+          {
+            "nonce": "e9d1eba47dd7e6c1532dc782ff63125db83042bb32841db7eeafd528f3ea7af9",
+            "chacha_key": "54241f68dc2e50e1db79e892c7c7a471856beeb8d51b7f4d16f16ab0645d2f1a",
+            "chacha_nonce": "a963ed7dc29b7b1046820a1d",
+            "hmac_key": "aba215c8634530dc21c70ddb3b3ee4291e0fa5fa79be0f85863747bde281c8b2"
+          },
+          {
+            "nonce": "a94ecf8efeee9d7068de730fad8daf96694acb70901d762de39fa8a5039c3c49",
+            "chacha_key": "c0565e9e201d2381a2368d7ffe60f555223874610d3d91fbbdf3076f7b1374dd",
+            "chacha_nonce": "329bb3024461e84b2e1c489b",
+            "hmac_key": "ac42445491f092481ce4fa33b1f2274700032db64e3a15014fbe8c28550f2fec"
+          },
+          {
+            "nonce": "533605ea214e70c25e9a22f792f4b78b9f83a18ab2103687c8a0075919eaaa53",
+            "chacha_key": "ab35a5e1e54d693ff023db8500d8d4e79ad8878c744e0eaec691e96e141d2325",
+            "chacha_nonce": "653d759042b85194d4d8c0a7",
+            "hmac_key": "b43628e37ba3c31ce80576f0a1f26d3a7c9361d29bb227433b66f49d44f167ba"
+          },
+          {
+            "nonce": "7f38df30ceea1577cb60b355b4f5567ff4130c49e84fed34d779b764a9cc184c",
+            "chacha_key": "a37d7f211b84a551a127ff40908974eb78415395d4f6f40324428e850e8c42a3",
+            "chacha_nonce": "b822e2c959df32b3cb772a7c",
+            "hmac_key": "1ba31764f01f69b5c89ded2d7c95828e8052c55f5d36f1cd535510d61ba77420"
+          },
+          {
+            "nonce": "11b37f9dbc4d0185d1c26d5f4ed98637d7c9701fffa65a65839fa4126573a4e5",
+            "chacha_key": "964f38d3a31158a5bfd28481247b18dd6e44d69f30ba2a40f6120c6d21d8a6ba",
+            "chacha_nonce": "5f72c5b87c590bcd0f93b305",
+            "hmac_key": "2fc4553e7cedc47f29690439890f9f19c1077ef3e9eaeef473d0711e04448918"
+          },
+          {
+            "nonce": "8be790aa483d4cdd843189f71f135b3ec7e31f381312c8fe9f177aab2a48eafa",
+            "chacha_key": "95c8c74d633721a131316309cf6daf0804d59eaa90ea998fc35bac3d2fbb7a94",
+            "chacha_nonce": "409a7654c0e4bf8c2c6489be",
+            "hmac_key": "21bb0b06eb2b460f8ab075f497efa9a01c9cf9146f1e3986c3bf9da5689b6dc4"
+          },
+          {
+            "nonce": "19fd2a718ea084827d6bd73f509229ddf856732108b59fc01819f611419fd140",
+            "chacha_key": "cc6714b9f5616c66143424e1413d520dae03b1a4bd202b82b0a89b0727f5cdc8",
+            "chacha_nonce": "1b7fd2534f015a8f795d8f32",
+            "hmac_key": "2bef39c4ce5c3c59b817e86351373d1554c98bc131c7e461ed19d96cfd6399a0"
+          },
+          {
+            "nonce": "3c2acd893952b2f6d07d8aea76f545ca45961a93fe5757f6a5a80811d5e0255d",
+            "chacha_key": "c8de6c878cb469278d0af894bc181deb6194053f73da5014c2b5d2c8db6f2056",
+            "chacha_nonce": "6ffe4f1971b904a1b1a81b99",
+            "hmac_key": "df1cd69dd3646fca15594284744d4211d70e7d8472e545d276421fbb79559fd4"
+          },
+          {
+            "nonce": "7dbea4cead9ac91d4137f1c0a6eebb6ba0d1fb2cc46d829fbc75f8d86aca6301",
+            "chacha_key": "c8e030f6aa680c3d0b597da9c92bb77c21c4285dd620c5889f9beba7446446b0",
+            "chacha_nonce": "a9b5a67d081d3b42e737d16f",
+            "hmac_key": "355a85f551bc3cce9a14461aa60994742c9bbb1c81a59ca102dc64e61726ab8e"
+          },
+          {
+            "nonce": "45422e676cdae5f1071d3647d7a5f1f5adafb832668a578228aa1155a491f2f3",
+            "chacha_key": "758437245f03a88e2c6a32807edfabff51a91c81ca2f389b0b46f2c97119ea90",
+            "chacha_nonce": "263830a065af33d9c6c5aa1f",
+            "hmac_key": "7c581cf3489e2de203a95106bfc0de3d4032e9d5b92b2b61fb444acd99037e17"
+          },
+          {
+            "nonce": "babc0c03fad24107ad60678751f5db2678041ff0d28671ede8d65bdf7aa407e9",
+            "chacha_key": "bd68a28bd48d9ffa3602db72c75662ac2848a0047a313d2ae2d6bc1ac153d7e9",
+            "chacha_nonce": "d0f9d2a1ace6c758f594ffdd",
+            "hmac_key": "eb435e3a642adfc9d59813051606fc21f81641afd58ea6641e2f5a9f123bb50a"
+          },
+          {
+            "nonce": "7a1b8aac37d0d20b160291fad124ab697cfca53f82e326d78fef89b4b0ea8f83",
+            "chacha_key": "9e97875b651a1d30d17d086d1e846778b7faad6fcbc12e08b3365d700f62e4fe",
+            "chacha_nonce": "ccdaad5b3b7645be430992eb",
+            "hmac_key": "6f2f55cf35174d75752f63c06cc7cbc8441759b142999ed2d5a6d09d263e1fc4"
+          },
+          {
+            "nonce": "8370e4e32d7e680a83862cab0da6136ef607014d043e64cdf5ecc0c4e20b3d9a",
+            "chacha_key": "1472bed5d19db9c546106de946e0649cd83cc9d4a66b087a65906e348dcf92e2",
+            "chacha_nonce": "ed02dece5fc3a186f123420b",
+            "hmac_key": "7b3f7739f49d30c6205a46b174f984bb6a9fc38e5ccfacef2dac04fcbd3b184e"
+          },
+          {
+            "nonce": "9f1c5e8a29cd5677513c2e3a816551d6833ee54991eb3f00d5b68096fc8f0183",
+            "chacha_key": "5e1a7544e4d4dafe55941fcbdf326f19b0ca37fc49c4d47e9eec7fb68cde4975",
+            "chacha_nonce": "7d9acb0fdc174e3c220f40de",
+            "hmac_key": "e265ab116fbbb86b2aefc089a0986a0f5b77eda50c7410404ad3b4f3f385c7a7"
+          },
+          {
+            "nonce": "c385aa1c37c2bfd5cc35fcdbdf601034d39195e1cabff664ceb2b787c15d0225",
+            "chacha_key": "06bf4e60677a13e54c4a38ab824d2ef79da22b690da2b82d0aa3e39a14ca7bdd",
+            "chacha_nonce": "26b450612ca5e905b937e147",
+            "hmac_key": "22208152be2b1f5f75e6bfcc1f87763d48bb7a74da1be3d102096f257207f8b3"
+          },
+          {
+            "nonce": "3ff73528f88a50f9d35c0ddba4560bacee5b0462d0f4cb6e91caf41847040ce4",
+            "chacha_key": "850c8a17a23aa761d279d9901015b2bbdfdff00adbf6bc5cf22bd44d24ecabc9",
+            "chacha_nonce": "4a296a1fb0048e5020d3b129",
+            "hmac_key": "b1bf49a533c4da9b1d629b7ff30882e12d37d49c19abd7b01b7807d75ee13806"
+          },
+          {
+            "nonce": "2dcf39b9d4c52f1cb9db2d516c43a7c6c3b8c401f6a4ac8f131a9e1059957036",
+            "chacha_key": "17f8057e6156ba7cc5310d01eda8c40f9aa388f9fd1712deb9511f13ecc37d27",
+            "chacha_nonce": "a8188daff807a1182200b39d",
+            "hmac_key": "47b89da97f68d389867b5d8a2d7ba55715a30e3d88a3cc11f3646bc2af5580ef"
+          }
+        ]
+      },
+      "calc_padded_len": [
+        [16, 32],
+        [32, 32],
+        [33, 64],
+        [37, 64],
+        [45, 64],
+        [49, 64],
+        [64, 64],
+        [65, 96],
+        [100, 128],
+        [111, 128],
+        [200, 224],
+        [250, 256],
+        [320, 320],
+        [383, 384],
+        [384, 384],
+        [400, 448],
+        [500, 512],
+        [512, 512],
+        [515, 640],
+        [700, 768],
+        [800, 896],
+        [900, 1024],
+        [1020, 1024],
+        [65536, 65536]
+      ],
+      "encrypt_decrypt": [
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000001",
+          "sec2": "0000000000000000000000000000000000000000000000000000000000000002",
+          "conversation_key": "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d",
+          "nonce": "0000000000000000000000000000000000000000000000000000000000000001",
+          "plaintext": "a",
+          "payload": "AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABee0G5VSK0/9YypIObAtDKfYEAjD35uVkHyB0F4DwrcNaCXlCWZKaArsGrY6M9wnuTMxWfp1RTN9Xga8no+kF5Vsb"
+        },
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000002",
+          "sec2": "0000000000000000000000000000000000000000000000000000000000000001",
+          "conversation_key": "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d",
+          "nonce": "f00000000000000000000000000000f00000000000000000000000000000000f",
+          "plaintext": "🍕🫃",
+          "payload": "AvAAAAAAAAAAAAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAPSKSK6is9ngkX2+cSq85Th16oRTISAOfhStnixqZziKMDvB0QQzgFZdjLTPicCJaV8nDITO+QfaQ61+KbWQIOO2Yj"
+        },
+        {
+          "sec1": "5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a",
+          "sec2": "4b22aa260e4acb7021e32f38a6cdf4b673c6a277755bfce287e370c924dc936d",
+          "conversation_key": "3e2b52a63be47d34fe0a80e34e73d436d6963bc8f39827f327057a9986c20a45",
+          "nonce": "b635236c42db20f021bb8d1cdff5ca75dd1a0cc72ea742ad750f33010b24f73b",
+          "plaintext": "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀",
+          "payload": "ArY1I2xC2yDwIbuNHN/1ynXdGgzHLqdCrXUPMwELJPc7s7JqlCMJBAIIjfkpHReBPXeoMCyuClwgbT419jUWU1PwaNl4FEQYKCDKVJz+97Mp3K+Q2YGa77B6gpxB/lr1QgoqpDf7wDVrDmOqGoiPjWDqy8KzLueKDcm9BVP8xeTJIxs="
+        },
+        {
+          "sec1": "8f40e50a84a7462e2b8d24c28898ef1f23359fff50d8c509e6fb7ce06e142f9c",
+          "sec2": "b9b0a1e9cc20100c5faa3bbe2777303d25950616c4c6a3fa2e3e046f936ec2ba",
+          "conversation_key": "d5a2f879123145a4b291d767428870f5a8d9e5007193321795b40183d4ab8c2b",
+          "nonce": "b20989adc3ddc41cd2c435952c0d59a91315d8c5218d5040573fc3749543acaf",
+          "plaintext": "ability🤝的 ȺȾ",
+          "payload": "ArIJia3D3cQc0sQ1lSwNWakTFdjFIY1QQFc/w3SVQ6yvbG2S0x4Yu86QGwPTy7mP3961I1XqB6SFFTzqDZZavhxoWMj7mEVGMQIsh2RLWI5EYQaQDIePSnXPlzf7CIt+voTD"
+        },
+        {
+          "sec1": "875adb475056aec0b4809bd2db9aa00cff53a649e7b59d8edcbf4e6330b0995c",
+          "sec2": "9c05781112d5b0a2a7148a222e50e0bd891d6b60c5483f03456e982185944aae",
+          "conversation_key": "3b15c977e20bfe4b8482991274635edd94f366595b1a3d2993515705ca3cedb8",
+          "nonce": "8d4442713eb9d4791175cb040d98d6fc5be8864d6ec2f89cf0895a2b2b72d1b1",
+          "plaintext": "pepper👀їжак",
+          "payload": "Ao1EQnE+udR5EXXLBA2Y1vxb6IZNbsL4nPCJWisrctGxY3AduCS+jTUgAAnfvKafkmpy15+i9YMwCdccisRa8SvzW671T2JO4LFSPX31K4kYUKelSAdSPwe9NwO6LhOsnoJ+"
+        },
+        {
+          "sec1": "eba1687cab6a3101bfc68fd70f214aa4cc059e9ec1b79fdb9ad0a0a4e259829f",
+          "sec2": "dff20d262bef9dfd94666548f556393085e6ea421c8af86e9d333fa8747e94b3",
+          "conversation_key": "4f1538411098cf11c8af216836444787c462d47f97287f46cf7edb2c4915b8a5",
+          "nonce": "2180b52ae645fcf9f5080d81b1f0b5d6f2cd77ff3c986882bb549158462f3407",
+          "plaintext": "( ͡° ͜ʖ ͡°)",
+          "payload": "AiGAtSrmRfz59QgNgbHwtdbyzXf/PJhogrtUkVhGLzQHv4qhKQwnFQ54OjVMgqCea/Vj0YqBSdhqNR777TJ4zIUk7R0fnizp6l1zwgzWv7+ee6u+0/89KIjY5q1wu6inyuiv"
+        },
+        {
+          "sec1": "d5633530f5bcfebceb5584cfbbf718a30df0751b729dd9a789b9f30c0587d74e",
+          "sec2": "b74e6a341fb134127272b795a08b59250e5fa45a82a2eb4095e4ce9ed5f5e214",
+          "conversation_key": "75fe686d21a035f0c7cd70da64ba307936e5ca0b20710496a6b6b5f573377bdd",
+          "nonce": "e4cd5f7ce4eea024bc71b17ad456a986a74ac426c2c62b0a15eb5c5c8f888b68",
+          "plaintext": "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،",
+          "payload": "AuTNX3zk7qAkvHGxetRWqYanSsQmwsYrChXrXFyPiItoIBsWu1CB+sStla2M4VeANASHxM78i1CfHQQH1YbBy24Tng7emYW44ol6QkFD6D8Zq7QPl+8L1c47lx8RoODEQMvNCbOk5ffUV3/AhONHBXnffrI+0025c+uRGzfqpYki4lBqm9iYU+k3Tvjczq9wU0mkVDEaM34WiQi30MfkJdRbeeYaq6kNvGPunLb3xdjjs5DL720d61Flc5ZfoZm+CBhADy9D9XiVZYLKAlkijALJur9dATYKci6OBOoc2SJS2Clai5hOVzR0yVeyHRgRfH9aLSlWW5dXcUxTo7qqRjNf8W5+J4jF4gNQp5f5d0YA4vPAzjBwSP/5bGzNDslKfcAH"
+        },
+        {
+          "sec1": "d5633530f5bcfebceb5584cfbbf718a30df0751b729dd9a789b9f30c0587d74e",
+          "sec2": "b74e6a341fb134127272b795a08b59250e5fa45a82a2eb4095e4ce9ed5f5e214",
+          "conversation_key": "75fe686d21a035f0c7cd70da64ba307936e5ca0b20710496a6b6b5f573377bdd",
+          "nonce": "38d1ca0abef9e5f564e89761a86cee04574b6825d3ef2063b10ad75899e4b023",
+          "plaintext": "الكل في المجمو عة (5)",
+          "payload": "AjjRygq++eX1ZOiXYahs7gRXS2gl0+8gY7EK11iZ5LAjbOTrlfrxak5Lki42v2jMPpLSicy8eHjsWkkMtF0i925vOaKG/ZkMHh9ccQBdfTvgEGKzztedqDCAWb5TP1YwU1PsWaiiqG3+WgVvJiO4lUdMHXL7+zKKx8bgDtowzz4QAwI="
+        },
+        {
+          "sec1": "d5633530f5bcfebceb5584cfbbf718a30df0751b729dd9a789b9f30c0587d74e",
+          "sec2": "b74e6a341fb134127272b795a08b59250e5fa45a82a2eb4095e4ce9ed5f5e214",
+          "conversation_key": "75fe686d21a035f0c7cd70da64ba307936e5ca0b20710496a6b6b5f573377bdd",
+          "nonce": "4f1a31909f3483a9e69c8549a55bbc9af25fa5bbecf7bd32d9896f83ef2e12e0",
+          "plaintext": "𝖑𝖆𝖟𝖞 社會科學院語學研究所",
+          "payload": "Ak8aMZCfNIOp5pyFSaVbvJryX6W77Pe9MtmJb4PvLhLgh/TsxPLFSANcT67EC1t/qxjru5ZoADjKVEt2ejdx+xGvH49mcdfbc+l+L7gJtkH7GLKpE9pQNQWNHMAmj043PAXJZ++fiJObMRR2mye5VHEANzZWkZXMrXF7YjuG10S1pOU="
+        },
+        {
+          "sec1": "d5633530f5bcfebceb5584cfbbf718a30df0751b729dd9a789b9f30c0587d74e",
+          "sec2": "b74e6a341fb134127272b795a08b59250e5fa45a82a2eb4095e4ce9ed5f5e214",
+          "conversation_key": "75fe686d21a035f0c7cd70da64ba307936e5ca0b20710496a6b6b5f573377bdd",
+          "nonce": "a3e219242d85465e70adcd640b564b3feff57d2ef8745d5e7a0663b2dccceb54",
+          "plaintext": "🙈 🙉 🙊 0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟 Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗",
+          "payload": "AqPiGSQthUZecK3NZAtWSz/v9X0u+HRdXnoGY7LczOtUf05aMF89q1FLwJvaFJYICZoMYgRJHFLwPiOHce7fuAc40kX0wXJvipyBJ9HzCOj7CgtnC1/cmPCHR3s5AIORmroBWglm1LiFMohv1FSPEbaBD51VXxJa4JyWpYhreSOEjn1wd0lMKC9b+osV2N2tpbs+rbpQem2tRen3sWflmCqjkG5VOVwRErCuXuPb5+hYwd8BoZbfCrsiAVLd7YT44dRtKNBx6rkabWfddKSLtreHLDysOhQUVOp/XkE7OzSkWl6sky0Hva6qJJ/V726hMlomvcLHjE41iKmW2CpcZfOedg=="
+        }
+      ],
+      "encrypt_decrypt_long_msg": [
+        {
+          "conversation_key": "8fc262099ce0d0bb9b89bac05bb9e04f9bc0090acc181fef6840ccee470371ed",
+          "nonce": "326bcb2c943cd6bb717588c9e5a7e738edf6ed14ec5f5344caa6ef56f0b9cff7",
+          "pattern": "x",
+          "repeat": 65535,
+          "plaintext_sha256": "09ab7495d3e61a76f0deb12cb0306f0696cbb17ffc12131368c7a939f12f56d3",
+          "payload_sha256": "90714492225faba06310bff2f249ebdc2a5e609d65a629f1c87f2d4ffc55330a"
+        },
+        {
+          "conversation_key": "56adbe3720339363ab9c3b8526ffce9fd77600927488bfc4b59f7a68ffe5eae0",
+          "nonce": "ad68da81833c2a8ff609c3d2c0335fd44fe5954f85bb580c6a8d467aa9fc5dd0",
+          "pattern": "!",
+          "repeat": 65535,
+          "plaintext_sha256": "6af297793b72ae092c422e552c3bb3cbc310da274bd1cf9e31023a7fe4a2d75e",
+          "payload_sha256": "8013e45a109fad3362133132b460a2d5bce235fe71c8b8f4014793fb52a49844"
+        },
+        {
+          "conversation_key": "7fc540779979e472bb8d12480b443d1e5eb1098eae546ef2390bee499bbf46be",
+          "nonce": "34905e82105c20de9a2f6cd385a0d541e6bcc10601d12481ff3a7575dc622033",
+          "pattern": "🦄",
+          "repeat": 16383,
+          "plaintext_sha256": "a249558d161b77297bc0cb311dde7d77190f6571b25c7e4429cd19044634a61f",
+          "payload_sha256": "b3348422471da1f3c59d79acfe2fe103f3cd24488109e5b18734cdb5953afd15"
+        }
+      ]
+    },
+    "invalid": {
+      "encrypt_msg_lengths": [0, 65536, 100000, 10000000],
+      "get_conversation_key": [
+        {
+          "sec1": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "pub2": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "note": "sec1 higher than curve.n"
+        },
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000000",
+          "pub2": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "note": "sec1 is 0"
+        },
+        {
+          "sec1": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364139",
+          "pub2": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "note": "pub2 is invalid, no sqrt, all-ff"
+        },
+        {
+          "sec1": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "pub2": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "note": "sec1 == curve.n"
+        },
+        {
+          "sec1": "0000000000000000000000000000000000000000000000000000000000000002",
+          "pub2": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "note": "pub2 is invalid, no sqrt"
+        },
+        {
+          "sec1": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "pub2": "0000000000000000000000000000000000000000000000000000000000000000",
+          "note": "pub2 is point of order 3 on twist"
+        },
+        {
+          "sec1": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "pub2": "eb1f7200aecaa86682376fb1c13cd12b732221e774f553b0a0857f88fa20f86d",
+          "note": "pub2 is point of order 13 on twist"
+        },
+        {
+          "sec1": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "pub2": "709858a4c121e4a84eb59c0ded0261093c71e8ca29efeef21a6161c447bcaf9f",
+          "note": "pub2 is point of order 3319 on twist"
+        }
+      ],
+      "decrypt": [
+        {
+          "conversation_key": "ca2527a037347b91bea0c8a30fc8d9600ffd81ec00038671e3a0f0cb0fc9f642",
+          "nonce": "daaea5ca345b268e5b62060ca72c870c48f713bc1e00ff3fc0ddb78e826f10db",
+          "plaintext": "n o b l e",
+          "payload": "#Atqupco0WyaOW2IGDKcshwxI9xO8HgD/P8Ddt46CbxDbrhdG8VmJdU0MIDf06CUvEvdnr1cp1fiMtlM/GrE92xAc1K5odTpCzUB+mjXgbaqtntBUbTToSUoT0ovrlPwzGjyp",
+          "note": "unknown encryption version"
+        },
+        {
+          "conversation_key": "36f04e558af246352dcf73b692fbd3646a2207bd8abd4b1cd26b234db84d9481",
+          "nonce": "ad408d4be8616dc84bb0bf046454a2a102edac937c35209c43cd7964c5feb781",
+          "plaintext": "⚠️",
+          "payload": "AK1AjUvoYW3IS7C/BGRUoqEC7ayTfDUgnEPNeWTF/reBZFaha6EAIRueE9D1B1RuoiuFScC0Q94yjIuxZD3JStQtE8JMNacWFs9rlYP+ZydtHhRucp+lxfdvFlaGV/sQlqZz",
+          "note": "unknown encryption version 0"
+        },
+        {
+          "conversation_key": "ca2527a037347b91bea0c8a30fc8d9600ffd81ec00038671e3a0f0cb0fc9f642",
+          "nonce": "daaea5ca345b268e5b62060ca72c870c48f713bc1e00ff3fc0ddb78e826f10db",
+          "plaintext": "n o s t r",
+          "payload": "Atфupco0WyaOW2IGDKcshwxI9xO8HgD/P8Ddt46CbxDbrhdG8VmJZE0UICD06CUvEvdnr1cp1fiMtlM/GrE92xAc1EwsVCQEgWEu2gsHUVf4JAa3TpgkmFc3TWsax0v6n/Wq",
+          "note": "invalid base64"
+        },
+        {
+          "conversation_key": "cff7bd6a3e29a450fd27f6c125d5edeb0987c475fd1e8d97591e0d4d8a89763c",
+          "nonce": "09ff97750b084012e15ecb84614ce88180d7b8ec0d468508a86b6d70c0361a25",
+          "plaintext": "¯\\_(ツ)_/¯",
+          "payload": "Agn/l3ULCEAS4V7LhGFM6IGA17jsDUaFCKhrbXDANholyySBfeh+EN8wNB9gaLlg4j6wdBYh+3oK+mnxWu3NKRbSvQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "note": "invalid MAC"
+        },
+        {
+          "conversation_key": "cfcc9cf682dfb00b11357f65bdc45e29156b69db424d20b3596919074f5bf957",
+          "nonce": "65b14b0b949aaa7d52c417eb753b390e8ad6d84b23af4bec6d9bfa3e03a08af4",
+          "plaintext": "🥎",
+          "payload": "AmWxSwuUmqp9UsQX63U7OQ6K1thLI69L7G2b+j4DoIr0oRWQ8avl4OLqWZiTJ10vIgKrNqjoaX+fNhE9RqmR5g0f6BtUg1ijFMz71MO1D4lQLQfW7+UHva8PGYgQ1QpHlKgR",
+          "note": "invalid MAC"
+        },
+        {
+          "conversation_key": "5254827d29177622d40a7b67cad014fe7137700c3c523903ebbe3e1b74d40214",
+          "nonce": "7ab65dbb8bbc2b8e35cafb5745314e1f050325a864d11d0475ef75b3660d91c1",
+          "plaintext": "elliptic-curve cryptography",
+          "payload": "Anq2XbuLvCuONcr7V0UxTh8FAyWoZNEdBHXvdbNmDZHB573MI7R7rrTYftpqmvUpahmBC2sngmI14/L0HjOZ7lWGJlzdh6luiOnGPc46cGxf08MRC4CIuxx3i2Lm0KqgJ7vA",
+          "note": "invalid padding"
+        },
+        {
+          "conversation_key": "fea39aca9aa8340c3a78ae1f0902aa7e726946e4efcd7783379df8096029c496",
+          "nonce": "7d4283e3b54c885d6afee881f48e62f0a3f5d7a9e1cb71ccab594a7882c39330",
+          "plaintext": "noble",
+          "payload": "An1Cg+O1TIhdav7ogfSOYvCj9dep4ctxzKtZSniCw5MwRrrPJFyAQYZh5VpjC2QYzny5LIQ9v9lhqmZR4WBYRNJ0ognHVNMwiFV1SHpvUFT8HHZN/m/QarflbvDHAtO6pY16",
+          "note": "invalid padding"
+        },
+        {
+          "conversation_key": "0c4cffb7a6f7e706ec94b2e879f1fc54ff8de38d8db87e11787694d5392d5b3f",
+          "nonce": "6f9fd72667c273acd23ca6653711a708434474dd9eb15c3edb01ce9a95743e9b",
+          "plaintext": "censorship-resistant and global social network",
+          "payload": "Am+f1yZnwnOs0jymZTcRpwhDRHTdnrFcPtsBzpqVdD6b2NZDaNm/TPkZGr75kbB6tCSoq7YRcbPiNfJXNch3Tf+o9+zZTMxwjgX/nm3yDKR2kHQMBhVleCB9uPuljl40AJ8kXRD0gjw+aYRJFUMK9gCETZAjjmrsCM+nGRZ1FfNsHr6Z",
+          "note": "invalid padding"
+        },
+        {
+          "conversation_key": "5cd2d13b9e355aeb2452afbd3786870dbeecb9d355b12cb0a3b6e9da5744cd35",
+          "nonce": "b60036976a1ada277b948fd4caa065304b96964742b89d26f26a25263a5060bd",
+          "plaintext": "0",
+          "payload": "",
+          "note": "invalid payload length: 0"
+        },
+        {
+          "conversation_key": "d61d3f09c7dfe1c0be91af7109b60a7d9d498920c90cbba1e137320fdd938853",
+          "nonce": "1a29d02c8b4527745a2ccb38bfa45655deb37bc338ab9289d756354cea1fd07c",
+          "plaintext": "1",
+          "payload": "Ag==",
+          "note": "invalid payload length: 4"
+        },
+        {
+          "conversation_key": "873bb0fc665eb950a8e7d5971965539f6ebd645c83c08cd6a85aafbad0f0bc47",
+          "nonce": "c826d3c38e765ab8cc42060116cd1464b2a6ce01d33deba5dedfb48615306d4a",
+          "plaintext": "2",
+          "payload": "AqxgToSh3H7iLYRJjoWAM+vSv/Y1mgNlm6OWWjOYUClrFF8=",
+          "note": "invalid payload length: 48"
+        },
+        {
+          "conversation_key": "9f2fef8f5401ac33f74641b568a7a30bb19409c76ffdc5eae2db6b39d2617fbe",
+          "nonce": "9ff6484642545221624eaac7b9ea27133a4cc2356682a6033aceeef043549861",
+          "plaintext": "3",
+          "payload": "Ap/2SEZCVFIhYk6qx7nqJxM6TMI1ZoKmAzrO7vBDVJhhuZXWiM20i/tIsbjT0KxkJs2MZjh1oXNYMO9ggfk7i47WQA==",
+          "note": "invalid payload length: 92"
+        }
+      ]
+    }
+  }
+}

--- a/client/core/testdata/nip44v3.vectors.json
+++ b/client/core/testdata/nip44v3.vectors.json
@@ -1,0 +1,528 @@
+{
+    "encrypt_decrypt": [
+        {
+            "secret1": "1b7023bb70248d8edab44658c5e2677dd7e5d7093ec062eb204975df4255fddc",
+            "secret2": "827844538be12d1cfa0f7fa096668cc4f2c4a25c2c8f7e92ca6cb05c3c445d17",
+            "nonce": "b5451a6d90ec575b4cdcedf4987429eeab1bbaa192ea3db89eafa058826885a6",
+            "kind": 1,
+            "scope_hex": "",
+            "prk": "3520160171dc39d75e64768d4fb667647480d458fc4d5c26d000a7cb3c8805b1",
+            "encryption_key": "de94e4663af538351a9b75b8af31e968ed8b88241ddbce43ad1d4ae2b984327d",
+            "mac_key": "70e65d5ff8769e92fbdf163b00b1b317bd4d30fe82de6b00d05cd74fb576febd",
+            "plaintext_hex": "efbbbf48656c6c6f20776f726c6421",
+            "ciphertext": "A7VFGm2Q7FdbTNzt9Jh0Ke6rG7qhkuo9uJ6voFiCaIWmMJrEDBNRRCorotVxmP7ge14Y+UtDn1/Pn3uzAaNNzHUAAAABAAAAAPJgoFXpn6mjFE0hUZrnZljeaYwSdqBKbVDXcyLgVGC8"
+        },
+        {
+            "secret1": "f9869a8237c9fffd3bc175d21cc144051de4889da28b462ca1e4557adc2d2275",
+            "secret2": "c4c53829b9ad83682873761b71d667457935eaa84159a206dea58f18be09d05d",
+            "nonce": "f99a4a4a84a4906d839b62861dcd54883cccabb3616d003f27250ac00e672c50",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "prk": "7eeee2eac804eae839f64c4f2204ba6c205a65ae895bea006a45afd2ff9afee0",
+            "encryption_key": "56c727b1f69ff6ecb29c6cfd6469c1908da5556b0c13123b3303d5068edf03b6",
+            "mac_key": "f6be43893bffe64c43d56ee2692014d3e5275a78a3cd8268e2e1e0cb707a6bad",
+            "plaintext_hex": "6e6f7374722e6c616e64206e697034347633",
+            "ciphertext": "A/maSkqEpJBtg5tihh3NVIg8zKuzYW0APyclCsAOZyxQfHiK7t6u8D4JR3dRUKMpBRQzoOYtunePezG3p65AXPEAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzvgOo5isSBI06S531Yb9j9l+LpL9dA0D9/LLtorb866Y="
+        },
+        {
+            "secret1": "2f69dcb9891cf749ab0b4e07a718a9e364c44e7603d851c7c09e080b631534fb",
+            "secret2": "110ffc1f2ea8b15ffd5d24c59dc1b72c4b1f8180dd5ccb6a68097ff328f49e54",
+            "nonce": "ffffd9144f5fe48077ac672e1366d303dfebdf60b1abd07fce1ff762bb25a4aa",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "prk": "dd23c1dad51c025ed632be8b8da198517eef83a86729ccf524382f6011c9500b",
+            "encryption_key": "44f5de03559045aeb509d670299e7eab7f12682a7d5cc6c9a1441fd35f9484a9",
+            "mac_key": "ab08e3aa28d40c9376a56056dea33b3e935402da5585607b081ad166cecd8432",
+            "plaintext_hex": "f09f9088f09fa694",
+            "ciphertext": "A///2RRPX+SAd6xnLhNm0wPf699gsavQf84f92K7JaSqrm0b+bxgKBqNS04QURAmEXZlYBY9Ed4neDw2uOAqkGcAAAABAAAACeOBr+S4lueVjIEUNKR4ekMqHUoWb/ks495G0c1lD6oPQ3ZFsa4LHvRE"
+        },
+        {
+            "secret1": "e945941c87478b88c8af150219ed8055692f3f01543a3dec3cb40854fdf8545b",
+            "secret2": "11eefd6b9a1a4d4e4b71840aa77eb47d3821d825ca8d4e45065ff563bdc342d9",
+            "nonce": "726cab7f363afe8c0783dc1d2d6e4700ace52a26996a53ba3928ef3c865cc235",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "prk": "7fafc5865086ba6ef1d48c93fa5e8c84dc0fd73924f23a4560d8d0f31f9ab2db",
+            "encryption_key": "2b6ed20127afba197082b52159120042d0bdfec6df2e657944f79a62ec90a1d0",
+            "mac_key": "2e72490f486fd6f0ed2ca5e508dff16b6db6936df59b77406717e6aed645d2a0",
+            "plaintext_hex": "e69a97e58fb7e58c96e381aee3819fe38281e381aee382a2e382afe382bbe382b9e588b6e5bea1e6a99fe883bde3818ce799bbe5a0b4e38197e381bee38197e3819fefbc81",
+            "ciphertext": "A3Jsq382Ov6MB4PcHS1uRwCs5SommWpTujko7zyGXMI1d8FRsRgcGnjOo+Ifry8x/QC+vDDkPCHv7WDaem7tQ10AAAABAAAABu+7v++/vm+/pDQcUXHli2Do1EEoqYFmF/67UUcl31Ks9TRy9vCwc2IUY6Ev9T+oBanqVWGbPgAWysjisi5dIPAEcndMK2Ur4m2UqTo3WVTIqKmy30ad5VOwl4v1AHweiZvJU/w+lQ=="
+        },
+        {
+            "secret1": "98c7c39a4abf5f923db71a3e2c0951fa020bc5ba1555c158ebc8663e1582bb01",
+            "secret2": "b775d4f4ef14b1a93cc34a534a64a1ec2cd1a64a5a7b45f837af5ea4595b37dc",
+            "nonce": "ec64f769d99bc3c6f5231145b546334275d910e11fe9a11351ee487e4dbfd4ec",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "prk": "98fca3e635b9478407385a8989fb78ddb115d992a92019852953a4cd139aeb69",
+            "encryption_key": "9e6bdba691401f02de1403f75ebcb3516f5ff3b77c8a3918d8a3393e73eb3188",
+            "mac_key": "b05399edc9e6eae42cc21ec5941a73e8b7387bf10f49dfcfd740131309d81c35",
+            "plaintext_hex": "9b8de973ddf42a02103de24d9b7a4f0c4f551abaf7cd88f08e7a9c4d41ec5f777b45c890c112968fee50dccd3287583e9a3a33f962d78054f36dcb6f1ea9a8aa3fcb80953e04f6a2b3c3c4e26909ef7c5e84da6df3fd423215015640b249c91b28b38b18499b615bf1e92635e1df15aeeba2063692ce7cc8296582ceed25ceda",
+            "ciphertext": "A+xk92nZm8PG9SMRRbVGM0J12RDhH+mhE1HuSH5Nv9Tsg6J943ljpXnIaVIuHaXrWfa99RkqZOW6NGy6oqm2HocAAAABAAAAA++AgNCkiGZgN5Uzx1HVpcoLQQisIwWD32PqBoQ4T598/KmHsxUAGEARiXh9ikGXtwKuH8a8EzTcobkr4OEXfPs0h5u0A1HUJ3M/Hc/orcqZgeA0RhfZe3IASVmQfU9/pge+nTPjJVK5ZHOlEBnt7tmYcT8vqv9bpxbyhCBGMO6nEFhUtrr2IKCW3Z6vljg7T3FDr7aVIY/cxniq4E+e5ec9pZ+wn3j9PAibWgEANCDK5nyiH6B348lnqxfmu8bvzzyPhA=="
+        },
+        {
+            "secret1": "b0e73a57d65972a4276879cb8604f683dfd9197cc236f299ea55acb66bfa8ff0",
+            "secret2": "ebf87d9858227055ac9f789911edad1b55777edc99dd4b8634f52bb8c0922edc",
+            "nonce": "c027624d50656a34add75cec7e476e6287bc919cacf0ebbda6d3277c02b0a239",
+            "kind": 1,
+            "scope_hex": "",
+            "prk": "a76ecc57266a24238761cf79c9909e27af6adfa523fb914a1a54e17d15e26287",
+            "encryption_key": "3c5be4141db8d4e4bfd998b6a4f995922070b9dc4af41c5d50c89c7ccd437f0e",
+            "mac_key": "92704765cd32cbe3beb21f347541184fc0cff839c8d2077d198d1f91103bdd22",
+            "plaintext_hex": "6120646563656e7472616c697a65642070726f746f636f6c20666f7220616e797468696e67",
+            "ciphertext": "A8AnYk1QZWo0rddc7H5HbmKHvJGcrPDrvabTJ3wCsKI5ZMf+aMW7P7Iz5qDghY+87TL5pZjNiykm0xpMKlkwITgAAAABAAAAAE2F94qgXOR+co8R41Vu04wLtkrI3Y5QJbVmutA5v1MkCgrLCmZAwNXhQsUnzUOuAPloXVQQdgQL4gmVgIz0rqQ="
+        },
+        {
+            "secret1": "0bac57d63af3e6650152577f7d5515062270b68cd2cda1250604ab70b7cdf091",
+            "secret2": "ddb09a891ef13bbf1b9ed8fb403afce4eea2197428da805dc85d90eee76e20f2",
+            "nonce": "0da18d3ebcc5f269f6415e3e3fcb5e1a8d76318fe439ec83cfdf99ef8eaacee9",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "prk": "d084d04cb7e61bb0c8fc7fbfaf48b58863fc01c1a4cebc7d48cad3b3853ac7a7",
+            "encryption_key": "be6eb2e4aa213dc2260abc2414e763057ab7df785e33338f1a3167ac280ee7fb",
+            "mac_key": "59f55d61316dee4f7f71c7b3d9704ef822d5d31bcfda30d02a267f29cb20d92e",
+            "plaintext_hex": "efbbbf48656c6c6f20776f726c6421",
+            "ciphertext": "Aw2hjT68xfJp9kFePj/LXhqNdjGP5Dnsg8/fme+Oqs7p+xyexXUdk8ZJ2rtLWT1xQ9lXxWSiagEVpRg35PndmKQAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzuKZ6xxWsljlgBA/i6yz7+dmE6dyszU9qkR7f2xDUQdg="
+        },
+        {
+            "secret1": "b69f38d981ad22b1fd25473756b2dd9c69d1554c6d31ae2a64c0fc82aafd86ac",
+            "secret2": "c916f18fd08a90c1d20bdfe27f31c53d33ebefdbe28e3da8797632b4b474b9df",
+            "nonce": "8b3c3f3aaf575328259ac5e3c08191dde308c573e3f4e7cda7042f82133143fb",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "prk": "93c97bd637c3fc60d9dbdb410df34c4a614c52db57ed0f2a218e8a973e125265",
+            "encryption_key": "e0a45a9306cc404aea91687e2b3c26abe23b0e12945799279e332c1880cacd78",
+            "mac_key": "b21748a15b40d53bbdaeb81c419c160994780d141324fcb1ac65bcd8be6bb6f4",
+            "plaintext_hex": "6e6f7374722e6c616e64206e697034347633",
+            "ciphertext": "A4s8PzqvV1MoJZrF48CBkd3jCMVz4/TnzacEL4ITMUP7b2QxXAKNEKp93ebvTrmrJ4aeJtLvqRokEeGXPBLE9UsAAAABAAAACeOBr+S4lueVjO04T51hx+sZw9n3gheEAyVOP0w/pWFvFtCuolpBkHvk"
+        },
+        {
+            "secret1": "20d7e7e95a8e6376438182425c33c9445055fa4a8bd2c57e5c7902015433e18d",
+            "secret2": "d38139efe4118dd5862c2556600ef7914d1659cabbd1a3d5fd9f2a0abe9dcbb3",
+            "nonce": "20c635f2f795178ea0bbf9856dd99da02138ba79337d2511d887f2a065b917c9",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "prk": "4f9c75fe7c850a79f83000901ef8f020301c06e413a84de01784971ec249bb7b",
+            "encryption_key": "4345c818ddb2793427d8f5bb056e663cd941f910165601ff6806866cb7fb0fc3",
+            "mac_key": "4eb9ee0ea464574336446a8aae961f05b6a65cd5feb2087417eabf5344c554da",
+            "plaintext_hex": "f09f9088f09fa694",
+            "ciphertext": "AyDGNfL3lReOoLv5hW3ZnaAhOLp5M30lEdiH8qBluRfJTmsWPfIzALsx5OokjdKYAWkgDkES88FoC4k6wtgxUK8AAAABAAAABu+7v++/vmSE/qHW8+XDY97+8EQCRVPzORPYKrnLM6mNRp+zl2C6"
+        },
+        {
+            "secret1": "1a2c6e81b5f1038fdda1f555d0431d1bd3efb22d57f608708fa46d7d7b96f1f5",
+            "secret2": "c18596eac499c94e04334021c1b6952757d83aeda2aa84f90ab47357cdd29fdb",
+            "nonce": "a05a11dcd50aa1e855b7e11a816158a1a4827d21a00b60105ed3c8e802770d77",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "prk": "c043b08590fcc2ef03e299633af842deffd1b5dbd2bf598606bf02abb898303d",
+            "encryption_key": "ba927e27a656a34369920ce7be028b6f6cb5878890123d1d3ba6b9f7ef4ab9c4",
+            "mac_key": "71163bde93ea8fa3b5574e81869416bcb8f6954a3b746e1b2ed24546949e208c",
+            "plaintext_hex": "e69a97e58fb7e58c96e381aee3819fe38281e381aee382a2e382afe382bbe382b9e588b6e5bea1e6a99fe883bde3818ce799bbe5a0b4e38197e381bee38197e3819fefbc81",
+            "ciphertext": "A6BaEdzVCqHoVbfhGoFhWKGkgn0hoAtgEF7TyOgCdw13O273WC9FSDyMtfOYNFvOlZQcaSrLdo6WBQ7ZI2UWn5MAAAABAAAAA++AgPPJWHFZya+M6arLz4wrWMHfL4Wyv4gYZBkicAvVBX0dMsr5tBcTP5xaM4lJZZnokEvMZRzYbjrfNTjT2gCWBapNdr/QrHxlTDa54nRmVR/2GBLkmQ5QeIiDm6OhfjXyYA=="
+        }
+    ],
+    "decrypt_only": [
+        {
+            "secret1": "fce6ddb6b9611964b37466e29f89f212f6905a70e5b0ea20b33ac9a4a74e60cb",
+            "secret2": "45d28e26e1072c9495857efc85bb56ba0833271d7cb183c6459b8ca17311ed7e",
+            "nonce": "d55b86093a16aabd228b9ac1724749e492fc3a81491c7374bd7a1d28a7b3b4a3",
+            "kind": 1,
+            "scope_hex": "",
+            "prk": "5f359143a097d9b66ec8e0cff7c111076efa06b5ec2f9185e13a304c4467a4e8",
+            "encryption_key": "cbb7467f7c3a6f04c5ac6e4554de2034b67f2ac32a94d58f44e7a14e80912b0b",
+            "mac_key": "784feeb31cf134baaa13d387f5102cf1f06a0e4d60cc737ba4c0311987401e9e",
+            "plaintext_hex": "efbbbf48656c6c6f20776f726c6421",
+            "ciphertext": "A9Vbhgk6Fqq9IouawXJHSeSS/DqBSRxzdL16HSins7Sji9VE1vdW4PQiqseqUsGZsaAvIe2yGmfWOXiimOZHRUUAAAABAAAAAHm5SMpSTmibFgS1CqDSU5sC6MEPKNyTHS7oxNAb/AAFwta2Xpcc",
+            "note": "non-standard padding (23 bytes instead of 17)"
+        },
+        {
+            "secret1": "099f9dd917f81a515d587164ed21bfcc3897bf705a7c9b3de85abcea809831df",
+            "secret2": "9806d1447c80921a15ff6c737204d985fbee09a6fb123ec8c1ef8749a939ac6d",
+            "nonce": "382baacbba8cba0cc6e8a7b4444fb157186118a18b3dbf652fb6b1e8267bcac1",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "prk": "57dec8dfe66043f16b839513bffe2855984a725e50d8c63d4f5738d9dc6d0ed9",
+            "encryption_key": "c8ef9801a429de8526739c8d84c62eaf632b0d52023590c7449c8178885dcd57",
+            "mac_key": "7ad04de35b988b240f78285e597fdca8e963988664f4808878afc2ba0aa9a4c1",
+            "plaintext_hex": "6e6f7374722e6c616e64206e697034347633",
+            "ciphertext": "Azgrqsu6jLoMxuintERPsVcYYRihiz2/ZS+2segme8rBD0AqKypuSHff1x0FW+qO4lQlLltEjPWrvoMo7fbKOfwAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYznEO1UCJd2Ld0YV51u6kOkY3g22UhvNBAXY3sFnKmPu6fYx9s0rDWwNZcGxsMs+VydrONvM5F",
+            "note": "non-standard padding (36 bytes instead of 14)"
+        },
+        {
+            "secret1": "a62c0eae8281f8997c6391889be1c39df8d06acbde7cbb5e23b8e6ba28c95328",
+            "secret2": "c51b92dfea8551090c2e17d22953f7124fdd6a59e7c67daadcb92819279801d4",
+            "nonce": "f08ea755450d9666cc122f2aa89794b170b8c69c6d7ff5f1d25bfae52164ca3a",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "prk": "916e05d26ccb1d5f58698911c85789b89529baa9c4fb5fdcdac80f94afb525f8",
+            "encryption_key": "9110aa1049b70cdd93c38fa4888459d7286a78f5ca584d4dd658905660d4faea",
+            "mac_key": "a597dea28fc706883f9dcc4917209ffc10788c95e86f090a694ea51bc5fe7a11",
+            "plaintext_hex": "f09f9088f09fa694",
+            "ciphertext": "A/COp1VFDZZmzBIvKqiXlLFwuMacbX/18dJb+uUhZMo6uAhk3+WwQOcgQUgH4zhxaRzi80m70t5a9uV5B11EdpcAAAABAAAACeOBr+S4lueVjPeRbg5pf83dLf79+g1wPXb8mjm/rT9e",
+            "note": "non-standard padding (15 bytes instead of 24)"
+        },
+        {
+            "secret1": "740853175b987393b113ac196ccf5152ed4a206b1a365291abacaf106c7a3bca",
+            "secret2": "da1a37af7852a7e5c0a7ce90a39950039bfaeab96297ef83b9d8817f5a2d26f9",
+            "nonce": "f7e0f4b83ebb87657001b8e47d5940a3d062dfebae66da5a2ad0f4e498fedf85",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "prk": "75c09260e4c8b8240514aee23723531df5f7816a25601e74e0ccbe87a965b309",
+            "encryption_key": "94cf5b47ccfd36dadee996e637ae2a11bd9ac53ff7a29573fe368adf8b1e4f20",
+            "mac_key": "a2e6d59755d7193c5cb9eba5965a42d2696062d455c2c7c535ad88b1c13d415b",
+            "plaintext_hex": "e69a97e58fb7e58c96e381aee3819fe38281e381aee382a2e382afe382bbe382b9e588b6e5bea1e6a99fe883bde3818ce799bbe5a0b4e38197e381bee38197e3819fefbc81",
+            "ciphertext": "A/fg9Lg+u4dlcAG45H1ZQKPQYt/rrmbaWirQ9OSY/t+Fhm1xiEi20bWbMLIDrNw7Gz6XU0bDmmmgYl3g4z68Z+4AAAABAAAABu+7v++/vhLMBXKVPi51crCqEwCQnuB0V13+nE22PpVe7jQiELzDMqdrE6intBrXyHJLrJ4VteEZoiU92jZDoG9ieltDh0NnKRKq7cuW/om3DIhB0DCb0Pq6C5g/VaFaz2+mVPXV0p2BMW2MpuKUJ7/VYAlJPNSlK/JSYpQq",
+            "note": "non-standard padding (50 bytes instead of 27)"
+        },
+        {
+            "secret1": "28531e3c28be034f8bcca7bc25e5b9a6cbbcce8567f2a9016b3f1ad7707a724a",
+            "secret2": "96108e608b4231562b07d21021361e3efab87350021a9247ce410585c0adf757",
+            "nonce": "a82a808ca1a40368336f19e9d3f83bfaaa35e4b8bffc9b5d9426ae518b9f34d1",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "prk": "38846e1253b841b6960c3be79ec4b6bc1e0ce7c6e40a05f6ea2190ff0c53044b",
+            "encryption_key": "cbecc983553fb82f9f3f615dd959a451d66388d8632d2028a684c9f02c611f3f",
+            "mac_key": "5ed551ef02ba987cfdd4716c4a840a654501ea57aee9da055651669f85ac016e",
+            "plaintext_hex": "9b8de973ddf42a02103de24d9b7a4f0c4f551abaf7cd88f08e7a9c4d41ec5f777b45c890c112968fee50dccd3287583e9a3a33f962d78054f36dcb6f1ea9a8aa3fcb80953e04f6a2b3c3c4e26909ef7c5e84da6df3fd423215015640b249c91b28b38b18499b615bf1e92635e1df15aeeba2063692ce7cc8296582ceed25ceda",
+            "ciphertext": "A6gqgIyhpANoM28Z6dP4O/qqNeS4v/ybXZQmrlGLnzTRH0t5gnTV0ylQcxxkbLRHyKXnIagqYk5XMlG/85NYwuwAAAABAAAAA++AgM9zXmWWTYSixZDotwM+8HmJHW3aBt44KvZkhInVvt+Xmzh1YaPW8cbVr9kOQ38+cc5E285UfL164P71915Pr6mHNGOHtpKcX3P6TXCrch2MLux4m9xHf0BPcuv4+bwC0fLpNKVJLnNAnnGm7VOXdE2HhX4NP8ujzvH6cKTGfiyK0OlVpWX6Le+v/h2wm6m2SAHSJLbi6fIdA6MDilizVMqyaEFZ3n8eRYQ+To6eFKojRQw=",
+            "note": "non-standard padding (50 bytes instead of 64)"
+        }
+    ],
+    "long_encrypt_decrypt": [
+        {
+            "secret1": "e35f016acdf0bec26f9f0e97fd813aa042727cb1e5ac2adf1c7b8d18d393f455",
+            "secret2": "e3c47278057365a1007414224f54ee99e6198ac6b6a82917e635375a1f9afa8e",
+            "nonce": "0598a9aa024df86e1e532e8cd3ed412e5b8bc914ff0340aa8868f9fd2fe2871f",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "pattern_hex": "9b8de973ddf42a02103de24d9b7a4f0c4f551abaf7cd88f08e7a9c4d41ec5f777b45c890c112968fee50dccd3287583e9a3a33f962d78054f36dcb6f1ea9a8aa3fcb80953e04f6a2b3c3c4e26909ef7c5e84da6df3fd423215015640b249c91b28b38b18499b615bf1e92635e1df15aeeba2063692ce7cc8296582ceed25ceda",
+            "repeat": 511,
+            "ciphertext_sha256": "cf2c183f974c2601c0ec5d4fad0f0f98f18b0c83bc4e988c53ec1e496528deb1"
+        },
+        {
+            "secret1": "69efe21ce6ffe00d4126a019542e61324ff59fef06c81798cf1ec9810bfa5566",
+            "secret2": "91749344a212c2168587ad46197ef2eb026e3fa6839cb4286599c4f24820431c",
+            "nonce": "8c9f02398c9c5c11260b9ec27292bd32f0127c3e5366b255e0878ecb82e81eeb",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "pattern_hex": "9b8de973ddf42a02103de24d9b7a4f0c4f551abaf7cd88f08e7a9c4d41ec5f777b45c890c112968fee50dccd3287583e9a3a33f962d78054f36dcb6f1ea9a8aa3fcb80953e04f6a2b3c3c4e26909ef7c5e84da6df3fd423215015640b249c91b28b38b18499b615bf1e92635e1df15aeeba2063692ce7cc8296582ceed25ceda",
+            "repeat": 1023,
+            "ciphertext_sha256": "8538f11d334dee64c561961ab7b371a90cb5ded3d1bf6c544d93aa4c72e5b1c0"
+        },
+        {
+            "secret1": "9ed97778c4bcaf3b5c66c41d3b97ec62e89e2bb9ead5d27a980a1c268a24a2c9",
+            "secret2": "58cba97d2985b001a7367a088a2e868a85158bd218f2a5858eb23a43de4ea382",
+            "nonce": "d8212d54ca0a36a7a5ed9f33656aebcd995f64dc6c4551a54b0dad5b897e254c",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "pattern_hex": "9b8de973ddf42a02103de24d9b7a4f0c4f551abaf7cd88f08e7a9c4d41ec5f777b45c890c112968fee50dccd3287583e9a3a33f962d78054f36dcb6f1ea9a8aa3fcb80953e04f6a2b3c3c4e26909ef7c5e84da6df3fd423215015640b249c91b28b38b18499b615bf1e92635e1df15aeeba2063692ce7cc8296582ceed25ceda",
+            "repeat": 2047,
+            "ciphertext_sha256": "66c5b453cc7123d9826115d437902db5226dd25f41aea9519f986938709c2901"
+        },
+        {
+            "secret1": "77930acaf9d28607482f0d329d65eea04fd218a957f25004d6606414dcdea848",
+            "secret2": "c31571de3b9b8053d5477a8dd090d7ed7ffbed98f8e9c904b8034ba77f74e232",
+            "nonce": "b40a2f2ae51c8355ed8bce7f810628c5fd3a4c5d4fe9170c159b9c7e9d1d5f87",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "pattern_hex": "f09fa694",
+            "repeat": 16383,
+            "ciphertext_sha256": "ccd2942a398aaab22845d6d65599a82fa9ee5fc1caecb5a8cc358771b1b7ba7b"
+        },
+        {
+            "secret1": "dc0ded78a0d133195b49429aadc6d424fde9b98a0e9ee12b4382bc0f08125a1c",
+            "secret2": "fac11ede5498f415f3a48cdf052a4e0d2f77fc4012baaf77de70a3f2cb4bc195",
+            "nonce": "7f2506e82ad6d97fa2cbbc2cf9f3a02bb61ce65bbe72a891c07c7bde23ade06b",
+            "kind": 1,
+            "scope_hex": "",
+            "pattern_hex": "f09fa694",
+            "repeat": 32767,
+            "ciphertext_sha256": "d84d643bda0d6f11dfc165eff69ab7c12c31f7f651603fe9e3397fb2ebb44a24"
+        },
+        {
+            "secret1": "b585991901f19ca1353b4122a591c3ade793338174f70326ee351d54b2b4c9be",
+            "secret2": "cdbc4210a142109928087965a6e47922ed65763165cebdb54498770da448d5b0",
+            "nonce": "aef913a704ce90355a134dd5f4ea253115d9d426269f371f45a33de3c79a90d7",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "pattern_hex": "f09fa694",
+            "repeat": 65535,
+            "ciphertext_sha256": "75d4386e1e5bf39c2775486c066274fbceb9e0aff2880b513ec1593ce8a68f74"
+        },
+        {
+            "secret1": "57420cd8c43b789a506e7dd1eb433b010e5323eb219de7c6a6a6f6976aa80693",
+            "secret2": "370091dce8dce4c3cf6b1a67ec8f41f9ae78a69ea902c67bdfe8930d90b2b7d6",
+            "nonce": "15ecf921c0e227f5199523de99193626087d506d998b8abd3c086e66fb25af0e",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "pattern_hex": "e38193e38293e381abe381a1e381afe4b896e7958c",
+            "repeat": 3120,
+            "ciphertext_sha256": "0577e05453f458e700740be3d849096f3d9d46924333ce3aa27c342a786a6cc4"
+        },
+        {
+            "secret1": "aeda4666950455c2e038d6b7d9e000be92be6aaecbb57b7f0f980ba29da52453",
+            "secret2": "9d819437f4eb60290bfb9aa547d426516a3ea07a2149e46f3310acc85dd45a18",
+            "nonce": "56146d9c3caf5c118288754d2caabd142eb45e1f2d80f3caf5183888ca2ee416",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "pattern_hex": "e38193e38293e381abe381a1e381afe4b896e7958c",
+            "repeat": 6241,
+            "ciphertext_sha256": "6a0c112e126aa897f80ac73227fbb062ac7ded96f641a05fa4634a9f4a8c702b"
+        },
+        {
+            "secret1": "f153b2eadf9aa51bedf90ac8804dbe2bc4fed1ddd3861a857ae80a20d5c55f27",
+            "secret2": "22c42e7079ae57313d99c2f025c1be2f5dd999a3898d9aecbed7a207a1018510",
+            "nonce": "a7db4437442ca0ffbd836822c622115bc001de197c9f1a1d3d67a1e63c044d30",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "pattern_hex": "e38193e38293e381abe381a1e381afe4b896e7958c",
+            "repeat": 12482,
+            "ciphertext_sha256": "c066419c9ee88e7c8a77dbe25fac1dd8e9720fa4f481924058189062b12e3fe1"
+        },
+        {
+            "secret1": "217d14ae21140584417aa9bbcab4bdf4adccb5e74b191d65d2b357794f7f7143",
+            "secret2": "cccdef797a083bea633fcff31f255b57b5d5c99b682eda8ff132066dc3cd9127",
+            "nonce": "143cb408e61cf7b4281b0ccf300284a68d7df282f71667df5740b5f282424880",
+            "kind": 1,
+            "scope_hex": "",
+            "pattern_hex": "21",
+            "repeat": 65532,
+            "ciphertext_sha256": "e5360cffeef8c31c88a3455b920d9d9a98c8669b77d38ac232e0f67420467e5d"
+        },
+        {
+            "secret1": "625bbf8de97b71e8d70092bb6c576ee95895b7e6d2acf924790c80dd69785e8f",
+            "secret2": "13e7e6925ef02a644ea1c7bf8b68ff7de8c676ecf7f22d49a78a1802a6933189",
+            "nonce": "1bbbfd8803eac5c844e96ade2fdacf18fe3bda62312bdda102a29b52dd0c97bf",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "pattern_hex": "21",
+            "repeat": 131068,
+            "ciphertext_sha256": "8dd9a3157906d3a4e3de2b4d552cddae489a0996812bacca7728996a2605cae9"
+        },
+        {
+            "secret1": "266503c3818aa70800280c53be6f7f8156273c6c606cfbb0803d8eb63dca65f9",
+            "secret2": "9846126fad398ea9b6fe7ebddd7e28c021691eaff5355847cca42a2caacacb68",
+            "nonce": "9815cf89d4ab86023b1a427166fd8db49681a077d5724d1b743a57cd6fb96b81",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "pattern_hex": "21",
+            "repeat": 262140,
+            "ciphertext_sha256": "0bd33e75b6bb9be42a1fce897801d064943945a930977551437031a413e07443"
+        },
+        {
+            "secret1": "39506d419c1dede09cba910247457d66be7b213adbd981e3af0ef69b46c790f5",
+            "secret2": "5294e3ad19298a304753a32a42be2d44f3438f553677f30aab591f8a19ba4fd4",
+            "nonce": "8ccdf24876123afdbce42e59d4e03c53589150b4f23b087d3e3bfe89d96a54a6",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "pattern_hex": "00",
+            "repeat": 65532,
+            "ciphertext_sha256": "c4c030de28d8b5fa9aafb1961aab296f078aced2988897c7907fa67cae073de1"
+        },
+        {
+            "secret1": "86bbd84e3e9e2db2e7ec37fb16900723aac499f1074b66586b44a3ed63022a3e",
+            "secret2": "17d3ff292c4a65e6181ecc201b9c5ed0c7e8408f36183659181414ddbb17c3d5",
+            "nonce": "f7ce68c00fb546c23efb88f778819c131797705abfc222886406b8547a9c244c",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "pattern_hex": "00",
+            "repeat": 131068,
+            "ciphertext_sha256": "3992c52ad7811ba181f572d37a0e1c9a4dbc1d9b127caa171896eb861d1e818c"
+        },
+        {
+            "secret1": "d38c5d7c0ba3b3e103318eb12952a481a204ab8dfd1d440b8882e9f0649ac0ee",
+            "secret2": "484475e3653226fd962fb9ca9ea8c8d4929473308eb53fd73a8ccd95e5eb8b98",
+            "nonce": "47fd0420348c7c4dead0c52874f2efe9ba9ecc9c4f9ee82319e1f33338d3ab86",
+            "kind": 1,
+            "scope_hex": "",
+            "pattern_hex": "00",
+            "repeat": 262140,
+            "ciphertext_sha256": "e03e2f16a5ee7e874d3cdc52e36ae8e73791d664540cdb7ac36f65687c7fc2a5"
+        },
+        {
+            "secret1": "fd20231a23032bde7acc638eb7086784670dcf8bc90e57a65c1d03d68594d3f0",
+            "secret2": "b47f3ba965fbea51c927b6846543480aeb25275c0e01c5c4d286ea087e70ee92",
+            "nonce": "6c9820a69d021d86a695eb3d5cc11ec638a799aca10ecfb9819b1efa3b9731ff",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "pattern_hex": "ff",
+            "repeat": 65532,
+            "ciphertext_sha256": "6621fc89a79464d19cbef605d962c9f43af90568c8c352007829445d1886c9bf"
+        },
+        {
+            "secret1": "38c961d0c8289789cec189e8db140f740abf34c8251eb16ad93cc5f9021abeb3",
+            "secret2": "e985cda5e08979c17a2c148532434c6f830bc2243e7a5592704972328f24d62d",
+            "nonce": "3957e9cc3be20433aff61993558572099e186312e714050cd3a589ff675f0e07",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "pattern_hex": "ff",
+            "repeat": 131068,
+            "ciphertext_sha256": "e41d7c737462f18b653683796d739c3b93f284c9bc15182bd94d278d13b84dea"
+        },
+        {
+            "secret1": "0666935a88d5196746c799ce0593dede7a8e8044930e62e07793950b9dab9b4d",
+            "secret2": "e3505f4e3b8fd37da2a9b4f3cb67864819e6272cdcdcf198f422598fa1114d21",
+            "nonce": "56fef50b564913b040a9ee83c9c1eb36ac6553a9e5ad699ac036fb4338a38e35",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "pattern_hex": "ff",
+            "repeat": 262140,
+            "ciphertext_sha256": "086aaa494e3a4ca5bc573d91fbed292d9abe05fb730c54660bf5813250744aab"
+        }
+    ],
+    "padded_length": [[0,32],[1,32],[32,32],[33,64],[34,64],[64,64],[65,96],[66,96],[96,96],[97,128],[98,128],[128,128],[129,192],[130,192],[192,192],[193,256],[194,256],[256,256],[257,384],[258,384],[384,384],[385,512],[386,512],[512,512],[513,768],[514,768],[768,768],[769,1024],[770,1024],[1024,1024],[1025,1536],[1026,1536],[1536,1536],[1537,2048],[1538,2048],[2048,2048],[2049,3072],[2050,3072],[3072,3072],[3073,4096],[3074,4096],[4096,4096],[4097,6144],[4098,6144],[6144,6144],[6145,8192],[6146,8192],[8192,8192],[8193,12288],[8194,12288],[12288,12288],[12289,16384],[12290,16384],[16384,16384],[16385,20480],[16386,20480],[20480,20480],[20481,24576],[20482,24576],[24576,24576],[24577,28672],[24578,28672],[28672,28672],[28673,32768],[28674,32768],[32768,32768],[32769,40960],[32770,40960],[40960,40960],[40961,49152],[40962,49152],[49152,49152],[49153,57344],[49154,57344],[57344,57344],[57345,65536],[57346,65536],[65536,65536],[65537,81920],[65538,81920],[81920,81920],[81921,98304],[81922,98304],[98304,98304],[98305,114688],[98306,114688],[114688,114688],[114689,131072],[114690,131072],[131072,131072],[131073,163840],[131074,163840],[163840,163840],[163841,196608],[163842,196608],[196608,196608],[196609,229376],[196610,229376],[229376,229376],[229377,262144],[229378,262144],[262144,262144],[262145,327680],[262146,327680],[327680,327680],[327681,393216],[327682,393216],[393216,393216],[393217,458752],[393218,458752],[458752,458752],[458753,524288],[458754,524288],[524288,524288],[524289,655360],[524290,655360],[655360,655360],[655361,786432],[655362,786432],[786432,786432],[786433,917504],[786434,917504],[917504,917504],[917505,1048576],[917506,1048576],[1048576,1048576],[1048577,1310720],[1048578,1310720],[1310720,1310720],[1310721,1572864],[1310722,1572864],[1572864,1572864],[1572865,1835008],[1572866,1835008],[1835008,1835008],[1835009,2097152],[1835010,2097152],[2097152,2097152],[2097153,2621440],[2097154,2621440],[2621440,2621440],[2621441,3145728],[2621442,3145728],[3145728,3145728],[3145729,3670016],[3145730,3670016],[3670016,3670016],[3670017,4194304],[3670018,4194304],[4194304,4194304],[4194305,5242880],[4194306,5242880],[5242880,5242880],[5242881,6291456],[5242882,6291456],[6291456,6291456],[6291457,7340032],[6291458,7340032],[7340032,7340032],[7340033,8388608],[7340034,8388608],[8388608,8388608],[8388609,10485760],[8388610,10485760],[10485760,10485760],[10485761,12582912],[10485762,12582912],[12582912,12582912],[12582913,14680064],[12582914,14680064],[14680064,14680064],[14680065,16777216],[14680066,16777216],[16777216,16777216],[16777217,20971520],[16777218,20971520]],
+    "invalid_decryption": [
+        {
+            "secret": "b2a4cca9347992d235fe115382098e313f6eaa3680248443b90c64e4e2ab039e",
+            "public": "dc62907f84a35acecfc55b6d82961399f019981be0cd7d5e6a5a0620f9158870",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "Awx1nilOH4b0PT+ZszAS4TqOfADUQxWfAHAUVyJmy7c8EvrgFmKouWAVFZyjYN2XuuGSWHlKeuo9bF9t7MwMGfwAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzVeOxtyTClFO2/OPL6lpuSi3WFTdQgbhX6g/f1Iv2K6o=",
+            "why": "invalid MAC"
+        },
+        {
+            "secret": "83ed5a7ae0494831e938a0a8226472954be9daffb4bf5d7641473b35e959cf90",
+            "public": "90ecf0dd8a793c74809735cc37cc3b9de20ffc9aae0eae7a1a0c740ecf09e395",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "A90ZzLN2HaQRTrzzLoobOtW+c9GyPxVp64fhIygpEpLaYYbCN6Pq1rjptBbN5S2vCFPCsE3wmU5u3Wx6L8oZxJoAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYz8Sxek35q19YWqmhyQNRHVZ+sNTtdgXO3MCnvjw0nanb233a39sc969Lm5DaUPN+yTKV0NbtYYN5hIWDOMOXj63XtzT7S7i/LAhv/l8y1zLTc0aUUoIjEg0EHi/FvlakK",
+            "why": "invalid MAC"
+        },
+        {
+            "secret": "efd2ac18f500ac0fa1b9639149432ff2d309d1b49c7f683c9ca4613d14449dce",
+            "public": "84194beab56b44c426b866261772bc0a447ea34f94f2317ce1350cb714021a25",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "A5vkMZfJPQuWeOQsEiuZX1M4VJLY/k2G1mL8EKHK/yq7gifeC4V4zQ4L1iiQ1oVgmTmhwb/vd21Fm3YZrpYGEvYAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzQlapufh4trECMJjdb8m/TNFFcFJJSmiM/XQpnKXM/wc=",
+            "why": "invalid padding"
+        },
+        {
+            "secret": "2926c352495ce986639ccbb263ad2221df731bae6ee8ec329cbb5d00c5b9ca87",
+            "public": "3c4b835fc7de0dd3a02971b559ccd5d3bcd2eb3cce7c1023b93892918effb71d",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "AzW5Wy/bvTYdcVOLIL8W26mfgTFG19S0H2BC9kyqgqK+TZ8oI00WJTNqwJIg8JE7DqDnOY+Q40Yd3G8Hi4GobQ8AAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYz3cI/rKzcQ22idVIBuFgLEVJaK1W5uxh6M6AdMoKKtdxO+lESYYWCEh/zzj35MFMwSJTn8z+XFvv9f2jYgQXHvPmY13wLOpIrpoS2W8luUbOVf9fip5mZXHw3neYvc7jA",
+            "why": "invalid padding"
+        },
+        {
+            "secret": "47c04c4c6d385ddaaef691bd58dab94f81f4ba9eb1ab832339c3d0042f998dc5",
+            "public": "cb6a3aa6d94a58c9f03354a2a8723c3449e06b19a0ccfe19353195b28ddf7694",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "ciphertext": "#A2A/tbfDDqn4qx267aPFZDwyH78j9zZV8g8ekZKonH8bDR7vYhp7zzh3oJAlJWem/Z5OVrRvUAJQrx8q289PqsEAAAABAAAACeOBr+S4lueVjASdOe8pTxevoZoYq1Y8rRarB6+yzRlquT4RZlmHH3jLEQmAbBjQGrOXi1uWPbaKC8j/VpjW5S9BAtyMSMpUcHg=",
+            "why": "unsupported future version"
+        },
+        {
+            "secret": "751321afdaaf76aeb87851ca8f35eab87d0f50e1ec595c67e7e37ced7d6b7b9a",
+            "public": "a340bd34205bb0f3dc2f9aa3fcb70fc52c326cc4566c457bb9cfb9ae17c239af",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "ciphertext": "AP9SHg4CFoD4fy22vSMNZV+efP7Ld7GCOpIKeZANqL+Kspe380sGxRQGKyy/liCuMi8DbcfQJypivkS+Y/bz3sIAAAABAAAACeOBr+S4lueVjMM0jKIQIfjKuEBBmjWPFmQsB20qe5pcJiLpnnXmp12z",
+            "why": "unsupported version 0"
+        },
+        {
+            "secret": "c4ca1bf68b1f768bbc3670d554036b5c892303319ed6f7228e8dc2f6c99dd0b3",
+            "public": "537986db4ffe564eb7d565643e78dbc24e86650957e6e7c2c8d0124fd04fd68f",
+            "kind": 1,
+            "scope_hex": "",
+            "ciphertext": "Ap2Mv1HTQrVArE2UVevKq7rQ+a0FMw8OBuiAMnA81jJit7c0QzkEMr/o+5++t0/FbXFABfQaTRpF+dBuISyw3rEAAAABAAAAAC5e+Y9lfvgD1trmXL2Jv5H3Khi8ayWJJQMrVOEMd9tlJNj1b7k/ZzIG71f2GBzzoeBImA2fk+q6Iix4v5jUulo=",
+            "why": "unsupported version 2"
+        },
+        {
+            "secret": "9460c5781801b35f01c1093434266cab5ba997014c52d9a16c3772f8580ac61b",
+            "public": "375cf44101e7d77699da6b8d7e633f507eaa82720d4d3cea1c0db85447975fa3",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "BAahtRKP0WL8luCz9m6TydiQtWUfoIWvkRlg2tatPVOCAwYrO8Dw3DZMgeTGjaehohfAmVyZ6SneuTQF3Ho+EUIAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzpHJCeyhgMaqIsPgWO635BaIwmRU4cfe9aA6gGqGI7SY=",
+            "why": "unsupported version 4"
+        },
+        {
+            "secret": "b46bd96a998b00b55e48ad76c1fa0c68bc64b94174a189983b689fc05a0cec52",
+            "public": "797b06ba5dd8ca23a8c8cae4e9ee8963b25d9bf92618fa0b62db1ddc7b611453",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "ciphertext": "",
+            "why": "empty payload"
+        },
+        {
+            "secret": "42602869f3d35e0bb04f72e3053d8de9cccf1e78dd6926c9311134784a5e70d6",
+            "public": "94a4ac3a4bf998dc64ab07cbb573ecb045e028f9b19c88f02af8f73d334ba0bd",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "ciphertext": "Aw==",
+            "why": "payload only has 1 byte"
+        },
+        {
+            "secret": "d2dccc683567cd0cc6d9ec907703ddb362ecb61ef8e6c8ebb7411a293230935a",
+            "public": "294da03d650400e766953c9fb78600b788598a35e47b9755a891802de76f7a09",
+            "kind": 1,
+            "scope_hex": "ef8080",
+            "ciphertext": "A6oBqSSHPckKYt8Doymo2s1ku7LJxSNSfSuQdBoXaRe8q+5FQmvwbejIzJEaVKdUhbykNt5VFxno+sZtreNhrHgAAAABAAAVCO+AgAnTQMJrGJX7muna+wwIyM82vR398H+fhL6XxOam03jQErUC9W+klrNflk6oJ4mmyO88x6FJcf6n6LfDpGjMogNuMxoR1crWfknPMJuHggEUfOU6AjN7CgGiFPdnfcgbUPP487vxX9iw7U8WhQCfnh46vQTdwCDIm0C3aUp2/fJ0xNTVIZkFVKV1CyvyFpVicY9Zc7fmeEIDAsJvM1beK9sWqp9CI/sMU9OXmTfjdugSuisDRevchLkr6h5kB/rXDw==",
+            "why": "scope length out-of-bounds"
+        },
+        {
+            "secret": "e1ef663aeb335452c9670d8a9f1f75cae5077f216314e9b49761610b4eb98538",
+            "public": "b729446e5cdbd2e4ac7967b056c17d5e4735035f2d2cf829722a0a85ca1fb6cb",
+            "kind": 1,
+            "scope_hex": "efbbbfefbfbe",
+            "ciphertext": "A/uzxqp0UwE6j7p8PIRKJDa0ah39GGyMbM0fOivlqESqbfFnp5OD2FSHR9TOTeJwiAfLXcXkoZPwiNKjB4ZgXV4AAAABAAAABu+7v++/vm7l8A==",
+            "why": "ciphertext too short"
+        },
+        {
+            "secret": "327ffef01143a4dae30e201add671183424b39b1f33f64d78c19c22d3a7e790c",
+            "public": "039f6ce0144af03f0f3caf8a070a6a36519e2942286c2295a23785b0668ea621",
+            "kind": 30078,
+            "scope_hex": "737065632e6e6f7374722e6c616e642f6e697034347633",
+            "ciphertext": "A5jnLthci6SRC9V9Ak/AKGyB7xAGPLGZx+fW9wjfvOKQuug5cUUGX4R0mmxFHl5/TtcQ4syIiTtgXL3uVveIP3MAAHV+AAAAF3NwZWMubm9zdHIubGFuZC9uaXA0NHYzS3rEqFHqpL5Yqh/xY+a9i0XAyY960LDSfzQjSZh4UHzbuxmMEk92jAczsFkI9cWqd+xzahX59yD9l+UnCw3o9yXmzZIaA6UYPFI20f2VnH+G6F0Zt917fgt0bJwR3QUwblT63eOKLJGYhXqC11dweuKORW6oGJagRFo7P8r3UIFTHPkL5xMhUtZS7TS7GDKTB7kmEp5trwfzboiWxzp12LSlkUU9Nctyf6KE4iEQbk2jDndbC9npCn1rFpsFiHsd!",
+            "why": "invalid base64 (trailing)"
+        },
+        {
+            "secret": "53d492157f17e6804bacdef3942fbb220a7239aab0e6bd6355eb3ff989ea0076",
+            "public": "ad2e1f00a4d5985810072cea336b0670f8e924368bca5b15c84ba8f3d7cae478",
+            "kind": 1,
+            "scope_hex": "e381afe4b896e7958c",
+            "ciphertext": "A3oG29gbEA%8QXjVLA5JeYOl1Hj5bJVaNcl2tAnfEHm5pzS0V+3eF8Tns8+A+TkfxrSc3DuAbkxc9SgWC+214cBIAAAABAAAACeOBr+S4lueVjGfB4CLk22vLao5NE6OH5KlgzSy++iyD7FZEmAkCVOfQkrnbj9kzyLF7HRygI5E2FJdeQkX6WDiHtwzP/UWwd+cnMaXTYS7vL0Zh6Lvz/PKicCecxB0NvkAdYM3hOpodhXEYd2nano+37mU1Cahp2uwyygJQTb427cHBucQiVpIadVoKqMeIA7EGvO9HTgTxgE93vyT26NqZFO9aniV1bFc7y9nq1OYHFfNQgzdxVMTQ88SwMbq2TSpU5uJc/cphNA==",
+            "why": "invalid base64 (middle)"
+        },
+        {
+            "secret": "d4db7f6dcf6a45843739a806876a9da849f75f7a36702e7b4f7a10a986bf76cd",
+            "public": "0377961328c3bb0db459cd22033d7a7ca1e29d7f42fd3f1b038530a2402879c8",
+            "kind": 1,
+            "scope_hex": "",
+            "ciphertext": "Ay1pBSibePLV49S4vfkgB4GCHR0Xywd7acm1WoC1ZaX6Jg38sM0PQAshZtniNKpUjQWZGw4e7kSKEgFIGhT6SxQAAAADAAAAABuabdmj5F6vlFssb3CHu/ndTMpdcPSWXklapkGwxJRS",
+            "why": "context mismatch (kind)"
+        },
+        {
+            "secret": "b00e9f068deb4b69c474109502839c981bd429075eeab9e5f41db9022c0cd869",
+            "public": "6de2d6a91eb75f5e6038d633da8695f35fad807d5bad6b9e25ae8f526e10c05f",
+            "kind": 1,
+            "scope_hex": "68656c6c6f20776f726c6421",
+            "ciphertext": "A49dkIXX4dVAn6A9ql4cQ3MQfoU7rPrsg9/8V8d5NL9+A7Ntb9VIbBQ4V2ORFXS5rzOkHhZkKmtnn3dpMUiQWwsAACcQAAAADGhlbGxvIHdvcmxkIRb3rRdfIPuJvtEnjn6dj7RgKg1OUvGmCQoXmp+32EN6XL+vEHnbIbvLWLqIV7eCAmOqrPVGngCJEppHzzFMuhM=",
+            "why": "context mismatch (kind)"
+        },
+        {
+            "secret": "e150f3f5fd2eb47c49e8c1ee0ca51d3502d370108a98519d212731746fc513c2",
+            "public": "901f54e63d0d1df5bf120e12faf00d6e4ec3c6d9fe81e0dc0f35cf1d5a489ac2",
+            "kind": 30078,
+            "scope_hex": "6170706c69636174696f6e2d64617461",
+            "ciphertext": "A/JaJhlnuKYJhr6LdZ46lkK7cw0nxGvA4rp112e70q0O9jMnXxaWqqNE7nZnllwl7yuGWRtcLU2q6uWAUZ6wthIAAHV+AAAAD2luY29ycmVjdC1zY29wZZ++z1BEvaKntWN9G+9EIT0da0luVAV/hAvOoUg90pXE4C6nsAKmpZ3Q2YfAvtUDlkMpxPv4u10Rlz0VGlPo9GtcGJp4X2aq/5gdbTZJF8mxnkhZ4zQqwRibV0JJ0ZNZxg==",
+            "why": "context mismatch (scope)"
+        },
+        {
+            "secret": "1c9c9ff5df8a9ff99e50b3dac27d987422567e9122075097edea2915e12580ca",
+            "public": "32178882654a70441f1c507902ae3a89888ecd2266930a45f8d6b2f578643307",
+            "kind": 4,
+            "scope_hex": "efbbbf",
+            "ciphertext": "A3c7VODzMr9mQXQNRtw3MQsntesGokh3g8nQwdAK4iWqL/nV6HPOhnz5xFf1UjyvTrHJC8BrGjRefguMrJLrfy8AAAAEAAAAD2luY29ycmVjdC1zY29wZfvq9zBo8LQrHyulrPg0swuPZs4W3Xy1TSQlmczZ643aOllm+9DveIcqoXoQaGQTs1RDLeekOMNquv9a5XMWZ431ysJ44L3ET4Ztw5Eevnxx3pgaob8bCikyuGT+5CyR2A==",
+            "why": "context mismatch (scope)"
+        },
+        {
+            "secret": "18a8c52a7d94c36bf08ec04336247ab2c67014b964a3e33f3d6677e697f2008c",
+            "public": "d1069a731110484f212fa9fe2fa4dcd2e2c0857b5e0dda1bd5667901ce303d81",
+            "kind": 4,
+            "scope_hex": "ff",
+            "ciphertext": "A3PSjybYp19qos4LlMKEdlPQShJIBOJBGjjOI6etumpU4VaN0LYMB8qECxbwF7ebuv2Lxu5h0yXtNpdJtX4Z5fgAAAAEAAAAAf+AeTttkffcDMHUCDRxKYA3p7nnmK2hNvB04X0VP2H27Q==",
+            "why": "invalid scope (not valid utf8)"
+        }
+    ]
+}

--- a/client/core/usercontext.go
+++ b/client/core/usercontext.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	nostr "github.com/0ceanslim/grain/server/types"
 )
@@ -99,3 +101,91 @@ func (uc *UserContext) ClearFixedRelays() { uc.client.ClearFixedRelays() }
 
 // FixedRelaysEnabled reports whether the fixed-relay override is active.
 func (uc *UserContext) FixedRelaysEnabled() bool { return uc.client.FixedRelaysEnabled() }
+
+// StreamNotes streams author's text notes (kind 1) from their outbox relays as
+// each relay answers — the lazy-hydration path for a profile feed. Pass options
+// like [WithLimit] to bound it. Routing honours the fixed-relay override.
+func (uc *UserContext) StreamNotes(ctx context.Context, author string, opts ...StreamOption) <-chan *nostr.Event {
+	relays := uc.client.RouteFetch(author)
+	filter := nostr.Filter{Authors: []string{author}, Kinds: []int{1}}
+	return uc.client.StreamEvents(ctx, filter, relays, opts...)
+}
+
+// FetchNotes collects author's text notes (kind 1) from their outbox relays.
+// Best-effort: per-relay failures are logged, so an empty result means "none
+// found" rather than a hard error. For incremental delivery use [StreamNotes].
+func (uc *UserContext) FetchNotes(ctx context.Context, author string, opts ...StreamOption) []*nostr.Event {
+	relays := uc.client.RouteFetch(author)
+	filter := nostr.Filter{Authors: []string{author}, Kinds: []int{1}}
+	return uc.client.QueryEvents(ctx, filter, relays, opts...)
+}
+
+// Reply builds a NIP-10 kind-1 reply to parent, signs it as this user, and
+// publishes it under the outbox model so it reaches the parent author's inbox as
+// well as the user's own audience. It returns the signed reply and the per-relay
+// broadcast results. Requires a signer.
+func (uc *UserContext) Reply(parent *nostr.Event, content string) (*nostr.Event, []BroadcastResult, error) {
+	if parent == nil {
+		return nil, nil, fmt.Errorf("reply: parent event is nil")
+	}
+	evt := &nostr.Event{
+		Kind:      1,
+		Content:   content,
+		CreatedAt: time.Now().Unix(),
+		Tags:      buildReplyTags(parent),
+	}
+	results, err := uc.SignAndPublish(evt)
+	return evt, results, err
+}
+
+// buildReplyTags assembles the NIP-10 e/p tags for a reply to parent: the thread
+// root and the immediate parent as marked "e" tags, plus "p" tags for everyone
+// already in the thread and the parent's author, so the whole thread is notified.
+func buildReplyTags(parent *nostr.Event) [][]string {
+	var tags [][]string
+
+	// Thread root: a marked "root" e-tag on the parent, else the first "e" tag
+	// (positional NIP-10), else the parent itself is the root.
+	root := ""
+	for _, tag := range parent.Tags {
+		if len(tag) >= 4 && tag[0] == "e" && tag[3] == "root" {
+			root = tag[1]
+			break
+		}
+	}
+	if root == "" {
+		for _, tag := range parent.Tags {
+			if len(tag) >= 2 && tag[0] == "e" {
+				root = tag[1]
+				break
+			}
+		}
+	}
+	if root != "" && root != parent.ID {
+		tags = append(tags, []string{"e", root, "", "root"})
+		tags = append(tags, []string{"e", parent.ID, "", "reply"})
+	} else {
+		tags = append(tags, []string{"e", parent.ID, "", "root"})
+	}
+
+	// Notify everyone already in the thread, plus the parent's author.
+	seen := make(map[string]struct{})
+	addP := func(pk string) {
+		if pk == "" {
+			return
+		}
+		if _, ok := seen[pk]; ok {
+			return
+		}
+		seen[pk] = struct{}{}
+		tags = append(tags, []string{"p", pk})
+	}
+	for _, tag := range parent.Tags {
+		if len(tag) >= 2 && tag[0] == "p" {
+			addP(tag[1])
+		}
+	}
+	addP(parent.PubKey)
+
+	return tags
+}

--- a/client/core/usercontext.go
+++ b/client/core/usercontext.go
@@ -75,17 +75,17 @@ func (uc *UserContext) Sign(event *nostr.Event) error {
 // Publish routes an already-signed event under the outbox model (the author's
 // outbox ∪ each p-tagged recipient's inbox; metadata also to the indexers) and
 // broadcasts it, returning the per-relay results.
-func (uc *UserContext) Publish(event *nostr.Event) ([]BroadcastResult, error) {
+func (uc *UserContext) Publish(ctx context.Context, event *nostr.Event) ([]BroadcastResult, error) {
 	relays := uc.client.RoutePublish(event)
-	return uc.client.PublishEvent(event, relays)
+	return uc.client.PublishEvent(ctx, event, relays)
 }
 
 // SignAndPublish signs event as this user and then publishes it.
-func (uc *UserContext) SignAndPublish(event *nostr.Event) ([]BroadcastResult, error) {
+func (uc *UserContext) SignAndPublish(ctx context.Context, event *nostr.Event) ([]BroadcastResult, error) {
 	if err := uc.Sign(event); err != nil {
 		return nil, err
 	}
-	return uc.Publish(event)
+	return uc.Publish(ctx, event)
 }
 
 // PinFixedRelays enables the fixed-relay override — reads come from readRelays,
@@ -124,7 +124,7 @@ func (uc *UserContext) FetchNotes(ctx context.Context, author string, opts ...St
 // publishes it under the outbox model so it reaches the parent author's inbox as
 // well as the user's own audience. It returns the signed reply and the per-relay
 // broadcast results. Requires a signer.
-func (uc *UserContext) Reply(parent *nostr.Event, content string) (*nostr.Event, []BroadcastResult, error) {
+func (uc *UserContext) Reply(ctx context.Context, parent *nostr.Event, content string) (*nostr.Event, []BroadcastResult, error) {
 	if parent == nil {
 		return nil, nil, fmt.Errorf("reply: parent event is nil")
 	}
@@ -134,7 +134,7 @@ func (uc *UserContext) Reply(parent *nostr.Event, content string) (*nostr.Event,
 		CreatedAt: time.Now().Unix(),
 		Tags:      buildReplyTags(parent),
 	}
-	results, err := uc.SignAndPublish(evt)
+	results, err := uc.SignAndPublish(ctx, evt)
 	return evt, results, err
 }
 

--- a/client/core/usercontext.go
+++ b/client/core/usercontext.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"fmt"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+// UserContext is the per-session handle a downstream app uses to act as one user
+// on the outbox engine: their editable relay config ([SessionRelays]), an
+// optional [Signer] for publishing, and the shared [Client] that owns the
+// connection pool. Construct it with [Client.NewUserContext].
+//
+// grain's own web layer (client/api, client/session, …) is a reference consumer
+// of this surface; a CLI or bot uses it directly. Read-only callers omit the
+// signer.
+//
+// Pre-1.0 note: the network methods don't take a context.Context yet (it lands
+// in a follow-up slice), and PublishDM is deferred until NIP-44 encryption is
+// available. See docs/design/outbox-relay-pool.md §11.
+type UserContext struct {
+	client *Client
+	pubkey string
+	signer Signer
+	relays *SessionRelays
+}
+
+// UserOption configures a [UserContext] at construction.
+type UserOption func(*UserContext)
+
+// WithSigner attaches a signer so the context can publish. Without one the
+// context is read-only and [UserContext.Sign] / [UserContext.SignAndPublish]
+// return an error.
+func WithSigner(s Signer) UserOption {
+	return func(uc *UserContext) { uc.signer = s }
+}
+
+// NewUserContext creates a [UserContext] for pubkey (64-char hex) on this
+// client. Apply options such as [WithSigner] to attach a signer.
+func (c *Client) NewUserContext(pubkey string, opts ...UserOption) *UserContext {
+	uc := &UserContext{client: c, pubkey: pubkey, relays: newSessionRelays()}
+	for _, o := range opts {
+		o(uc)
+	}
+	return uc
+}
+
+// PublicKey returns the context user's pubkey (hex).
+func (uc *UserContext) PublicKey() string { return uc.pubkey }
+
+// Client returns the shared client that owns the connection pool.
+func (uc *UserContext) Client() *Client { return uc.client }
+
+// Signer returns the attached signer, or nil for a read-only context.
+func (uc *UserContext) Signer() Signer { return uc.signer }
+
+// Relays returns the user's editable, role-tagged session relay config.
+func (uc *UserContext) Relays() *SessionRelays { return uc.relays }
+
+// Sign signs event as this user. It requires a signer and errors if the signer's
+// public key does not match the context user, so a caller can't accidentally
+// sign as someone else.
+func (uc *UserContext) Sign(event *nostr.Event) error {
+	if uc.signer == nil {
+		return fmt.Errorf("user context for %s is read-only: no signer attached", uc.pubkey)
+	}
+	if pk := uc.signer.PublicKey(); pk != uc.pubkey {
+		return fmt.Errorf("signer pubkey %s does not match user context %s", pk, uc.pubkey)
+	}
+	return uc.signer.SignEvent(event)
+}
+
+// Publish routes an already-signed event under the outbox model (the author's
+// outbox ∪ each p-tagged recipient's inbox; metadata also to the indexers) and
+// broadcasts it, returning the per-relay results.
+func (uc *UserContext) Publish(event *nostr.Event) ([]BroadcastResult, error) {
+	relays := uc.client.RoutePublish(event)
+	return uc.client.PublishEvent(event, relays)
+}
+
+// SignAndPublish signs event as this user and then publishes it.
+func (uc *UserContext) SignAndPublish(event *nostr.Event) ([]BroadcastResult, error) {
+	if err := uc.Sign(event); err != nil {
+		return nil, err
+	}
+	return uc.Publish(event)
+}
+
+// PinFixedRelays enables the fixed-relay override — reads come from readRelays,
+// writes go to writeRelays — which DISABLES the outbox model. Discouraged; for
+// users who explicitly want a fixed-/single-relay client. The override is
+// client-wide (see [Client.SetFixedRelays]), not scoped to this context.
+func (uc *UserContext) PinFixedRelays(readRelays, writeRelays []string) {
+	uc.client.SetFixedRelays(readRelays, writeRelays)
+}
+
+// ClearFixedRelays disables the override and restores outbox routing.
+func (uc *UserContext) ClearFixedRelays() { uc.client.ClearFixedRelays() }
+
+// FixedRelaysEnabled reports whether the fixed-relay override is active.
+func (uc *UserContext) FixedRelaysEnabled() bool { return uc.client.FixedRelaysEnabled() }

--- a/client/core/usercontext_test.go
+++ b/client/core/usercontext_test.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"testing"
+
+	nostr "github.com/0ceanslim/grain/server/types"
+)
+
+func TestNewUserContext(t *testing.T) {
+	c := NewClient(DefaultConfig())
+	uc := c.NewUserContext("abc123")
+	if uc.PublicKey() != "abc123" {
+		t.Errorf("PublicKey() = %q", uc.PublicKey())
+	}
+	if uc.Client() != c {
+		t.Error("Client() should return the constructing client")
+	}
+	if uc.Signer() != nil {
+		t.Error("a context built without WithSigner should be read-only")
+	}
+	if uc.Relays() == nil {
+		t.Error("Relays() must not be nil")
+	}
+}
+
+func TestUserContextSign(t *testing.T) {
+	c := NewClient(DefaultConfig())
+
+	// Read-only context: Sign must refuse.
+	ro := c.NewUserContext("deadbeef")
+	if err := ro.Sign(&nostr.Event{Kind: 1}); err == nil {
+		t.Error("read-only context should fail to Sign")
+	}
+
+	es, err := NewEventSignerFromRandom()
+	if err != nil {
+		t.Fatalf("NewEventSignerFromRandom: %v", err)
+	}
+
+	// Signer pubkey must match the context pubkey.
+	mismatch := c.NewUserContext("not-the-signers-key", WithSigner(es))
+	if err := mismatch.Sign(&nostr.Event{Kind: 1}); err == nil {
+		t.Error("Sign should reject a signer whose pubkey != context pubkey")
+	}
+
+	// Matching context: signs, stamps pubkey, verifies.
+	uc := c.NewUserContext(es.PublicKey(), WithSigner(es))
+	evt := &nostr.Event{Kind: 1, Content: "hi", CreatedAt: 1700000000}
+	if err := uc.Sign(evt); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if evt.PubKey != es.PublicKey() {
+		t.Errorf("Sign left PubKey = %q", evt.PubKey)
+	}
+	if !VerifyEventSignature(evt) {
+		t.Error("signed event failed verification")
+	}
+}
+
+func TestSessionRelays(t *testing.T) {
+	sr := newSessionRelays()
+	sr.Set("wss://a", RoleOutbox|RoleInbox)
+	sr.Set("wss://b", RoleInbox)
+	sr.Add("wss://b", RoleDMInbox)
+
+	if got := sr.Get("wss://a"); got != RoleOutbox|RoleInbox {
+		t.Errorf("Get(a) = %v", got)
+	}
+	if got := sr.Get("wss://b"); got != RoleInbox|RoleDMInbox {
+		t.Errorf("Get(b) = %v", got)
+	}
+	if inboxes := sr.ByRole(RoleInbox); len(inboxes) != 2 || inboxes[0] != "wss://a" || inboxes[1] != "wss://b" {
+		t.Errorf("ByRole(Inbox) = %v (want sorted [a b])", inboxes)
+	}
+	if out := sr.ByRole(RoleOutbox); len(out) != 1 || out[0] != "wss://a" {
+		t.Errorf("ByRole(Outbox) = %v", out)
+	}
+
+	sr.Set("wss://a", 0) // setting zero removes
+	if got := sr.Get("wss://a"); got != 0 {
+		t.Errorf("Set(a, 0) should remove; Get = %v", got)
+	}
+	sr.Remove("wss://b")
+	if len(sr.All()) != 0 {
+		t.Errorf("All() = %v, want empty", sr.All())
+	}
+}

--- a/client/core/usercontext_test.go
+++ b/client/core/usercontext_test.go
@@ -57,6 +57,68 @@ func TestUserContextSign(t *testing.T) {
 	}
 }
 
+func TestBuildReplyTags(t *testing.T) {
+	hasTag := func(tags [][]string, want ...string) bool {
+		for _, tg := range tags {
+			if len(tg) < len(want) {
+				continue
+			}
+			ok := true
+			for i, w := range want {
+				if tg[i] != w {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return true
+			}
+		}
+		return false
+	}
+	countP := func(tags [][]string, pk string) int {
+		n := 0
+		for _, tg := range tags {
+			if len(tg) >= 2 && tg[0] == "p" && tg[1] == pk {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Reply to a top-level note: parent is the root, author gets a p-tag.
+	top := &nostr.Event{ID: "P1", PubKey: "AUTHOR", Kind: 1}
+	tt := buildReplyTags(top)
+	if !hasTag(tt, "e", "P1", "", "root") {
+		t.Errorf("top-level reply missing root e-tag: %v", tt)
+	}
+	if !hasTag(tt, "p", "AUTHOR") {
+		t.Errorf("top-level reply missing author p-tag: %v", tt)
+	}
+
+	// Reply within a thread: carry the root, mark the parent as reply, notify
+	// the whole thread, and don't duplicate the parent author.
+	mid := &nostr.Event{
+		ID: "P2", PubKey: "BOB", Kind: 1,
+		Tags: [][]string{
+			{"e", "ROOT", "", "root"},
+			{"e", "P1", "", "reply"},
+			{"p", "ALICE"},
+			{"p", "BOB"}, // parent author already present — must not double
+		},
+	}
+	mt := buildReplyTags(mid)
+	if !hasTag(mt, "e", "ROOT", "", "root") {
+		t.Errorf("threaded reply missing root: %v", mt)
+	}
+	if !hasTag(mt, "e", "P2", "", "reply") {
+		t.Errorf("threaded reply missing reply marker: %v", mt)
+	}
+	if !hasTag(mt, "p", "ALICE") || countP(mt, "BOB") != 1 {
+		t.Errorf("threaded reply p-tags wrong (want ALICE + single BOB): %v", mt)
+	}
+}
+
 func TestSessionRelays(t *testing.T) {
 	sr := newSessionRelays()
 	sr.Set("wss://a", RoleOutbox|RoleInbox)

--- a/client/data/fetch.go
+++ b/client/data/fetch.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -106,7 +107,7 @@ func FetchAndCacheUserDataWithCoreClient(publicKey string) error {
 	go func() {
 		defer wg.Done()
 		log.ClientData().Debug("Fetching user metadata", "pubkey", publicKey)
-		userMetadata, profileErr = coreClient.GetUserProfile(publicKey, relaysForQueries)
+		userMetadata, profileErr = coreClient.GetUserProfile(context.Background(), publicKey, relaysForQueries)
 	}()
 	wg.Wait()
 

--- a/client/data/fetch.go
+++ b/client/data/fetch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0ceanslim/grain/client/cache"
 	"github.com/0ceanslim/grain/client/connection"
 	"github.com/0ceanslim/grain/client/core"
+	nostr "github.com/0ceanslim/grain/server/types"
 	"github.com/0ceanslim/grain/server/utils/log"
 )
 
@@ -83,15 +84,38 @@ func FetchAndCacheUserDataWithCoreClient(publicKey string) error {
 		return fmt.Errorf("no relays available for fetching user data")
 	}
 
-	// Fetch user's mailboxes (kind 10002) first with better error handling
-	log.ClientData().Info("Fetching user mailboxes", "pubkey", publicKey, "relay_count", len(relaysForQueries))
-	mailboxes, err := coreClient.GetUserRelays(publicKey)
-	if err != nil {
+	// Fetch mailboxes (kind 10002) and metadata (kind 0) concurrently. They are
+	// independent queries, and running them serially was a dominant chunk of
+	// login latency (#77): each waits on its own relay round-trip, so back to
+	// back they doubled the worst case. Subscription IDs are unique per call
+	// (see generateSubscriptionID), so the two REQs don't cross-wire.
+	var (
+		mailboxes    *core.Mailboxes
+		userMetadata *nostr.Event
+		mailboxErr   error
+		profileErr   error
+		wg           sync.WaitGroup
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		log.ClientData().Info("Fetching user mailboxes", "pubkey", publicKey, "relay_count", len(relaysForQueries))
+		mailboxes, mailboxErr = coreClient.GetUserRelays(publicKey)
+	}()
+	go func() {
+		defer wg.Done()
+		log.ClientData().Debug("Fetching user metadata", "pubkey", publicKey)
+		userMetadata, profileErr = coreClient.GetUserProfile(publicKey, relaysForQueries)
+	}()
+	wg.Wait()
+
+	// Mailboxes are optional — the user may not have published a relay list.
+	if mailboxErr != nil {
 		log.ClientData().Warn("Failed to fetch mailboxes, user may not have relay list published",
 			"pubkey", publicKey,
-			"error", err,
+			"error", mailboxErr,
 			"relays_used", relaysForQueries)
-		// Set mailboxes to nil - this is not an error, user may not have published a relay list
 		mailboxes = nil
 	} else if mailboxes != nil {
 		totalRelays := len(mailboxes.Read) + len(mailboxes.Write) + len(mailboxes.Both)
@@ -103,13 +127,10 @@ func FetchAndCacheUserDataWithCoreClient(publicKey string) error {
 			"total_relays", totalRelays)
 	}
 
-	// Fetch user metadata (profile) using the same relays
-	log.ClientData().Debug("Fetching user metadata", "pubkey", publicKey)
-	userMetadata, err := coreClient.GetUserProfile(publicKey, relaysForQueries)
-	if err != nil || userMetadata == nil {
-		return fmt.Errorf("failed to fetch user metadata: %w", err)
+	// Metadata is required.
+	if profileErr != nil || userMetadata == nil {
+		return fmt.Errorf("failed to fetch user metadata: %w", profileErr)
 	}
-
 	log.ClientData().Info("Successfully fetched user metadata", "pubkey", publicKey, "event_id", userMetadata.ID)
 
 	// Cache the data using the cache package function

--- a/client/data/fetch.go
+++ b/client/data/fetch.go
@@ -136,6 +136,12 @@ func FetchAndCacheUserDataWithCoreClient(publicKey string) error {
 	// Cache the data using the cache package function
 	cache.CacheUserDataFromObjects(publicKey, userMetadata, mailboxes)
 
+	// Login-hydration: warm the media-server + relay-list caches in the
+	// background so the settings pages render from cache instead of fetching on
+	// open. Both Warm* helpers spawn their own goroutine, so this never blocks.
+	coreClient.WarmMediaServers(publicKey)
+	coreClient.WarmUserRelayLists(publicKey)
+
 	// Initialize client relays based on what we found
 	if mailboxes != nil {
 		// User has mailboxes - replace client relays with user's preferred relays

--- a/client/init.go
+++ b/client/init.go
@@ -54,6 +54,10 @@ func InitializeClient(ctx context.Context, serverCfg *cfgType.ServerConfig) erro
 	// Start relay connection health check (check every 5 minutes)
 	connection.StartRelayHealthCheck(ctx, 5*time.Minute)
 
+	// Start the outbox pool's idle-connection sweeper (reclaims per-user relays
+	// the pool dialed on demand once they go idle).
+	connection.StartRelayEvictionSweeper(ctx, time.Minute)
+
 	log.ClientMain().Info("Client package initialized successfully")
 	return nil
 }

--- a/client/nostr_kinds.go
+++ b/client/nostr_kinds.go
@@ -12,6 +12,11 @@
 // Update by reading the upstream README, not by inventing labels.
 package client
 
+import (
+	"encoding/json"
+	"net/http"
+)
+
 // KindLabels maps kind → "Display Name (NIP-XX)" or
 // "Display Name (deprecated)" where applicable. Keep ordered by
 // kind for diffability; ranges (10000+) are NOT enumerated because
@@ -88,3 +93,12 @@ var KindLabels = map[int]string{
 // "" if the kind isn't in the table. Callers that want a fallback
 // string should `if l := KindLabel(k); l != "" { ... }`.
 func KindLabel(k int) string { return KindLabels[k] }
+
+// KindLabelsHandler serves the kind → label table as JSON for client UIs (the
+// relay-stream feed). Object keys are stringified kinds; unknown kinds are
+// simply absent and the UI falls back to "Kind N".
+func KindLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_ = json.NewEncoder(w).Encode(KindLabels)
+}

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -151,6 +151,9 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/client/fixed-relays", api.FixedRelaysHandler)
 	// Session app-relay preferences (local roles: indexer/broadcast/local/trusted).
 	mux.HandleFunc("/api/v1/client/app-relays", api.AppRelaysHandler)
+	// Known-relays browser: list the known set + per-relay NIP-11 (cached).
+	mux.HandleFunc("/api/v1/client/known-relays", api.KnownRelaysHandler)
+	mux.HandleFunc("/api/v1/relay-info", api.RelayInfoHandler)
 
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -135,6 +135,11 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/user/profile/build", api.BuildProfileHandler)
 	mux.HandleFunc("/api/v1/user/relays", api.GetUserRelaysHandler)
 
+	// Media-server lists (Blossom kind 10063 + NIP-96 kind 10096) for the
+	// upload flow: the user's resolved lists, plus grain's quick-add suggestions.
+	mux.HandleFunc("/api/v1/user/media-servers", api.GetUserMediaServersHandler)
+	mux.HandleFunc("/api/v1/media-servers/suggested", api.GetSuggestedMediaServersHandler)
+
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)
 	mux.HandleFunc("/api/v1/events/publish", api.PublishSignedHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -154,6 +154,8 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	// Known-relays browser: list the known set + per-relay NIP-11 (cached).
 	mux.HandleFunc("/api/v1/client/known-relays", api.KnownRelaysHandler)
 	mux.HandleFunc("/api/v1/relay-info", api.RelayInfoHandler)
+	// TCP-connect latency for a set of relays — the browser's "fastest first" sort.
+	mux.HandleFunc("/api/v1/relays/ping", api.PingRelaysHandler)
 
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -149,6 +149,7 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)
 	mux.HandleFunc("/api/v1/events/publish", api.PublishSignedHandler)
+	mux.HandleFunc("/api/v1/events/publish/stream", api.PublishSignedStreamHandler)
 
 	// Relay management endpoints
 	mux.HandleFunc("/api/v1/client/relays", api.ClientRelaysHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -138,6 +138,7 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	// Media-server lists (Blossom kind 10063 + NIP-96 kind 10096) for the
 	// upload flow: the user's resolved lists, plus grain's quick-add suggestions.
 	mux.HandleFunc("/api/v1/user/media-servers", api.GetUserMediaServersHandler)
+	mux.HandleFunc("/api/v1/user/media-servers/build", api.BuildMediaServersHandler)
 	mux.HandleFunc("/api/v1/media-servers/suggested", api.GetSuggestedMediaServersHandler)
 
 	// Event querying endpoints

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -156,6 +156,10 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/relay-info", api.RelayInfoHandler)
 	// TCP-connect latency for a set of relays — the browser's "fastest first" sort.
 	mux.HandleFunc("/api/v1/relays/ping", api.PingRelaysHandler)
+	// NIP-42 AUTH: relays that have challenged us, answer one, revoke one.
+	mux.HandleFunc("/api/v1/client/auth-requests", api.AuthRequestsHandler)
+	mux.HandleFunc("/api/v1/client/auth", api.SubmitAuthHandler)
+	mux.HandleFunc("/api/v1/client/auth/remove", api.RemoveAuthHandler)
 
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -143,6 +143,7 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 
 	// Relay-list management: build a NIP-65 / NIP-17 / NIP-51 relay list to sign,
 	// and the fixed-relay override (advanced opt-out of the outbox model).
+	mux.HandleFunc("/api/v1/user/relay-lists", api.GetUserRelayListsHandler)
 	mux.HandleFunc("/api/v1/user/relay-list/build", api.BuildRelayListHandler)
 	mux.HandleFunc("/api/v1/client/fixed-relays", api.FixedRelaysHandler)
 

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -132,10 +132,12 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 
 	// User data fetching endpoints
 	mux.HandleFunc("/api/v1/user/profile", api.GetUserProfileHandler)
+	mux.HandleFunc("/api/v1/user/profile/build", api.BuildProfileHandler)
 	mux.HandleFunc("/api/v1/user/relays", api.GetUserRelaysHandler)
 
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)
+	mux.HandleFunc("/api/v1/events/publish", api.PublishSignedHandler)
 
 	// Relay management endpoints
 	mux.HandleFunc("/api/v1/client/relays", api.ClientRelaysHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -159,4 +159,8 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 
 	// Relay-pool status (total vs connected) for the dashboard indicator
 	mux.HandleFunc("/api/v1/client/status", api.ClientStatusHandler)
+
+	// Live update channel (SSE) — server->browser push for live-sync (#87) and
+	// the streaming fetch path (#77).
+	mux.HandleFunc("/api/v1/stream", api.StreamHandler)
 }

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -141,6 +141,11 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/user/media-servers/build", api.BuildMediaServersHandler)
 	mux.HandleFunc("/api/v1/media-servers/suggested", api.GetSuggestedMediaServersHandler)
 
+	// Relay-list management: build a NIP-65 / NIP-17 / NIP-51 relay list to sign,
+	// and the fixed-relay override (advanced opt-out of the outbox model).
+	mux.HandleFunc("/api/v1/user/relay-list/build", api.BuildRelayListHandler)
+	mux.HandleFunc("/api/v1/client/fixed-relays", api.FixedRelaysHandler)
+
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)
 	mux.HandleFunc("/api/v1/events/publish", api.PublishSignedHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -149,6 +149,8 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/user/relay-lists", api.GetUserRelayListsHandler)
 	mux.HandleFunc("/api/v1/user/relay-list/build", api.BuildRelayListHandler)
 	mux.HandleFunc("/api/v1/client/fixed-relays", api.FixedRelaysHandler)
+	// Session app-relay preferences (local roles: indexer/broadcast/local/trusted).
+	mux.HandleFunc("/api/v1/client/app-relays", api.AppRelaysHandler)
 
 	// Event querying endpoints
 	mux.HandleFunc("/api/v1/events/query", api.QueryEventsHandler)

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -60,6 +60,9 @@ func RegisterEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/ping/", api.PingHandler)
 	mux.HandleFunc("/api/v1/keys/decode/nip19/", api.Nip19DecodeHandler) // Decode NIP-19 entities
 
+	// Kind → human-readable label table (for the relay-stream feed).
+	mux.HandleFunc("/api/v1/kinds", KindLabelsHandler)
+
 	// OpenAPI / Swagger UI. The spec is served standalone so other
 	// tooling (Postman, openapi-generator, etc.) can consume it
 	// without scraping the UI shell. The UI itself is grain's own

--- a/client/registerEndpoints.go
+++ b/client/registerEndpoints.go
@@ -141,4 +141,7 @@ func registerCoreClientEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/client/relays", api.ClientRelaysHandler)
 	mux.HandleFunc("/api/v1/client/connect/", api.ClientConnectHandler)
 	mux.HandleFunc("/api/v1/client/disconnect/", api.ClientDisconnectHandler)
+
+	// Relay-pool status (total vs connected) for the dashboard indicator
+	mux.HandleFunc("/api/v1/client/status", api.ClientStatusHandler)
 }

--- a/client/stream/hub.go
+++ b/client/stream/hub.go
@@ -1,0 +1,112 @@
+// Package stream is grain's server->browser push channel. A per-pubkey hub fans
+// live messages (login-hydration live-sync #87, streaming fetch #77) out to a
+// user's open pages over SSE; connections register on connect and drop on
+// disconnect. Lifecycle callbacks let a consumer start work (e.g. the own-event
+// subscription) only while a page is actually open.
+package stream
+
+import "sync"
+
+// Message is a JSON-serialisable push sent to a user's open pages.
+type Message struct {
+	Type string `json:"type"`           // "list-updated" | "profile-updated" | ...
+	Kind int    `json:"kind,omitempty"` // event kind, when relevant
+	Data any    `json:"data,omitempty"` // optional payload
+}
+
+// conn is one open SSE connection's buffered outbound channel.
+type conn struct {
+	ch chan Message
+}
+
+// Hub fans push messages out to a user's open browser pages, keyed by pubkey.
+type Hub struct {
+	mu      sync.Mutex
+	clients map[string]map[*conn]struct{} // pubkey -> set of connections
+	onFirst func(pubkey string)           // first connection for a pubkey opened
+	onLast  func(pubkey string)           // last connection for a pubkey closed
+}
+
+var hub = &Hub{clients: make(map[string]map[*conn]struct{})}
+
+// Default returns the process-wide hub.
+func Default() *Hub { return hub }
+
+// SetLifecycle wires callbacks fired when a pubkey gains its first / loses its
+// last open connection — so the live-sync subscription runs only while a page is
+// open. Either may be nil.
+func (h *Hub) SetLifecycle(onFirst, onLast func(string)) {
+	h.mu.Lock()
+	h.onFirst, h.onLast = onFirst, onLast
+	h.mu.Unlock()
+}
+
+// Register adds a connection for pubkey and returns its message channel plus an
+// unregister func to call on disconnect.
+func (h *Hub) Register(pubkey string) (<-chan Message, func()) {
+	c := &conn{ch: make(chan Message, 16)}
+
+	h.mu.Lock()
+	set, ok := h.clients[pubkey]
+	if !ok {
+		set = make(map[*conn]struct{})
+		h.clients[pubkey] = set
+	}
+	first := len(set) == 0
+	set[c] = struct{}{}
+	onFirst := h.onFirst
+	h.mu.Unlock()
+
+	if first && onFirst != nil {
+		onFirst(pubkey)
+	}
+	return c.ch, func() { h.unregister(pubkey, c) }
+}
+
+func (h *Hub) unregister(pubkey string, c *conn) {
+	h.mu.Lock()
+	set := h.clients[pubkey]
+	last := false
+	if set != nil {
+		if _, ok := set[c]; ok {
+			delete(set, c)
+			close(c.ch)
+		}
+		if len(set) == 0 {
+			delete(h.clients, pubkey)
+			last = true
+		}
+	}
+	onLast := h.onLast
+	h.mu.Unlock()
+
+	if last && onLast != nil {
+		onLast(pubkey)
+	}
+}
+
+// Push delivers a message to all of pubkey's open connections. Non-blocking: a
+// connection whose buffer is full drops the message rather than stalling others.
+func (h *Hub) Push(pubkey string, msg Message) {
+	h.mu.Lock()
+	set := h.clients[pubkey]
+	conns := make([]*conn, 0, len(set))
+	for c := range set {
+		conns = append(conns, c)
+	}
+	h.mu.Unlock()
+
+	for _, c := range conns {
+		select {
+		case c.ch <- msg:
+		default:
+		}
+	}
+}
+
+// HasClients reports whether pubkey currently has any open connection.
+func (h *Hub) HasClients(pubkey string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients[pubkey]) > 0
+}

--- a/client/templateEngine.go
+++ b/client/templateEngine.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"net/http"
 	"path"
+	"strconv"
+	"time"
 )
 
 type PageData struct {
@@ -19,10 +21,18 @@ var assetVersion = "dev"
 
 // SetAssetVersion wires the build version in so {{assetVersion}} in the
 // templates resolves to it. Called from main once the version is known.
+//
+// Dev builds carry no release version (Version == "dev"), and a fixed "dev"
+// stamp lets the browser and the PWA service worker stale-serve old JS across
+// rebuilds — the SW caches some scripts cache-first, so a constant ?v=dev URL
+// never re-fetches. Use a per-process value for dev instead, so every rebuild /
+// restart produces fresh ?v= URLs that bust both caches.
 func SetAssetVersion(v string) {
-	if v != "" {
-		assetVersion = v
+	if v == "" || v == "dev" {
+		assetVersion = "dev-" + strconv.FormatInt(time.Now().Unix(), 10)
+		return
 	}
+	assetVersion = v
 }
 
 // baseTemplateFuncs are the helpers every layout-rendered page needs.

--- a/config/Blacklist.go
+++ b/config/Blacklist.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -559,7 +560,7 @@ func FetchAuthorMuteListEvents(author string) ([]*nostr.Event, error) {
 		Authors: []string{author},
 		Kinds:   muteListKinds,
 	}
-	sub, err := client.Subscribe([]nostr.Filter{filter}, targets)
+	sub, err := client.Subscribe(context.Background(), []nostr.Filter{filter}, targets)
 	if err != nil {
 		return nil, fmt.Errorf("subscribe failed: %w", err)
 	}
@@ -588,7 +589,7 @@ func fetchAuthorMuteListPubkeys(client *core.Client, author string) []string {
 		Authors: []string{author},
 		Kinds:   muteListKinds,
 	}
-	sub, err := client.Subscribe([]nostr.Filter{filter}, targets)
+	sub, err := client.Subscribe(context.Background(), []nostr.Filter{filter}, targets)
 	if err != nil {
 		log.Config().Error("Failed to subscribe for mute list",
 			"author", author, "error", err)

--- a/config/admin_writes.go
+++ b/config/admin_writes.go
@@ -228,6 +228,36 @@ func UpdateBackupRelayConfig(br cfgType.BackupRelayConfig) error {
 	return saveServerConfig(*c)
 }
 
+// UpdateClientConfig stages the built-in Nostr client's connection settings +
+// the client-tag policy (#80/#99). index_relays must be ws/wss; a blank
+// client-tag name is filled with "grain" so it doesn't read as "unconfigured"
+// (which the loader treats as default-on).
+func UpdateClientConfig(cc cfgType.ClientConfig) error {
+	cleaned := cc.IndexRelays[:0]
+	for _, u := range cc.IndexRelays {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		if !strings.HasPrefix(u, "ws://") && !strings.HasPrefix(u, "wss://") {
+			return fmt.Errorf("each index relay must start with ws:// or wss:// (got %q)", u)
+		}
+		cleaned = append(cleaned, u)
+	}
+	cc.IndexRelays = cleaned
+	if cc.ClientTag.Name == "" {
+		cc.ClientTag.Name = "grain"
+	}
+	ConfigMu.Lock()
+	defer ConfigMu.Unlock()
+	c := GetConfig()
+	if c == nil {
+		return fmt.Errorf("config not loaded")
+	}
+	c.Client = cc
+	return saveServerConfig(*c)
+}
+
 // UpdateResourceLimits stages CPU/memory caps. The runtime/debug
 // hooks (GOMAXPROCS, soft memory limit) are applied at startup;
 // reload reapplies them.

--- a/config/types/client.go
+++ b/config/types/client.go
@@ -7,13 +7,26 @@ type ClientConfig struct {
 	// progresses (#56), these become the bootstrap layer that
 	// per-user mailbox/inbox sets are resolved through, rather than
 	// the relay set used for every operation.
-	IndexRelays       []string `yaml:"index_relays"`
-	ConnectionTimeout int      `yaml:"connection_timeout"` // seconds
-	ReadTimeout       int      `yaml:"read_timeout"`       // seconds
-	WriteTimeout      int      `yaml:"write_timeout"`      // seconds
-	MaxConnections    int      `yaml:"max_connections"`
-	RetryAttempts     int      `yaml:"retry_attempts"`
-	RetryDelay        int      `yaml:"retry_delay"` // seconds
-	KeepAlive         bool     `yaml:"keep_alive"`
-	UserAgent         string   `yaml:"user_agent"`
+	IndexRelays       []string `yaml:"index_relays" json:"index_relays"`
+	ConnectionTimeout int      `yaml:"connection_timeout" json:"connection_timeout"` // seconds
+	ReadTimeout       int      `yaml:"read_timeout" json:"read_timeout"`             // seconds
+	WriteTimeout      int      `yaml:"write_timeout" json:"write_timeout"`           // seconds
+	MaxConnections    int      `yaml:"max_connections" json:"max_connections"`
+	RetryAttempts     int      `yaml:"retry_attempts" json:"retry_attempts"`
+	RetryDelay        int      `yaml:"retry_delay" json:"retry_delay"` // seconds
+	KeepAlive         bool     `yaml:"keep_alive" json:"keep_alive"`
+	UserAgent         string   `yaml:"user_agent" json:"user_agent"`
+
+	// ClientTag controls grain's NIP-89 `client` tag on events it authors.
+	// grain always strips any foreign `client` tag (e.g. a stale
+	// `client:amethyst` carried over on a replaceable event); when enabled it
+	// stamps its own `["client", name]`. On by default; a logged-in user can opt
+	// out for their own events via the settings slider (#99).
+	ClientTag ClientTagConfig `yaml:"client_tag" json:"client_tag"`
+}
+
+// ClientTagConfig is the server-side default + name for grain's client tag.
+type ClientTagConfig struct {
+	Enabled bool   `yaml:"enabled" json:"enabled"`
+	Name    string `yaml:"name" json:"name"`
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -51,6 +51,16 @@ func ValidateAndApplyDefaults(cfg *cfgType.ServerConfig) (warnings []string, err
 		warnings = append(warnings, "server.implicit_req_limit was 0, defaulting to 500")
 	}
 
+	// Client (built-in Nostr client) defaults. An unset client_tag block (empty
+	// name) means "never configured" → grain's client tag is on, named "grain"
+	// (#99). Once the admin section writes it, the name is non-empty so this
+	// won't re-trigger and an explicit `enabled: false` is respected.
+	if cfg.Client.ClientTag.Name == "" {
+		cfg.Client.ClientTag.Name = "grain"
+		cfg.Client.ClientTag.Enabled = true
+		warnings = append(warnings, "client.client_tag unset, defaulting to enabled (\"grain\")")
+	}
+
 	// Logging defaults
 	if cfg.Logging.Level == "" {
 		cfg.Logging.Level = "info"

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -20,13 +20,11 @@ on it, not part of its import contract.
 > 0.8.0 is the bulk of the client work, and everything documented here is usable
 > today. NIP-44 encryption (v2 + v3) and NIP-42 AUTH both landed this cycle, and
 > both the read/fetch **and** publish paths take a `context.Context` for
-> caller-set deadlines and cancellation. Remaining items are non-blocking 1.0
-> hardening, **not** new surface:
-> - a pluggable `Logger` lets a consumer replace grain's logging (`SetLogger`);
->   `RelayListStore` (pluggable directory persistence) is the one remaining seam
->   planned for 1.0 — today the directory caches in memory.
-> - `PublishDM` (gift-wrapped NIP-17) is still pending — the NIP-44 primitives it
->   needs now exist (below), but the seal/gift-wrap assembly isn't wired yet.
+> caller-set deadlines and cancellation. The pluggable seams — `Signer`,
+> `Logger` (`SetLogger`), and `RelayListStore` (custom directory persistence) —
+> are all in place. The one still-pending item is **not** new library surface:
+> - `PublishDM` (gift-wrapped NIP-17) — the NIP-44 primitives it needs now exist
+>   (below), but the seal/gift-wrap assembly isn't wired yet.
 >
 > See [the design doc](design/outbox-relay-pool.md) §11 for the rationale.
 
@@ -44,7 +42,7 @@ on it, not part of its import contract.
 - [AUTH (NIP-42)](#auth-nip-42)
 - [The known-relays browser](#the-known-relays-browser)
 - [The client tag (NIP-89)](#the-client-tag-nip-89)
-- [Pluggable seams: Signer & Logger](#pluggable-seams-signer--logger)
+- [Pluggable seams](#pluggable-seams)
 - [The HTTP API (reference consumer)](#the-http-api-reference-consumer)
 - [API reference (essentials)](#api-reference-essentials)
 - [Runnable examples](#runnable-examples)
@@ -359,7 +357,7 @@ tag honest without leaking which app a foreign event came through.
 
 ---
 
-## Pluggable seams: Signer & Logger
+## Pluggable seams
 
 A `Signer` produces signatures for one pubkey. Supply one to publish; omit it
 for a read-only context.
@@ -380,9 +378,13 @@ implementing the two methods.
 `*slog.Logger` methods (`Debug`/`Info`/`Warn`/`Error`). It defaults to grain's
 own logging, so nothing changes until you opt out: `core.SetLogger(yourLogger)`
 (any `*slog.Logger` works, or implement the four methods) routes all
-client-library logging through your stack instead. (A `RelayListStore`
-directory-persistence seam is the last planned 1.0 seam; today the directory
-caches in memory.)
+client-library logging through your stack instead.
+
+**Persistence.** The relay directory caches per-user resolutions in memory by
+default. Set `Config.RelayListStore` to a custom `RelayListStore` — a
+`pubkey -> *UserRelays` store (`Get` / `Set` / `Delete` / `Range`) — to back it
+with a database that survives restarts or is shared across instances; the
+directory keeps the TTL and single-flight logic.
 
 ---
 

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -7,7 +7,7 @@ each user's relay lists, and routes every operation to the right relays under th
 [outbox model](https://mikedilger.com/gossip-model/): you read a user's notes
 from *their* outbox, and a reply you publish reaches the *parent author's* inbox.
 
-```
+```go
 import "github.com/0ceanslim/grain/client/core"
 ```
 
@@ -16,13 +16,38 @@ import "github.com/0ceanslim/grain/client/core"
 are the **reference consumer** of this surface — a worked example of how to build
 on it, not part of its import contract.
 
-> **Status (0.8.0, pre-1.0).** The surface below is stable enough to build on,
-> with known gaps: the **read/fetch** methods take a `context.Context`
-> (`Subscribe`, `GetUserProfile`, `StreamEvents`/`QueryEvents`, `FetchNotes`,
-> `StreamNotes`) so a fetch can be cancelled; the **publish** methods don't yet
-> (they carry their own deadlines). `PublishDM` (gift-wrapped NIP-17) is deferred
-> until NIP-44 encryption lands, and NIP-42 AUTH-for-`trusted` is not yet
-> implemented. See [the design doc](design/outbox-relay-pool.md) §11.
+> **Status (0.8.0).** This is the **feature-complete client-library surface** —
+> 0.8.0 is the bulk of the client work, and everything documented here is usable
+> today. NIP-44 encryption (v2 + v3) and NIP-42 AUTH both landed this cycle.
+> Remaining items are non-blocking 0.x→1.0 polish, **not** new surface:
+> - the **publish** methods don't yet take a `context.Context` (they carry their
+>   own deadlines); the **read/fetch** methods do, so a fetch can be cancelled.
+> - `RelayListStore` (pluggable persistence) and a pluggable `Logger` are seams
+>   planned for 1.0; today the directory caches in memory and logs via
+>   `server/utils/log`.
+> - `PublishDM` (gift-wrapped NIP-17) is still pending — the NIP-44 primitives it
+>   needs now exist (below), but the seal/gift-wrap assembly isn't wired yet.
+>
+> See [the design doc](design/outbox-relay-pool.md) §11 for the rationale.
+
+---
+
+## Contents
+
+- [Quick start](#quick-start)
+- [The outbox model & routing](#the-outbox-model--routing)
+- [The role model](#the-role-model)
+- [Streaming fetches](#streaming-fetches)
+- [Relay lists & mailboxes](#relay-lists--mailboxes)
+- [Media servers (Blossom + NIP-96)](#media-servers-blossom--nip-96)
+- [Encryption (NIP-44)](#encryption-nip-44)
+- [AUTH (NIP-42)](#auth-nip-42)
+- [The known-relays browser](#the-known-relays-browser)
+- [The client tag (NIP-89)](#the-client-tag-nip-89)
+- [Pluggable seam: the Signer](#pluggable-seam-the-signer)
+- [The HTTP API (reference consumer)](#the-http-api-reference-consumer)
+- [API reference (essentials)](#api-reference-essentials)
+- [Runnable examples](#runnable-examples)
 
 ---
 
@@ -145,6 +170,194 @@ user's outbox set for an outbox feed.
 
 ---
 
+## Relay lists & mailboxes
+
+The engine reads, parses, and assembles a user's replaceable relay-list events.
+`FetchUserRelayLists` resolves every kind a relay manager shows, concurrently:
+
+```go
+lists := client.FetchUserRelayLists(pubkey) // *UserRelayLists
+for _, e := range lists.NIP65 {             // 10002 entries
+    fmt.Println(e.URL, e.Read, e.Write)     // read=inbox, write=outbox, both=unmarked
+}
+fmt.Println(lists.DM, lists.Search, lists.Favorites) // 10050, 10007, 10012
+```
+
+`UserRelayLists` covers NIP-65 (`NIP65 []RelayListEntry`, with `Read`/`Write`
+markers) plus the NIP-51/37 string lists: `DM` (10050), `Blocked` (10006),
+`Search` (10007), `Favorites` (10012), `Private` (10013). For lists whose
+`.content` is encrypted, the `Encrypted` flags say which, and `EncryptedContent`
+carries the **raw, still-encrypted** blob per list — **grain never decrypts**; it
+passes the opaque content through so the consumer's signer can decrypt on demand
+(see [Encryption](#encryption-nip-44)).
+
+Parse a single 10002 yourself with `core.ParseNIP65Entries(event)`; it dedupes
+and merges read/write markers. To **write** a list, assemble an unsigned event
+and sign it with the user context:
+
+```go
+entries := []core.RelayListEntry{
+    {URL: "wss://out.example.com", Write: true},          // outbox only
+    {URL: "wss://in.example.com", Read: true},            // inbox only
+    {URL: "wss://both.example.com", Read: true, Write: true},
+}
+unsigned, err := core.AssembleRelayListEvent(existing, 10002, pubkey, entries)
+// unsigned has no ID/Sig — the caller signs:
+_, results, err := uc.SignAndPublish(unsigned)
+```
+
+`AssembleRelayListEvent` rewrites only the relay tags and **preserves the content
+and every non-relay tag** — the same conservative "don't drop data" rule the
+profile and media editors use. Tag shape is `["r", url[, "read"|"write"]]` for
+10002 and `["relay", url]` for 10050/10006/10007/10012. `existing` may be `nil`
+for a first list. Resolution is cached; `WarmUserRelayLists`,
+`InvalidateUserRelayLists`, and `ResolveUserRelayLists` (cache-first) manage the
+cache — invalidate after the user republishes their own list.
+
+---
+
+## Media servers (Blossom + NIP-96)
+
+The engine resolves a user's media-server lists — Blossom (kind 10063,
+[BUD-03](https://github.com/hzrd149/blossom/blob/master/buds/03.md)) and legacy
+NIP-96 (kind 10096) — with the same TTL-cached, single-flight directory as relay
+lists:
+
+```go
+ms := client.ResolveMediaServers(pubkey) // *MediaServers (blocking, cached)
+if ms.HasAny() {
+    fmt.Println("blossom:", ms.Blossom)  // primary first
+    fmt.Println("nip96:", ms.NIP96)
+}
+```
+
+`MediaServers` is `{Blossom, NIP96 []string; FetchedAt; Negative}` — `Negative`
+marks "user has published neither list" (cached briefly so a cold miss doesn't
+re-hit the network on every call). `HasAny()` is the "open the picker vs. prompt
+to set some up" decision.
+
+- `core.AssembleMediaServerEvent(existing, kind, pubkey, servers)` builds the
+  unsigned 10063/10096 event to sign and publish (same preserve-other-tags rule).
+- `core.SuggestedMediaServers()` is grain's curated quick-add list
+  (`MediaServerInfo`: URL, Kind, Cost, Retention, Mirror, Note, CTA);
+  `core.LookupMediaServerInfo(url)` returns capability chips for a known server.
+- `WarmMediaServers` / `InvalidateMediaServers` manage the cache.
+
+> The **upload** itself is client-side: the browser computes the file's sha256,
+> builds and signs a [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md)
+> (Blossom, PUT) or NIP-96 (multipart POST) authorization with the user's signer,
+> and uploads directly to the server (see `www/static/js/blossom-upload.js`). The
+> Go library's job is to **resolve which servers** to target; the signed upload
+> stays with whoever holds the key.
+
+---
+
+## Encryption (NIP-44)
+
+The built-in `EventSigner` exposes NIP-44 conversation encryption, validated
+against the official test vectors. **v2** is the deployed standard and the
+default; **v3** is the in-progress draft, opt-in, and binds the event `kind` and
+a `scope` into the MAC's authenticated data.
+
+```go
+// v2 (default) — the interoperable standard
+ciphertext, err := signer.NIP44Encrypt(peerPubKey, "hello")
+plaintext, err := signer.NIP44Decrypt(peerPubKey, ciphertext)
+
+// v3 (draft, opt-in) — kind + scope bound into the MAC
+ct, err := signer.NIP44V3Encrypt(peerPubKey, kind, scope, []byte("hello"))
+pt, err := signer.NIP44V3Decrypt(peerPubKey, kind, scope, ct)
+```
+
+The conversation key is derived from the ECDH of the signer's key and the peer's
+pubkey, so the **same key holder** decrypts. This is the primitive behind the
+private NIP-51/37 lists ([Relay lists & mailboxes](#relay-lists--mailboxes)):
+grain hands the consumer the raw encrypted blob, and the consumer decrypts it
+with the session signer. The gift-wrapped NIP-17 DM flow (`PublishDM`) is built
+on these primitives but not yet wired (see the status note above).
+
+---
+
+## AUTH (NIP-42)
+
+The engine tracks per-relay AUTH challenges so a consumer can answer them with
+the session signer. A relay that issues a challenge appears in `AuthRequests()`;
+the consumer builds and signs a kind-22242 event and forwards it with
+`SendAuth`:
+
+```go
+for _, req := range client.AuthRequests() { // []AuthState
+    if req.Authed {
+        continue // already answered this session
+    }
+    // Build + sign a kind-22242 event echoing the relay URL and challenge:
+    ev := &nostr.Event{
+        Kind: 22242,
+        Tags: [][]string{
+            {"relay", req.Relay},
+            {"challenge", req.Challenge},
+        },
+    }
+    if err := uc.Sign(ev); err != nil {
+        continue
+    }
+    if err := client.SendAuth(req.Relay, ev); err != nil { // forwarded on the challenged conn
+        // log + surface
+    }
+}
+```
+
+`AuthState` is `{Relay, Challenge, Authed, At}`. Once a relay is answered it
+stays authed for the **session**; a fresh challenge from the relay clears the
+flag so the consumer re-prompts (your signer will pop up automatically). Drop a
+relay with `RemoveAuth(url)`. In grain's reference UI this list **is** the
+"Trusted" list — relays you've chosen to authenticate to — so AUTH-for-`trusted`
+is opt-in per relay rather than a blanket auto-sign.
+
+---
+
+## The known-relays browser
+
+Everything the engine has seen — from resolutions and config — is browsable, with
+live status, NIP-11 metadata, and latency:
+
+```go
+all := client.KnownRelays()                 // []string, every relay seen
+status := client.KnownRelaysWithStatus()    // []KnownRelayStatus: connected/pinned/leased
+
+info := client.FetchRelayInfo(url)          // *RelayInfo (NIP-11; HTTP GET, TTL-cached)
+if info != nil && info.Limitation != nil && info.Limitation.AuthRequired {
+    // relay requires NIP-42 AUTH
+}
+
+latency := client.PingRelay(url)            // ms (TCP dial), -1 on failure
+pings := client.PingRelays(urls)            // map[url]ms, concurrent — for "sort: fastest"
+```
+
+`FetchRelayInfo` is a plain HTTP GET with `Accept: application/nostr+json` (not a
+pool/WebSocket connection), so the browser can show name, software, supported
+NIPs, and the auth/payment flags without holding a relay connection open. It
+returns `nil` (cached) when a relay advertises no NIP-11, to avoid retry storms.
+
+---
+
+## The client tag (NIP-89)
+
+`ApplyClientTag` stamps (or strips) the `client` tag on an event you're about to
+sign:
+
+```go
+core.ApplyClientTag(event, enabled, "grain") // enabled=false strips any client tag
+```
+
+It always removes any **foreign** `client` tag first (so re-published events
+don't leak another app's attribution), then adds `["client", name]` only when
+`enabled`. grain's reference UI defaults the name to `grain` and exposes a
+user-facing toggle plus admin defaults; the privacy-respecting default keeps the
+tag honest without leaking which app a foreign event came through.
+
+---
+
 ## Pluggable seam: the Signer
 
 A `Signer` produces signatures for one pubkey. Supply one to publish; omit it
@@ -158,10 +371,34 @@ type Signer interface {
 ```
 
 The built-in `EventSigner` (a local secp256k1 key via `NewEventSigner(hex)` or
-`NewEventSignerFromRandom()`) satisfies it. A consumer can plug in their own —
-NIP-46 remote signer, hardware, HSM — by implementing the two methods. (A
-`RelayListStore` persistence seam and a pluggable `Logger` are planned; today the
-directory caches in memory.)
+`NewEventSignerFromRandom()`) satisfies it, and adds the NIP-44 methods above. A
+consumer can plug in their own — NIP-46 remote signer, hardware, HSM — by
+implementing the two methods. (A `RelayListStore` persistence seam and a
+pluggable `Logger` are planned for 1.0; today the directory caches in memory.)
+
+---
+
+## The HTTP API (reference consumer)
+
+grain's `client/api` package wraps this library in an HTTP API for the bundled
+web client — the worked reference for consuming `client/core`. The endpoint
+groups mirror the sections above:
+
+| Group | What it exposes |
+|---|---|
+| keys | generate / validate / derive / NIP-19 encode-decode |
+| session, login, logout | signer login + session lifecycle |
+| profile | resolve + publish kind-0 metadata |
+| relay-list | the relay-list build/fetch + fixed-relay endpoints |
+| known-relays, relay-ping | the browser + latency sort |
+| media-servers | resolve + assemble media-server lists |
+| auth | the NIP-42 challenge list + answer/remove |
+| stream, events | the streaming feed + event publish |
+| client-tag | the client-tag default + toggle |
+
+The full request/response contract is the OpenAPI spec, generated at build via
+`make generate` and served by the dashboard at `/api/docs`. Treat that spec as
+the authoritative HTTP reference; this guide is the library reference beneath it.
 
 ---
 
@@ -176,6 +413,15 @@ directory caches in memory.)
   `QueryEvents(...) []*nostr.Event`.
 - `GetUserProfile(pubkey, relayHints) (*nostr.Event, error)`,
   `PublishEvent(event, relays) ([]BroadcastResult, error)`.
+- **Relay lists:** `FetchUserRelayLists(pubkey) *UserRelayLists`,
+  `ResolveUserRelayLists`, `WarmUserRelayLists`, `InvalidateUserRelayLists`,
+  `FetchRelayList(pubkey, kind)`, `OwnListRelays(pubkey)`.
+- **Media:** `ResolveMediaServers(pubkey) *MediaServers`, `FetchMediaServerList`,
+  `WarmMediaServers`, `InvalidateMediaServers`.
+- **Known relays:** `KnownRelays() []string`, `KnownRelaysWithStatus()`,
+  `FetchRelayInfo(url) *RelayInfo`, `PingRelay(url) int`, `PingRelays(urls)`.
+- **AUTH:** `AuthRequests() []AuthState`, `AuthChallenge(url)`,
+  `SendAuth(url, signed)`, `RemoveAuth(url)`.
 
 ### `UserContext`
 - `PublicKey()`, `Client()`, `Signer()`, `Relays() *SessionRelays`.
@@ -183,6 +429,13 @@ directory caches in memory.)
 - `FetchNotes(ctx, author, ...)`, `StreamNotes(ctx, author, ...)`,
   `Reply(parent, content)`.
 - `PinFixedRelays(read, write)`, `ClearFixedRelays()`, `FixedRelaysEnabled()`.
+
+### `EventSigner` (implements `Signer`)
+- `NewEventSigner(hex)`, `NewEventSignerFromRandom()`; `PublicKey()`,
+  `SignEvent(event)`.
+- NIP-44 v2: `NIP44Encrypt(peer, plaintext)`, `NIP44Decrypt(peer, payload)`.
+- NIP-44 v3 (draft): `NIP44V3Encrypt(peer, kind, scope, plaintext)`,
+  `NIP44V3Decrypt(peer, kind, scope, payload)`.
 
 ### `Role`
 A `uint16` bitmask; `Has(x)`, `String()`, and the `Role*` constants above.
@@ -193,6 +446,22 @@ A `uint16` bitmask; `Has(x)`, `String()`, and the `Role*` constants above.
 
 ### `UserRelays`
 Per-target resolution: `Outbox`, `Inbox`, `DMInbox []string`; `ForRole(role)`.
+
+### `UserRelayLists`
+`NIP65 []RelayListEntry`; `DM`, `Blocked`, `Search`, `Favorites`,
+`Private []string`; `Encrypted EncryptedFlags`, `EncryptedContent` (raw blobs).
+Build with `AssembleRelayListEvent`; parse 10002 with `ParseNIP65Entries`.
+
+### `MediaServers`
+`Blossom`, `NIP96 []string` (primary first); `HasAny()`. Build with
+`AssembleMediaServerEvent`; suggestions via `SuggestedMediaServers()`.
+
+### `RelayInfo`
+NIP-11: `Name`, `Description`, `Software`, `Version`, `SupportedNIPs []int`,
+`Icon`, `Limitation *RelayLimits` (`AuthRequired`, `PaymentRequired`, …).
+
+### `AuthState`
+`Relay`, `Challenge string`; `Authed bool`; `At time.Time`.
 
 ### `BroadcastResult`
 `RelayURL`, `Success`, `Accepted`, `Reason`, `Error`, `Message`, `Duration` —

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -17,10 +17,12 @@ are the **reference consumer** of this surface — a worked example of how to bu
 on it, not part of its import contract.
 
 > **Status (0.8.0, pre-1.0).** The surface below is stable enough to build on,
-> with two known gaps: the network methods don't take a `context.Context` on the
-> *existing* (pre-0.8) methods yet — the newer `StreamEvents`/`QueryEvents` do —
-> and `PublishDM` (gift-wrapped NIP-17) is deferred until NIP-44 encryption
-> lands. See [the design doc](design/outbox-relay-pool.md) §11.
+> with known gaps: the **read/fetch** methods take a `context.Context`
+> (`Subscribe`, `GetUserProfile`, `StreamEvents`/`QueryEvents`, `FetchNotes`,
+> `StreamNotes`) so a fetch can be cancelled; the **publish** methods don't yet
+> (they carry their own deadlines). `PublishDM` (gift-wrapped NIP-17) is deferred
+> until NIP-44 encryption lands, and NIP-42 AUTH-for-`trusted` is not yet
+> implemented. See [the design doc](design/outbox-relay-pool.md) §11.
 
 ---
 

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -18,10 +18,10 @@ on it, not part of its import contract.
 
 > **Status (0.8.0).** This is the **feature-complete client-library surface** —
 > 0.8.0 is the bulk of the client work, and everything documented here is usable
-> today. NIP-44 encryption (v2 + v3) and NIP-42 AUTH both landed this cycle.
-> Remaining items are non-blocking 0.x→1.0 polish, **not** new surface:
-> - the **publish** methods don't yet take a `context.Context` (they carry their
->   own deadlines); the **read/fetch** methods do, so a fetch can be cancelled.
+> today. NIP-44 encryption (v2 + v3) and NIP-42 AUTH both landed this cycle, and
+> both the read/fetch **and** publish paths take a `context.Context` for
+> caller-set deadlines and cancellation. Remaining items are non-blocking 1.0
+> hardening, **not** new surface:
 > - `RelayListStore` (pluggable persistence) and a pluggable `Logger` are seams
 >   planned for 1.0; today the directory caches in memory and logs via
 >   `server/utils/log`.
@@ -75,8 +75,9 @@ per-relay failures are logged, so an empty slice means "none found".
 signer, _ := core.NewEventSigner(privateKeyHex)            // local-key Signer
 uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
 
+ctx := context.Background()
 parent := /* the event being replied to */
-reply, results, err := uc.Reply(parent, "well said!")
+reply, results, err := uc.Reply(ctx, parent, "well said!")
 ```
 
 `Reply` builds a NIP-10 reply (thread root + parent markers, thread-wide `p`
@@ -84,8 +85,8 @@ tags), signs it as the context user, and publishes it under the outbox model —
 the author's own outbox **plus** the parent author's inbox — returning the
 per-relay [`BroadcastResult`](#broadcastresult)s.
 
-To publish an event you've built yourself: `uc.SignAndPublish(event)` (sign +
-route + broadcast), or `uc.Sign(event)` then `uc.Publish(event)` separately.
+To publish an event you've built yourself: `uc.SignAndPublish(ctx, event)` (sign +
+route + broadcast), or `uc.Sign(event)` then `uc.Publish(ctx, event)` separately.
 
 ---
 
@@ -203,7 +204,7 @@ entries := []core.RelayListEntry{
 }
 unsigned, err := core.AssembleRelayListEvent(existing, 10002, pubkey, entries)
 // unsigned has no ID/Sig — the caller signs:
-_, results, err := uc.SignAndPublish(unsigned)
+_, results, err := uc.SignAndPublish(context.Background(), unsigned)
 ```
 
 `AssembleRelayListEvent` rewrites only the relay tags and **preserves the content
@@ -411,8 +412,8 @@ the authoritative HTTP reference; this guide is the library reference beneath it
   `RoutePublish(event)`, `ResolveRelays(pubkey) *UserRelays`.
 - `StreamEvents(ctx, filter, relays, ...StreamOption) <-chan *nostr.Event`,
   `QueryEvents(...) []*nostr.Event`.
-- `GetUserProfile(pubkey, relayHints) (*nostr.Event, error)`,
-  `PublishEvent(event, relays) ([]BroadcastResult, error)`.
+- `GetUserProfile(ctx, pubkey, relayHints) (*nostr.Event, error)`,
+  `PublishEvent(ctx, event, relays) ([]BroadcastResult, error)`.
 - **Relay lists:** `FetchUserRelayLists(pubkey) *UserRelayLists`,
   `ResolveUserRelayLists`, `WarmUserRelayLists`, `InvalidateUserRelayLists`,
   `FetchRelayList(pubkey, kind)`, `OwnListRelays(pubkey)`.
@@ -425,9 +426,9 @@ the authoritative HTTP reference; this guide is the library reference beneath it
 
 ### `UserContext`
 - `PublicKey()`, `Client()`, `Signer()`, `Relays() *SessionRelays`.
-- `Sign(event)`, `Publish(event)`, `SignAndPublish(event)`.
+- `Sign(event)`, `Publish(ctx, event)`, `SignAndPublish(ctx, event)`.
 - `FetchNotes(ctx, author, ...)`, `StreamNotes(ctx, author, ...)`,
-  `Reply(parent, content)`.
+  `Reply(ctx, parent, content)`.
 - `PinFixedRelays(read, write)`, `ClearFixedRelays()`, `FixedRelaysEnabled()`.
 
 ### `EventSigner` (implements `Signer`)

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -1,744 +1,210 @@
-# Grain Client Library Guide
+# grain client library guide (0.8.0)
 
-Grain is a powerful Nostr client library built in Go that provides everything you need to build robust Nostr applications. It includes connection management, subscription handling, event building/signing, and authentication flows.
+grain's `client/core` package is an **importable, outbox-model Nostr client
+engine** in Go. A downstream app builds its own client on it — it does not
+reimplement relay routing. The engine owns a shared connection pool, resolves
+each user's relay lists, and routes every operation to the right relays under the
+[outbox model](https://mikedilger.com/gossip-model/): you read a user's notes
+from *their* outbox, and a reply you publish reaches the *parent author's* inbox.
 
-## Table of Contents
+```
+import "github.com/0ceanslim/grain/client/core"
+```
 
-- [Overview](#overview)
-- [Core Components](#core-components)
-- [Quick Start](#quick-start)
-- [Authentication & Sessions](#authentication--sessions)
-- [Relay Management](#relay-management)
-- [Subscriptions & Event Retrieval](#subscriptions--event-retrieval)
-- [Event Creation & Publishing](#event-creation--publishing)
-- [Key Management](#key-management)
-- [Advanced Features](#advanced-features)
-- [API Reference](#api-reference)
-- [Examples](#examples)
+`client/core` is pure Go (no cgo, no web/HTTP dependencies). grain's own
+`client/api`, `client/session`, `client/connection`, and `client/data` packages
+are the **reference consumer** of this surface — a worked example of how to build
+on it, not part of its import contract.
 
-## Overview
+> **Status (0.8.0, pre-1.0).** The surface below is stable enough to build on,
+> with two known gaps: the network methods don't take a `context.Context` on the
+> *existing* (pre-0.8) methods yet — the newer `StreamEvents`/`QueryEvents` do —
+> and `PublishDM` (gift-wrapped NIP-17) is deferred until NIP-44 encryption
+> lands. See [the design doc](design/outbox-relay-pool.md) §11.
 
-Grain provides a complete Nostr client implementation with:
+---
 
-- **Connection pooling**: Efficient management of WebSocket connections to multiple relays
-- **Event subscriptions**: Real-time event streaming with filtering
-- **Event publishing**: Build, sign, and broadcast events to relays
-- **User authentication**: Session management with multiple signing methods
-- **Key management**: Generate, derive, and convert Nostr keys
-- **Relay discovery**: Automatic relay list fetching and management
-- **Caching**: User data and relay information caching
+## Quick start
 
-## Core Components
-
-### 1. Client Core (`client/core/`)
-
-The heart of the library, providing the main `Client` struct and core functionality:
-
-- **`client.go`**: Main client with connection management
-- **`relays.go`**: WebSocket relay pool and connection handling  
-- **`subscriptions.go`**: Event subscription management
-- **`config.go`**: Client configuration
-- **`eventBuilder.go`**: Fluent API for building events
-- **`eventBroadcaster.go`**: Event publishing and broadcasting
-- **`eventSigner.go`**: Event signing utilities
-- **`eventSerializer.go`**: Event serialization helpers
-
-### 2. Shared Types (`server/types/`)
-
-Core Nostr data structures used throughout the library:
-
-- **`event.go`**: Nostr event structure
-- **`filter.go`**: Event filtering for subscriptions
-- **`subscription.go`**: Basic subscription structure
-
-### 3. API Layer (`client/api/`)
-
-HTTP API endpoints for web applications:
-
-- **`login.go`**: User authentication
-- **`session.go`**: Session management
-- **`keysGenerate.go`**: Key pair generation
-- **Authentication flow handlers**
-- **Event and relay management endpoints**
-
-### 4. Utilities (`client/core/tools/`)
-
-Helper functions for Nostr operations:
-
-- **Key pair generation and conversion**
-- **NIP-19 encoding/decoding (npub, nsec, etc.)**
-- **Public key derivation**
-
-## Quick Start
-
-### Basic Client Setup
+### Read-only: fetch a user's notes
 
 ```go
-package main
+client := core.NewClient(core.DefaultConfig())     // owns the shared pool
+uc := client.NewUserContext(authorHex)             // no signer → read-only
 
-import (
-    "log"
-    "github.com/0ceanslim/grain/client/core"
-)
+ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+defer cancel()
 
-func main() {
-    // Create client with default configuration
-    config := core.DefaultConfig()
-    client := core.NewClient(config)
-    
-    // Connect to relays
-    relays := []string{
-        "wss://relay.damus.io",
-        "wss://nos.lol", 
-        "wss://relay.nostr.band",
-    }
-    
-    if err := client.ConnectToRelays(relays); err != nil {
-        log.Fatal("Failed to connect:", err)
-    }
-    
-    log.Println("Connected to", len(client.GetConnectedRelays()), "relays")
-    
-    // Don't forget to cleanup
-    defer client.Close()
+notes := uc.FetchNotes(ctx, authorHex, core.WithLimit(20)) // → author's outbox
+```
+
+`FetchNotes` resolves the author's NIP-65 outbox relays and queries them
+concurrently, returning the kind-1 notes it collects. It is best-effort:
+per-relay failures are logged, so an empty slice means "none found".
+
+### Publishing: sign and broadcast a reply
+
+```go
+signer, _ := core.NewEventSigner(privateKeyHex)            // local-key Signer
+uc := client.NewUserContext(signer.PublicKey(), core.WithSigner(signer))
+
+parent := /* the event being replied to */
+reply, results, err := uc.Reply(parent, "well said!")
+```
+
+`Reply` builds a NIP-10 reply (thread root + parent markers, thread-wide `p`
+tags), signs it as the context user, and publishes it under the outbox model —
+the author's own outbox **plus** the parent author's inbox — returning the
+per-relay [`BroadcastResult`](#broadcastresult)s.
+
+To publish an event you've built yourself: `uc.SignAndPublish(event)` (sign +
+route + broadcast), or `uc.Sign(event)` then `uc.Publish(event)` separately.
+
+---
+
+## The outbox model & routing
+
+Routing is automatic: you name the intent, the engine picks the relays.
+
+| Operation | Routes to |
+|---|---|
+| Read a user's notes | their **outbox** (NIP-65 write), falling back to the indexers |
+| Read profile / relay lists | the **indexers** (+ the user's cached outbox) |
+| Publish a note | the author's **outbox** ∪ each p-tagged recipient's **inbox** |
+| Publish profile / relay list | the author's outbox ∪ the **indexers** |
+
+Inspect a routing decision without performing it:
+
+```go
+relays := client.Route(core.OpFetchNotes, authorHex) // == client.RouteFetch(authorHex)
+relays = client.RoutePublish(event)                  // per-event (recipients matter)
+ur := client.ResolveRelays(authorHex)                // *UserRelays: Outbox/Inbox/DMInbox
+```
+
+**Fixed-relay override (opt-out).** For a pinned single-/few-relay client,
+`uc.PinFixedRelays(read, write)` routes everything to a fixed set and **disables
+the outbox model** (replies stop reaching others' inboxes). Off by default and
+discouraged; clear with `uc.ClearFixedRelays()`.
+
+---
+
+## The role model
+
+Every relay serves one or more **roles**, a [`Role`](#role) bitmask split into
+three classes:
+
+- **Per-target, event-derived** — resolved from the *target* user's lists:
+  `RoleOutbox`, `RoleInbox` (NIP-65 10002), `RoleDMInbox` (NIP-17 10050).
+- **Self-only, event-derived** — the logged-in user's own lists: `RoleSearch`
+  (10007), `RoleBlocked` (10006), `RoleFavorite` (10012), `RolePrivateHome`
+  (10013, NIP-44).
+- **Locally configured** — app config, applied across every user: `RoleIndexer`,
+  `RoleBroadcast`, `RoleProxy`, `RoleLocal`, `RoleTrusted`.
+
+A user's editable, role-tagged config is `uc.Relays()` (a `*SessionRelays`):
+
+```go
+uc.Relays().Set("wss://relay.example.com", core.RoleOutbox|core.RoleInbox)
+uc.Relays().Add("wss://dm.example.com", core.RoleDMInbox)
+outboxes := uc.Relays().ByRole(core.RoleOutbox)
+all := uc.Relays().All() // map[string]core.Role snapshot
+```
+
+`RoleForListKind(kind)` maps a relay-list event kind to its role(s), e.g.
+`10002 → RoleOutbox|RoleInbox`.
+
+---
+
+## Streaming fetches
+
+`StreamEvents` is the general, multi-relay streaming primitive: it subscribes to
+a filter across many relays and delivers events on a channel as each relay
+answers, de-duplicated by id.
+
+```go
+feed := client.StreamEvents(ctx,
+    nostr.Filter{Kinds: []int{1}},
+    relays,
+    core.WithLive(), core.WithLimit(50))
+for ev := range feed {
+    // render ev as it arrives (lazy hydration)
 }
 ```
 
-### Custom Configuration
+- Closes on **all-EOSE** (a bounded fetch), `WithLimit(n)`, `ctx` cancellation,
+  or `WithTimeout(d)` (default 10s) — whichever is first.
+- `WithLive()` keeps it open past EOSE for a live feed.
+- `QueryEvents(...)` is the blocking collect-all convenience.
+- `uc.StreamNotes(ctx, author)` / `uc.FetchNotes(ctx, author)` are the
+  outbox-routed note feeds built on top.
+
+Point it at one relay (e.g. grain's own) for a single-source stream, or at a
+user's outbox set for an outbox feed.
+
+---
+
+## Pluggable seam: the Signer
+
+A `Signer` produces signatures for one pubkey. Supply one to publish; omit it
+for a read-only context.
 
 ```go
-config := &core.Config{
-    IndexRelays: []string{
-        "wss://your-relay.com",
-        "wss://another-relay.com",
-    },
-    ConnectionTimeout: 15 * time.Second,
-    ReadTimeout:       45 * time.Second,
-    WriteTimeout:      15 * time.Second,
-    MaxConnections:    20,
-    RetryAttempts:     5,
-    RetryDelay:        3 * time.Second,
-    UserAgent:         "my-nostr-client/1.0",
-}
-
-client := core.NewClient(config)
-```
-
-## Authentication & Sessions
-
-Grain provides a comprehensive authentication system supporting multiple signing methods:
-
-### Session Modes
-
-- **Read-Only Mode**: Query events and user data without signing capability
-- **Write Mode**: Full event creation and publishing with signing
-
-### Signing Methods
-
-- **No Signing**: Read-only access
-- **NIP-07 Browser Extension**: Uses browser extension for signing
-- **Private Key**: Direct private key signing
-- **Amber (Android)**: External signing via Amber app
-
-### Login Flow Example
-
-```go
-import "github.com/0ceanslim/grain/client/session"
-
-// Create session request
-loginReq := session.SessionInitRequest{
-    PublicKey:      "your-pubkey-hex",
-    RequestedMode:  session.WriteMode,
-    SigningMethod:  session.PrivateKeySigning,
-    PrivateKey:     "your-private-key-hex", // Only for private key signing
-}
-
-// This would typically be called via HTTP API
-userSession, err := session.CreateUserSession(responseWriter, loginReq)
-if err != nil {
-    log.Fatal("Login failed:", err)
-}
-
-log.Printf("Logged in as %s in %s mode", userSession.PublicKey, userSession.Mode)
-```
-
-## Relay Management
-
-### Basic Connection Management
-
-```go
-// Connect to multiple relays with retry
-err := client.ConnectToRelaysWithRetry(relays, 3)
-if err != nil {
-    log.Printf("Some connections failed: %v", err)
-}
-
-// Get connected relays
-connected := client.GetConnectedRelays()
-log.Printf("Connected to %d relays: %v", len(connected), connected)
-
-// Disconnect from specific relay
-err = client.DisconnectFromRelay("wss://relay.example.com")
-```
-
-### User Relay Discovery
-
-```go
-// Fetch user's relay list (kind 10002)
-mailboxes, err := client.GetUserRelays("pubkey-hex")
-if err != nil {
-    log.Printf("Failed to get user relays: %v", err)
-} else {
-    log.Printf("Read relays: %v", mailboxes.Read)
-    log.Printf("Write relays: %v", mailboxes.Write) 
-    log.Printf("Both relays: %v", mailboxes.Both)
-}
-
-// Switch client to use user's relays
-relayConfigs := []core.RelayConfig{
-    {URL: "wss://user-relay1.com", Read: true, Write: true},
-    {URL: "wss://user-relay2.com", Read: true, Write: false},
-}
-err = client.SwitchToUserRelays(relayConfigs)
-```
-
-## Subscriptions & Event Retrieval
-
-### Creating Subscriptions
-
-```go
-import nostr "github.com/0ceanslim/grain/server/types"
-
-// Create filters for subscription
-filters := []nostr.Filter{
-    {
-        Authors: []string{"pubkey1", "pubkey2"},
-        Kinds:   []int{1}, // Text notes
-        Limit:   &[]int{50}[0],
-    },
-}
-
-// Subscribe with specific relays (or nil for all connected)
-sub, err := client.Subscribe(filters, nil)
-if err != nil {
-    log.Fatal("Subscription failed:", err)
-}
-defer sub.Close()
-
-// Process events
-for {
-    select {
-    case event := <-sub.Events:
-        log.Printf("Received event: %s from %s", event.ID, event.PubKey)
-        
-    case relayURL := <-sub.EOSE:
-        log.Printf("End of stored events from %s", relayURL)
-        
-    case err := <-sub.Errors:
-        log.Printf("Subscription error: %v", err)
-        
-    case <-sub.Done:
-        log.Println("Subscription closed")
-        return
-    }
+type Signer interface {
+    PublicKey() string
+    SignEvent(event *nostr.Event) error
 }
 ```
 
-### Fetching User Profile
-
-```go
-// Get user metadata (kind 0)
-profile, err := client.GetUserProfile("pubkey-hex", nil)
-if err != nil {
-    log.Printf("Failed to get profile: %v", err)
-} else {
-    log.Printf("Profile: %s", profile.Content) // JSON metadata
-}
-```
-
-### Advanced Filtering
-
-```go
-// Complex filter with time range and tags
-since := time.Now().Add(-24 * time.Hour)
-until := time.Now()
-
-filters := []nostr.Filter{
-    {
-        Kinds: []int{1, 6, 7}, // Notes, reposts, reactions
-        Tags: map[string][]string{
-            "t": {"bitcoin", "nostr"}, // Hashtags
-        },
-        Since: &since,
-        Until: &until,
-        Limit: &[]int{100}[0],
-    },
-}
-```
-
-## Event Creation & Publishing
-
-### Building Events
-
-```go
-// Use the fluent builder API
-textNote := core.NewTextNote("Hello Nostr!")
-    .PTag("pubkey-to-mention", "wss://relay-hint.com")
-    .TTag("hello")
-    .TTag("nostr")
-
-// Build the event (not signed yet)
-event := textNote.Build()
-```
-
-### Event Signing
-
-```go
-// Create signer with private key
-signer, err := core.NewPrivateKeySigner("your-private-key-hex")
-if err != nil {
-    log.Fatal("Failed to create signer:", err)
-}
-
-// Sign the event
-err = signer.SignEvent(event)
-if err != nil {
-    log.Fatal("Failed to sign event:", err)
-}
-
-log.Printf("Signed event ID: %s", event.ID)
-```
-
-### Publishing Events
-
-```go
-// Publish to specific relays
-targetRelays := []string{"wss://relay1.com", "wss://relay2.com"}
-results, err := client.PublishEvent(event, targetRelays)
-if err != nil {
-    log.Fatal("Publish failed:", err)
-}
-
-// Check results
-for _, result := range results {
-    if result.Success {
-        log.Printf("✓ Published to %s", result.RelayURL)
-    } else {
-        log.Printf("✗ Failed %s: %v", result.RelayURL, result.Error)
-    }
-}
-```
-
-### High-Level Publishing
-
-```go
-// Build, sign, and publish in one call
-event, results, err := core.PublishEvent(client, signer, textNote, nil)
-if err != nil {
-    log.Fatal("Publish failed:", err)
-}
-
-// Get summary
-summary := core.SummarizeBroadcast(results)
-log.Printf("Published to %d/%d relays (%.1f%% success)", 
-    summary.Successful, summary.TotalRelays, summary.SuccessRate)
-```
-
-## Key Management
-
-### Generating Key Pairs
-
-```go
-import "github.com/0ceanslim/grain/client/core/tools"
-
-// Generate new key pair
-keyPair, err := tools.GenerateKeyPair()
-if err != nil {
-    log.Fatal("Key generation failed:", err)
-}
-
-log.Printf("Private key: %s", keyPair.PrivateKey) // hex
-log.Printf("Public key: %s", keyPair.PublicKey)   // hex
-log.Printf("nsec: %s", keyPair.Nsec)             // bech32
-log.Printf("npub: %s", keyPair.Npub)             // bech32
-```
-
-### Key Conversion
-
-```go
-// Derive public key from private key
-pubkey, err := tools.DerivePubkey("private-key-hex")
-
-// Convert to bech32 formats
-nsec, err := tools.EncodePrivkey("private-key-hex")
-npub, err := tools.EncodePubkey("public-key-hex")
-
-// Decode bech32 formats
-privkey, err := tools.DecodeNsec("nsec1...")
-pubkey, err := tools.DecodeNpub("npub1...")
-```
-
-## Advanced Features
-
-### Connection Retry Logic
-
-```go
-// Connect with automatic retries
-err := client.ConnectToRelaysWithRetry(relays, 5) // 5 retry attempts
-```
-
-### Publish with Retry
-
-```go
-// Publish with retry for failed relays
-results, err := client.PublishEventWithRetry(event, relays, 3)
-```
-
-### Dynamic Relay Switching
-
-```go
-// Switch to user's discovered relays
-err := client.ReplaceRelayConnections(userRelayConfigs)
-
-// Switch back to index relays
-err := client.SwitchToIndexRelays()
-```
-
-### Event Builders for Different Kinds
-
-```go
-// Reaction (kind 7)
-reaction := core.NewReaction("event-id-to-react-to", "🚀")
-
-// Repost (kind 6) 
-repost := core.NewRepost("event-id-to-repost", "wss://relay-hint.com")
-
-// Deletion (kind 5)
-deletion := core.NewDeletion([]string{"event-id1", "event-id2"}, "spam")
-
-// Contact list (kind 3)
-contacts := core.NewContactList()
-    .PTag("friend1-pubkey", "wss://their-relay.com")
-    .PTag("friend2-pubkey")
-
-// Relay list (kind 10002)
-relayList := core.NewRelayList()
-    .RTag("wss://my-read-relay.com", "read")
-    .RTag("wss://my-write-relay.com", "write")
-    .RTag("wss://my-general-relay.com", "")
-
-// Profile/Metadata (kind 0)
-profile := core.NewProfile()
-    .Content(`{"name":"Alice","about":"Nostr enthusiast","picture":"https://..."}`)
-```
-
-## API Reference
-
-### Core Client Methods
-
-#### Connection Management
-- `NewClient(config *Config) *Client` - Create new client instance
-- `ConnectToRelays(urls []string) error` - Connect to relay list
-- `ConnectToRelaysWithRetry(urls []string, maxRetries int) error` - Connect with retry
-- `DisconnectFromRelay(url string) error` - Disconnect from specific relay
-- `GetConnectedRelays() []string` - Get list of connected relay URLs
-- `GetRelayStatus() map[string]string` - Get detailed relay status
-- `Close() error` - Close all connections and cleanup
-
-#### Subscription Management  
-- `Subscribe(filters []Filter, relayHints []string) (*Subscription, error)` - Create subscription
-- `GetUserProfile(pubkey string, relayHints []string) (*Event, error)` - Fetch user profile
-- `GetUserRelays(pubkey string) (*Mailboxes, error)` - Get user's relay list
-
-#### Event Publishing
-- `PublishEvent(event *Event, targetRelays []string) ([]BroadcastResult, error)` - Publish event
-- `PublishEventWithRetry(event *Event, targetRelays []string, maxRetries int) ([]BroadcastResult, error)` - Publish with retry
-
-#### Relay Management
-- `ReplaceRelayConnections(newRelays []RelayConfig) error` - Replace all relay connections  
-- `SwitchToUserRelays(userRelays []RelayConfig) error` - Switch to user's relays
-- `SwitchToIndexRelays() error` - Switch back to index relays
-
-### Subscription Methods
-
-- `Start() error` - Begin receiving events
-- `Close() error` - Stop subscription and cleanup
-- `AddRelay(url string) error` - Add relay to active subscription
-- `RemoveRelay(url string) error` - Remove relay from subscription
-- `IsActive() bool` - Check if subscription is active
-- `GetRelayCount() int` - Get number of relays in subscription
-
-### Event Builder Methods
-
-#### Core Builder Methods
-- `Content(content string) *EventBuilder` - Set event content
-- `Tag(name string, values ...string) *EventBuilder` - Add generic tag
-- `CreatedAt(t time.Time) *EventBuilder` - Set timestamp
-- `Build() *Event` - Build final event (unsigned)
-
-#### Specific Tag Methods
-- `PTag(pubkey string, relayHint ...string) *EventBuilder` - Add pubkey reference
-- `ETag(eventID string, relayHint, marker string) *EventBuilder` - Add event reference  
-- `RTag(relayURL string, marker string) *EventBuilder` - Add relay reference
-- `DTag(identifier string) *EventBuilder` - Add identifier tag
-- `ATag(kind int, pubkey string, dTag string, relayHint ...string) *EventBuilder` - Add address reference
-- `TTag(hashtag string) *EventBuilder` - Add hashtag
-
-### Key Management Functions
-
-- `GenerateKeyPair() (*KeyPair, error)` - Generate new random key pair
-- `DerivePubkey(privkey string) (string, error)` - Derive public key from private key
-- `EncodePrivkey(privkey string) (string, error)` - Convert private key to nsec format
-- `EncodePubkey(pubkey string) (string, error)` - Convert public key to npub format
-- `DecodeNsec(nsec string) (string, error)` - Convert nsec to private key hex
-- `DecodeNpub(npub string) (string, error)` - Convert npub to public key hex
-
-## Examples
-
-### Complete Nostr Client Example
-
-```go
-package main
-
-import (
-    "log"
-    "time"
-    "context"
-    "github.com/0ceanslim/grain/client/core"
-    "github.com/0ceanslim/grain/client/core/tools"
-    nostr "github.com/0ceanslim/grain/server/types"
-)
-
-func main() {
-    // 1. Generate or load keys
-    keyPair, err := tools.GenerateKeyPair()
-    if err != nil {
-        log.Fatal("Key generation failed:", err)
-    }
-    
-    log.Printf("Generated identity: %s", keyPair.Npub)
-    
-    // 2. Create and configure client
-    config := core.DefaultConfig()
-    config.IndexRelays = []string{
-        "wss://relay.damus.io",
-        "wss://nos.lol",
-        "wss://relay.nostr.band",
-    }
-    
-    client := core.NewClient(config)
-    defer client.Close()
-    
-    // 3. Connect to relays
-    if err := client.ConnectToRelaysWithRetry(config.IndexRelays, 3); err != nil {
-        log.Printf("Some relays failed to connect: %v", err)
-    }
-    
-    connectedCount := len(client.GetConnectedRelays())
-    log.Printf("Connected to %d relays", connectedCount)
-    
-    if connectedCount == 0 {
-        log.Fatal("No relay connections available")
-    }
-    
-    // 4. Create signer for publishing
-    signer, err := core.NewPrivateKeySigner(keyPair.PrivateKey)
-    if err != nil {
-        log.Fatal("Failed to create signer:", err)
-    }
-    
-    // 5. Subscribe to global feed
-    filters := []nostr.Filter{
-        {
-            Kinds: []int{1}, // Text notes only
-            Limit: &[]int{20}[0],
-        },
-    }
-    
-    sub, err := client.Subscribe(filters, nil)
-    if err != nil {
-        log.Fatal("Subscription failed:", err)
-    }
-    
-    // 6. Process events for a bit
-    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-    defer cancel()
-    defer sub.Close()
-    
-    eventCount := 0
-    
-    go func() {
-        for {
-            select {
-            case event := <-sub.Events:
-                eventCount++
-                log.Printf("Event #%d: %s (kind %d) by %s", 
-                    eventCount, event.ID[:8], event.Kind, event.PubKey[:8])
-                    
-                if len(event.Content) > 0 {
-                    content := event.Content
-                    if len(content) > 100 {
-                        content = content[:100] + "..."
-                    }
-                    log.Printf("  Content: %s", content)
-                }
-                
-            case relayURL := <-sub.EOSE:
-                log.Printf("EOSE from %s", relayURL)
-                
-            case err := <-sub.Errors:
-                log.Printf("Subscription error: %v", err)
-                
-            case <-ctx.Done():
-                return
-            }
-        }
-    }()
-    
-    // 7. Publish a note after collecting some events
-    time.Sleep(5 * time.Second)
-    
-    noteContent := "Hello Nostr! This is my first note from the Grain library 🚀"
-    note := core.NewTextNote(noteContent)
-        .TTag("hello")
-        .TTag("grain")
-        .TTag("nostr")
-    
-    event, results, err := core.PublishEvent(client, signer, note, nil)
-    if err != nil {
-        log.Printf("Failed to publish note: %v", err)
-    } else {
-        log.Printf("Published note: %s", event.ID)
-        
-        summary := core.SummarizeBroadcast(results)
-        log.Printf("Broadcast: %d/%d relays (%.1f%% success)", 
-            summary.Successful, summary.TotalRelays, summary.SuccessRate)
-    }
-    
-    // 8. Wait for subscription to complete
-    <-ctx.Done()
-    log.Printf("Processed %d events total", eventCount)
-}
-```
-
-### Web API Integration Example
-
-```go
-package main
-
-import (
-    "net/http"
-    "log"
-    "github.com/0ceanslim/grain/client"
-    "github.com/0ceanslim/grain/client/api"
-)
-
-func main() {
-    // Initialize client components
-    if err := client.Init(); err != nil {
-        log.Fatal("Client init failed:", err)
-    }
-    
-    // Register API endpoints
-    client.RegisterEndpoints()
-    
-    // Add custom routes if needed
-    http.HandleFunc("/api/custom", func(w http.ResponseWriter, r *http.Request) {
-        // Your custom API logic here
-        w.WriteHeader(http.StatusOK)
-        w.Write([]byte(`{"status":"ok"}`))
-    })
-    
-    log.Println("Starting server on :8080")
-    log.Fatal(http.ListenAndServe(":8080", nil))
-}
-```
-
-Available API endpoints:
-- `POST /api/login` - User authentication
-- `GET /api/session` - Get current session
-- `POST /api/logout` - End session
-- `GET /api/keys/generate` - Generate new key pair
-- `GET /api/events` - Query events
-- `POST /api/connect` - Connect to relays  
-- `POST /api/disconnect` - Disconnect from relays
-- `GET /api/relays` - Get relay status
-
-### Subscription Patterns
-
-```go
-// Pattern 1: Real-time mentions
-func watchMentions(client *core.Client, userPubkey string) {
-    filters := []nostr.Filter{
-        {
-            Kinds: []int{1}, // Text notes
-            Tags: map[string][]string{
-                "p": {userPubkey}, // Mentions this user
-            },
-        },
-    }
-    
-    sub, err := client.Subscribe(filters, nil)
-    if err != nil {
-        log.Printf("Mention subscription failed: %v", err)
-        return
-    }
-    defer sub.Close()
-    
-    for event := range sub.Events {
-        log.Printf("You were mentioned by %s: %s", event.PubKey[:8], event.Content)
-    }
-}
-
-// Pattern 2: Timeline for following list
-func watchTimeline(client *core.Client, followingPubkeys []string) {
-    filters := []nostr.Filter{
-        {
-            Authors: followingPubkeys,
-            Kinds:   []int{1, 6}, // Notes and reposts
-            Limit:   &[]int{100}[0],
-        },
-    }
-    
-    sub, err := client.Subscribe(filters, nil)
-    if err != nil {
-        log.Printf("Timeline subscription failed: %v", err)
-        return
-    }
-    defer sub.Close()
-    
-    for event := range sub.Events {
-        log.Printf("Timeline: %s posted: %s", event.PubKey[:8], 
-            event.Content[:min(50, len(event.Content))])
-    }
-}
-
-// Pattern 3: Event thread
-func watchThread(client *core.Client, rootEventID string) {
-    filters := []nostr.Filter{
-        {
-            Tags: map[string][]string{
-                "e": {rootEventID}, // References this event
-            },
-            Kinds: []int{1, 7}, // Notes and reactions
-        },
-    }
-    
-    sub, err := client.Subscribe(filters, nil)
-    if err != nil {
-        log.Printf("Thread subscription failed: %v", err)
-        return
-    }
-    defer sub.Close()
-    
-    for event := range sub.Events {
-        if event.Kind == 1 {
-            log.Printf("Reply: %s", event.Content)
-        } else if event.Kind == 7 {
-            log.Printf("Reaction: %s", event.Content)
-        }
-    }
-}
-```
-
-This comprehensive guide covers all the essential aspects of using Grain as a Nostr client library. The library provides both low-level control for advanced use cases and high-level convenience methods for common operations.
+The built-in `EventSigner` (a local secp256k1 key via `NewEventSigner(hex)` or
+`NewEventSignerFromRandom()`) satisfies it. A consumer can plug in their own —
+NIP-46 remote signer, hardware, HSM — by implementing the two methods. (A
+`RelayListStore` persistence seam and a pluggable `Logger` are planned; today the
+directory caches in memory.)
+
+---
+
+## API reference (essentials)
+
+### `Client`
+- `NewClient(*Config) *Client` — owns the shared connection pool.
+- `NewUserContext(pubkey string, ...UserOption) *UserContext`.
+- `Route(op RouteOp, target string) []string`, `RouteFetch`, `RouteMetadata`,
+  `RoutePublish(event)`, `ResolveRelays(pubkey) *UserRelays`.
+- `StreamEvents(ctx, filter, relays, ...StreamOption) <-chan *nostr.Event`,
+  `QueryEvents(...) []*nostr.Event`.
+- `GetUserProfile(pubkey, relayHints) (*nostr.Event, error)`,
+  `PublishEvent(event, relays) ([]BroadcastResult, error)`.
+
+### `UserContext`
+- `PublicKey()`, `Client()`, `Signer()`, `Relays() *SessionRelays`.
+- `Sign(event)`, `Publish(event)`, `SignAndPublish(event)`.
+- `FetchNotes(ctx, author, ...)`, `StreamNotes(ctx, author, ...)`,
+  `Reply(parent, content)`.
+- `PinFixedRelays(read, write)`, `ClearFixedRelays()`, `FixedRelaysEnabled()`.
+
+### `Role`
+A `uint16` bitmask; `Has(x)`, `String()`, and the `Role*` constants above.
+`RoleForListKind(kind) (Role, bool)`.
+
+### `SessionRelays`
+`Set`, `Add`, `Remove`, `Get`, `ByRole`, `All` — concurrency-safe.
+
+### `UserRelays`
+Per-target resolution: `Outbox`, `Inbox`, `DMInbox []string`; `ForRole(role)`.
+
+### `BroadcastResult`
+`RelayURL`, `Success`, `Accepted`, `Reason`, `Error`, `Message`, `Duration` —
+the per-relay outcome of a publish (NIP-20 `OK`).
+
+---
+
+## Runnable examples
+
+Compile-checked examples of the public surface live in
+[`client/core/example_test.go`](../client/core/example_test.go) (an external
+`core_test` package, so they import the library exactly as you would). They run
+in CI via `go test ./...`, so the public API can't drift without breaking the
+build.
+
+See also the [outbox relay-pool design doc](design/outbox-relay-pool.md) for the
+full architecture and rationale.

--- a/docs/client-library-guide.md
+++ b/docs/client-library-guide.md
@@ -22,9 +22,9 @@ on it, not part of its import contract.
 > both the read/fetch **and** publish paths take a `context.Context` for
 > caller-set deadlines and cancellation. Remaining items are non-blocking 1.0
 > hardening, **not** new surface:
-> - `RelayListStore` (pluggable persistence) and a pluggable `Logger` are seams
->   planned for 1.0; today the directory caches in memory and logs via
->   `server/utils/log`.
+> - a pluggable `Logger` lets a consumer replace grain's logging (`SetLogger`);
+>   `RelayListStore` (pluggable directory persistence) is the one remaining seam
+>   planned for 1.0 — today the directory caches in memory.
 > - `PublishDM` (gift-wrapped NIP-17) is still pending — the NIP-44 primitives it
 >   needs now exist (below), but the seal/gift-wrap assembly isn't wired yet.
 >
@@ -44,7 +44,7 @@ on it, not part of its import contract.
 - [AUTH (NIP-42)](#auth-nip-42)
 - [The known-relays browser](#the-known-relays-browser)
 - [The client tag (NIP-89)](#the-client-tag-nip-89)
-- [Pluggable seam: the Signer](#pluggable-seam-the-signer)
+- [Pluggable seams: Signer & Logger](#pluggable-seams-signer--logger)
 - [The HTTP API (reference consumer)](#the-http-api-reference-consumer)
 - [API reference (essentials)](#api-reference-essentials)
 - [Runnable examples](#runnable-examples)
@@ -359,7 +359,7 @@ tag honest without leaking which app a foreign event came through.
 
 ---
 
-## Pluggable seam: the Signer
+## Pluggable seams: Signer & Logger
 
 A `Signer` produces signatures for one pubkey. Supply one to publish; omit it
 for a read-only context.
@@ -374,8 +374,15 @@ type Signer interface {
 The built-in `EventSigner` (a local secp256k1 key via `NewEventSigner(hex)` or
 `NewEventSignerFromRandom()`) satisfies it, and adds the NIP-44 methods above. A
 consumer can plug in their own — NIP-46 remote signer, hardware, HSM — by
-implementing the two methods. (A `RelayListStore` persistence seam and a
-pluggable `Logger` are planned for 1.0; today the directory caches in memory.)
+implementing the two methods.
+
+**Logging.** The library logs through a pluggable `Logger` — the four
+`*slog.Logger` methods (`Debug`/`Info`/`Warn`/`Error`). It defaults to grain's
+own logging, so nothing changes until you opt out: `core.SetLogger(yourLogger)`
+(any `*slog.Logger` works, or implement the four methods) routes all
+client-library logging through your stack instead. (A `RelayListStore`
+directory-persistence seam is the last planned 1.0 seam; today the directory
+caches in memory.)
 
 ---
 

--- a/docs/design/outbox-relay-pool.md
+++ b/docs/design/outbox-relay-pool.md
@@ -88,7 +88,7 @@ Four layers. The bottom layer is the *default* lists; above it sits **one shared
 
 ### 4.0 The shape in one paragraph
 
-There is **one default relay list** (app config) so the relay works before anyone logs in and so new sessions have a starting point. As the relay runs and users interact, it dials more and more relays into **one shared connection pool** — the "hundreds of websockets" of the outbox model, ref-counted and shared across sessions. When a user logs in they get a **per-session relay config**: their own event-derived relays (NIP-65 outbox/inbox, NIP-17 DM…) **plus** the default local-role relays, all **editable by that user and persisted in session cache** (e.g. "only ever write to relay X"). Every action selects a read-set or write-set *out of the shared pool*, computed from routing (§5) and narrowed by the session config. Interacting with another user pulls *that* user's outbox/inbox into the pool on demand.
+There is **one default relay list** (app config) so the relay works before anyone logs in and so new sessions have a starting point. As the relay runs and users interact, it dials more and more relays into **one shared connection pool** — the "hundreds of websockets" of the outbox model, ref-counted and shared across sessions. When a user logs in they get a **per-session relay config**: their own event-derived relays (NIP-65 outbox/inbox, NIP-17 DM…) **plus** the default local-role relays, all **editable by that user and persisted in session cache**. Every action selects a read-set or write-set *out of the shared pool*, computed from routing (§5). Interacting with another user pulls *that* user's outbox/inbox into the pool on demand — and **by default the client writes to other users' relays as well as its own** (that is the whole point of outbox). A user *can* explicitly pin to fixed relays ("only write to X / read from Y"), but that disables outbox routing and is opt-in and discouraged (§4.3).
 
 ### 4.1 App defaults — config: bootstrap + per-session seed
 
@@ -135,7 +135,7 @@ It holds, per logged-in pubkey:
 - the user's own **per-target-shaped** roles — `Outbox` / `Inbox` / `DMInbox` (also in the directory §4.4)
 - the user's own **self-only event-derived** roles, hydrated from their published lists — `Search` (10007) / `Blocked` (10006) / `Favorite` (10012) / `PrivateHome` (10013, decrypt with the user's signer)
 - **local** roles inherited from defaults — `Broadcast` / `Indexer` / `Proxy` / `Local` / `Trusted` — now user-overridable
-- user **constraints** that *narrow* the routed set — e.g. "only write to X", "only read from Y", per-relay enable/disable
+- an optional **fixed-relay override** (default **OFF**): pin the client to specific relays ("only write to X", "only read from Y"). This **turns the outbox model off** — replies stop reaching other users' inboxes — so it is explicit opt-in and **not recommended** unless the user deliberately wants a single-/fixed-relay client.
 
 ```go
 type SessionRelays struct {
@@ -190,7 +190,7 @@ This generalizes today's `Mailboxes` (which only has Read/Write/Both). The logge
 
 ## 5. Routing table
 
-`Route(op, targetPubkey) []string` composes the session's roles (§4.3) + the target's event-derived roles (§4.4), then **narrows by the session user's constraints** (e.g. "only write to X"). If the session has `Proxy` relays configured, feed-fetch ops short-circuit to proxy. The resolved URLs are then `Acquire`d from the shared pool (§4.2). A reply writes to **both** the author's outbox *and* the target's inbox, so the event lands where the target reads.
+`Route(op, targetPubkey) []string` composes the session's roles (§4.3) + the target's event-derived roles (§4.4). **By default this is full outbox routing** — a reply writes to **both** the author's outbox *and* the target's inbox (so it lands where the target reads), and reads hit the author's outbox. Routing collapses to a fixed relay set **only** if the user has explicitly enabled the fixed-relay override (§4.3), which turns outbox off. If the session has `Proxy` relays configured, feed-fetch ops short-circuit to proxy. The resolved URLs are then `Acquire`d from the shared pool (§4.2).
 
 | Operation | Relays resolved |
 |---|---|
@@ -294,7 +294,7 @@ client := core.NewClient(core.DefaultConfig())       // owns the shared pool (§
 // A user context = the per-session relay config (§4.3) + optional signer.
 uc := client.NewUserContext(pubkey, core.WithSigner(mySigner))
 uc.Relays().Set(url, core.RoleOutbox|core.RoleInbox)  // user edits their own config
-uc.Relays().OnlyWrite(url)                            // "only write to X" constraint
+uc.Relays().PinFixed(url)                             // opt-out: pin to fixed relays — DISABLES outbox, discouraged
 
 // Routing is automatic; the caller names the intent, not the relays.
 notes, err := uc.FetchNotes(ctx, authorPubkey)        // → author's Outbox

--- a/docs/design/outbox-relay-pool.md
+++ b/docs/design/outbox-relay-pool.md
@@ -57,25 +57,28 @@ The built-in Go client (`client/core`) is the library grain ships to downstream 
 
 ## 3. Relay role taxonomy
 
-Two sources, per #56. **Event-derived** roles are *per target user* (relay X is user A's outbox but user B's inbox). **Locally-configured** roles are *per install* (same set for every user you interact with).
+Roles fall into three classes by where the relay set comes from. (Research §12 pinned down the concrete kinds — several roles the first draft called "local" actually have standard published list events.)
 
-| Role | Source | Resolved from | Notes |
-|---|---|---|---|
-| `Outbox` | event-derived | NIP-65 kind 10002 `write` | where to publish a user's notes / fetch their notes |
-| `Inbox` | event-derived | NIP-65 kind 10002 `read` | where replies/zaps to a user are delivered |
-| `DMInbox` | event-derived | NIP-17 kind **10050** | where a user receives gift-wrapped DMs |
-| `PrivateInbox` | event-derived | **research — kind TBD** | open question §11 |
-| `PrivateHome` | local | client config | stores events only the local user can see |
-| `Proxy` | local | client config | aggregator override — short-circuits outbox expansion |
-| `Broadcast` | local | client config | fan-out; own publishes mirror here |
-| `Indexer` | local | client config (seed list) | resolve anyone's NIP-65/NIP-17 lists; default 5 in [`config.go:30`](../../client/core/config.go) |
-| `Search` | local | client config | NIP-50 capable; possible list-event — research §11 |
-| `Local` | local | client config | same device/LAN; latency-preferred |
-| `Trusted` | local | client config | **only** relays we'll sign NIP-42 AUTH for |
-| `Favorite` | local | session UX | surfaced in UI; low priority |
-| `Blocked` | local | session UX | pool never dials these |
+- **Per-target event-derived** — resolved for *any* user you interact with, from their published events; these populate the per-target directory (§4.4).
+- **Self-only event-derived** — the *logged-in user's own* published preferences; hydrated into the session config (§4.3) on login (some need the user's signer to decrypt). Not fetched for other users.
+- **Local-only** — app/session config; no standard published kind.
 
-A single relay URL can hold several roles (NIP-65 "both" = Outbox+Inbox; an indexer can also be trusted). **"Source: local" does not mean install-global** — local roles are seeded from app defaults into each *session* (§4.3) and are user-editable there; only the not-logged-in path uses the raw app defaults.
+| Role | Kind / source | NIP | Class | Notes |
+|---|---|---|---|---|
+| `Outbox` | 10002 `write` | 65 | per-target | publish a user's notes / fetch their notes |
+| `Inbox` | 10002 `read` | 65 | per-target | replies / zaps to a user are delivered here |
+| `DMInbox` | **10050** | 17 | per-target | gift-wrapped DM delivery; `["relay", url]` tags, empty content |
+| `PrivateHome` | **10013** (NIP-44 encrypted) | 37 | self-only | "relays for private content" (draft wraps); owner-only — needs the user's signer to decrypt |
+| `Search` | **10007** | 51 | self-only (+ local) | NIP-50 search relays |
+| `Blocked` | **10006** | 51 | self-only (+ local) | pool never dials these |
+| `Favorite` | **10012** (+ 30002 sets) | 51 | self-only (+ local) | browsable favorites; surfaced in UI |
+| `Indexer` | client config (seed list) | — | local | resolve anyone's NIP-65/17 lists; default 5 in [`config.go`](../../client/core/config.go) |
+| `Broadcast` | client config | — | local | own publishes mirror here for wider fan-out |
+| `Proxy` | client config | — | local | aggregator override — short-circuits outbox expansion |
+| `Local` | client config | — | local | same device / LAN; latency-preferred |
+| `Trusted` | client config | — | local | **only** relays we'll sign NIP-42 AUTH for |
+
+`PrivateInbox` from the first draft is **dropped** — no standard "private inbox" kind exists; kind 10013 covers the private-relay need as `PrivateHome`. A single URL can hold several roles (NIP-65 "both" = Outbox+Inbox; an indexer can also be trusted). The per-target directory (§4.4) only ever needs Outbox/Inbox/DMInbox; the self-only roles load into the session config (§4.3) from the logged-in user's own kinds, with local config as override/fallback.
 
 ---
 
@@ -129,8 +132,9 @@ func (rp *RelayPool) Release(url string)                                    // l
 The per-user overlay that makes the client behave exactly how that user wants. On login it is **seeded** from §4.1 defaults (local roles) **plus** the user's resolved event-derived relays, then it is **editable and persisted in session cache**. This extends today's `cache.clientRelays[pubkey]` ([`cache/relays.go`](../../client/cache/relays.go)), which already stores a per-user relay list but only with `read`/`write` bools — enrich it to the full `Role` set below.
 
 It holds, per logged-in pubkey:
-- the user's own **event-derived** roles — `Outbox` / `Inbox` / `DMInbox` / `PrivateInbox`
-- **local** roles inherited from defaults — `Broadcast` / `Indexer` / `Search` / `Trusted` / `Proxy` / `Local` / `PrivateHome` — now user-overridable
+- the user's own **per-target-shaped** roles — `Outbox` / `Inbox` / `DMInbox` (also in the directory §4.4)
+- the user's own **self-only event-derived** roles, hydrated from their published lists — `Search` (10007) / `Blocked` (10006) / `Favorite` (10012) / `PrivateHome` (10013, decrypt with the user's signer)
+- **local** roles inherited from defaults — `Broadcast` / `Indexer` / `Proxy` / `Local` / `Trusted` — now user-overridable
 - user **constraints** that *narrow* the routed set — e.g. "only write to X", "only read from Y", per-relay enable/disable
 
 ```go
@@ -148,8 +152,7 @@ const (
     RoleOutbox Role = 1 << iota
     RoleInbox
     RoleDMInbox
-    RolePrivateInbox
-    RolePrivateHome
+    RolePrivateHome // NIP-37 kind 10013 (encrypted, self-only)
     RoleProxy
     RoleBroadcast
     RoleIndexer
@@ -167,12 +170,11 @@ When nobody is logged in, routing falls back to §4.1 defaults directly.
 
 ```go
 type UserRelays struct {
-    Outbox       []string
-    Inbox        []string
-    DMInbox      []string
-    PrivateInbox []string
-    FetchedAt    time.Time
-    Negative     bool // cached "no list published" — short TTL
+    Outbox    []string // NIP-65 kind 10002 write
+    Inbox     []string // NIP-65 kind 10002 read
+    DMInbox   []string // NIP-17 kind 10050
+    FetchedAt time.Time
+    Negative  bool // cached "no list published" — short TTL
 }
 
 type RelayDirectory struct {
@@ -308,13 +310,18 @@ grain's `client/api`, `client/data`, `client/session`, and the global `coreClien
 
 ---
 
-## 12. Open research questions
+## 12. Research questions — resolved
 
-- **NIP-17 DM relay list:** confirm kind **10050** shape before wiring `DMInbox`.
-- **`PrivateInbox`:** #56 says "possibly a new event list; needs research." Confirm kind exists or drop the role to local-only.
-- **`Search` list event:** is there a user-published search-relay list, or is it purely app-config? (#56 flags this.)
-- **Persist `RelayDirectory` across restarts?** Or always cold-resolve from indexers. Cold is simpler; revisit if indexer load is a problem.
-- **`MaxConnections` default** — 256 is a guess; needs a load sanity check.
+Settled against the specs (June 2026):
+
+- **DMInbox = NIP-17 kind 10050.** `["relay", url]` tags, empty content, replaceable. Per-target.
+- **`PrivateInbox` dropped.** No standard "private inbox" relay list exists. The private-relay need is met by **NIP-37 kind 10013** ("relays for private content" / draft wraps) — **NIP-44 encrypted**, so resolvable only for the logged-in user (needs their signer). Mapped to `PrivateHome` (self-only).
+- **Search relays = NIP-51 kind 10007** — a real user-published list. Also found alongside it: **10006 blocked**, **10012 favorite** (+ **30002** relay sets). So Search / Blocked / Favorite are *self-only event-derived* (hydrate the logged-in user's own lists), with local config as override — not local-only as the first draft assumed.
+- **Directory persistence: no.** Cold-resolve per-target lists from indexers on demand, protected by the TTL cache (§4.4) + single-flight. Optional persistence can come later via the `RelayListStore` seam (§11) if indexer load justifies it.
+
+Still open (not blocking — tune under load):
+
+- **`MaxConnections` default (256)** wants a real load sanity check.
 
 ---
 

--- a/docs/design/outbox-relay-pool.md
+++ b/docs/design/outbox-relay-pool.md
@@ -1,0 +1,340 @@
+# Design: Outbox-model relay pool + streaming fetch path
+
+> **Status:** Draft for review — no code yet.
+> **Issues:** [#56 — Client library: outbox-model relay pool with role-based routing](https://github.com/0ceanSlim/grain/issues/56) (the engine), [#77 — Client fetch path: streaming + concurrent multi-relay queries with lazy UI hydration](https://github.com/0ceanSlim/grain/issues/77) (the consumer).
+> **Milestone:** v0.8 (Relay-as-actor) · both tagged `1.0 Requirement`.
+> **Scope decision:** full role model (all roles from #56), built in phases.
+
+---
+
+## 1. Why
+
+The built-in Go client (`client/core`) is the library grain ships to downstream apps. Today its pool is a flat, single-user, destructive design that cannot do outbox routing. This doc specifies the reshape and the streaming consumption layer that sits on top of it.
+
+### What the code actually does today (grounding)
+
+| Concern | Current behaviour | Where |
+|---|---|---|
+| Pool shape | flat `map[string]*RelayConnection`, no roles | [`client/core/relays.go:26`](../../client/core/relays.go) |
+| Process model | one global `coreClient` bound to ~5 index relays | [`client/connection/manager.go:10`](../../client/connection/manager.go) |
+| Switching to a user's relays | **tears down the whole pool and reconnects** | [`ReplaceRelayConnections`](../../client/core/client.go) `client.go:505` |
+| Routing | every query → all connected relays (= index relays) | [`Subscribe`](../../client/core/client.go) `client.go:132` |
+| Mailbox use | NIP-65 fetched + cached, **but the profile fetch in the same call still uses index relays** | [`FetchAndCacheUserDataWithCoreClient`](../../client/data/fetch.go) `fetch.go:54` |
+| Per-user relay store | JSON strings with only `read`/`write` bools | [`client/cache/relays.go`](../../client/cache/relays.go) |
+| Connection cap | `MaxConnections: 10` | [`client/core/config.go:41`](../../client/core/config.go) |
+
+### Two things #77 already got (don't re-do them)
+
+- **Login is already decoupled from the fetch.** `LoginHandler` returns the session immediately and `session.CreateUserSession` kicks a deduped background discovery — [`login.go:103`](../../client/api/login.go), [`FetchUserDataDeduped`](../../client/data/fetch.go) `fetch.go:25`. The issue calls this "80% of the perceived improvement." It's done.
+- **Single-flight dedup** for concurrent fetches of the same pubkey is done (same file).
+
+### One concrete bug that explains most of the remaining latency
+
+[`GetUserRelays`](../../client/core/client.go) (`client.go:321`) `select`s on `sub.Done`, but EOSE is routed to `sub.EOSE` ([`relays.go:97`](../../client/core/relays.go)) and `Done` is only closed by `Close()` (deferred to function return). **The mailbox fetch therefore never exits early on EOSE — it always burns the full 5 s timeout**, and the profile fetch runs serially after it. `GetUserProfile` (`client.go:262`) does it correctly. Fixing this + parallelizing the two fetches is the bulk of the "login hydration is slow" symptom, independent of the reshape.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+- A pool that holds **many users' relays simultaneously** (hundreds of connections), additively — no destructive swaps.
+- **Role-aware routing**: each operation goes to the right relays for the *target* user, not the local user's own set.
+- Full role taxonomy from #56, with per-user (event-derived) vs per-install (locally-configured) roles cleanly separated.
+- Per-user relay-list **hydration with caching + TTL**.
+- **Concurrent, first-wins queries** with **per-relay timeout + backoff** (#77 §1, §6).
+- Optional **streaming API boundary** (SSE/NDJSON) + **lazy UI hydration** (#77 §2, §3, §7), with the existing blocking endpoints preserved.
+- **AUTH policy**: only sign NIP-42 challenges for `trusted` relays.
+- Expose the pool + role assignments so downstream callers can read/edit them.
+- **Ship as a reusable, importable library.** A third party should `go get` grain's client package and build their own Nostr client on this outbox engine without reimplementing it or pulling in grain's web/HTTP layer — clean instance-based API, no required package globals, no cookie/HTTP coupling, pluggable signer + storage. (See §11.)
+
+**Non-goals (tracked elsewhere)**
+- Implementing individual NIPs (NIP-17 DM ciphertext, NIP-50 search semantics) — only their *relay-list* discovery is in scope here.
+- Relay-*server* changes — this is purely client-library work.
+- NIP-77 negentropy set reconciliation (#47, v1.0).
+- Cross-tab subscription multiplexing (#77 "out of scope").
+
+---
+
+## 3. Relay role taxonomy
+
+Two sources, per #56. **Event-derived** roles are *per target user* (relay X is user A's outbox but user B's inbox). **Locally-configured** roles are *per install* (same set for every user you interact with).
+
+| Role | Source | Resolved from | Notes |
+|---|---|---|---|
+| `Outbox` | event-derived | NIP-65 kind 10002 `write` | where to publish a user's notes / fetch their notes |
+| `Inbox` | event-derived | NIP-65 kind 10002 `read` | where replies/zaps to a user are delivered |
+| `DMInbox` | event-derived | NIP-17 kind **10050** | where a user receives gift-wrapped DMs |
+| `PrivateInbox` | event-derived | **research — kind TBD** | open question §11 |
+| `PrivateHome` | local | client config | stores events only the local user can see |
+| `Proxy` | local | client config | aggregator override — short-circuits outbox expansion |
+| `Broadcast` | local | client config | fan-out; own publishes mirror here |
+| `Indexer` | local | client config (seed list) | resolve anyone's NIP-65/NIP-17 lists; default 5 in [`config.go:30`](../../client/core/config.go) |
+| `Search` | local | client config | NIP-50 capable; possible list-event — research §11 |
+| `Local` | local | client config | same device/LAN; latency-preferred |
+| `Trusted` | local | client config | **only** relays we'll sign NIP-42 AUTH for |
+| `Favorite` | local | session UX | surfaced in UI; low priority |
+| `Blocked` | local | session UX | pool never dials these |
+
+A single relay URL can hold several roles (NIP-65 "both" = Outbox+Inbox; an indexer can also be trusted). **"Source: local" does not mean install-global** — local roles are seeded from app defaults into each *session* (§4.3) and are user-editable there; only the not-logged-in path uses the raw app defaults.
+
+---
+
+## 4. Data model
+
+Four layers. The bottom layer is the *default* lists; above it sits **one shared, growing connection pool**; above that, *per-session* config decides which relays each user uses; and a per-target-user directory feeds routing when you interact with someone else. Separating these is what lets the pool grow to hundreds of shared sockets while each user still routes their own way.
+
+### 4.0 The shape in one paragraph
+
+There is **one default relay list** (app config) so the relay works before anyone logs in and so new sessions have a starting point. As the relay runs and users interact, it dials more and more relays into **one shared connection pool** — the "hundreds of websockets" of the outbox model, ref-counted and shared across sessions. When a user logs in they get a **per-session relay config**: their own event-derived relays (NIP-65 outbox/inbox, NIP-17 DM…) **plus** the default local-role relays, all **editable by that user and persisted in session cache** (e.g. "only ever write to relay X"). Every action selects a read-set or write-set *out of the shared pool*, computed from routing (§5) and narrowed by the session config. Interacting with another user pulls *that* user's outbox/inbox into the pool on demand.
+
+### 4.1 App defaults — config: bootstrap + per-session seed
+
+- The seed `index_relays` + default local-role relays in [`config.go:30`](../../client/core/config.go).
+- Used directly for **not-logged-in** relay operations (mutelist fetch, dashboard, telemetry).
+- Copied as the **starting point** for each new session's local-role set (§4.3).
+
+### 4.2 Shared connection pool — process-wide, role-agnostic, ref-counted
+
+One live socket per URL, **shared by every session that needs it**, torn down only when nobody does. This is the pool that grows to hundreds of connections.
+
+```go
+// RelayConnection gains lease bookkeeping; the socket itself carries no roles.
+type RelayConnection struct {
+    URL    string
+    Conn   *websocket.Conn
+    Status ConnectionStatus
+    // ... existing fields (writeChan, done, closeOnce, Subscriptions) ...
+
+    leases   int        // active acquire() holders; 0 ⇒ eligible for idle evict
+    idleAt   time.Time  // when leases last hit 0
+    lastErr  time.Time  // for dial backoff
+    failCnt  int        // consecutive dial/read failures ⇒ exponential backoff
+}
+```
+
+Pool API (replaces the destructive `ReplaceRelayConnections` model):
+
+```go
+func (rp *RelayPool) Acquire(url, reason string) (*RelayConnection, error) // dial-on-demand, leases++
+func (rp *RelayPool) Release(url string)                                    // leases--, start idle timer at 0
+```
+
+- **Connect-on-demand:** `Acquire` dials only if absent and not `Blocked`.
+- **Idle eviction:** a sweeper closes connections with `leases == 0 && now-idleAt > IdleTTL`.
+- **Bounded dials:** a semaphore caps *concurrent* dials; a soft cap on *total* connections triggers LRU eviction of idle ones (the outbox pool routinely wants hundreds — see §10 config).
+- **Backoff:** failed dials set `failCnt`/`lastErr`; `Acquire` skips a relay still inside its backoff window so one dead relay isn't re-hammered.
+
+### 4.3 Per-session relay config — session cache, user-editable
+
+The per-user overlay that makes the client behave exactly how that user wants. On login it is **seeded** from §4.1 defaults (local roles) **plus** the user's resolved event-derived relays, then it is **editable and persisted in session cache**. This extends today's `cache.clientRelays[pubkey]` ([`cache/relays.go`](../../client/cache/relays.go)), which already stores a per-user relay list but only with `read`/`write` bools — enrich it to the full `Role` set below.
+
+It holds, per logged-in pubkey:
+- the user's own **event-derived** roles — `Outbox` / `Inbox` / `DMInbox` / `PrivateInbox`
+- **local** roles inherited from defaults — `Broadcast` / `Indexer` / `Search` / `Trusted` / `Proxy` / `Local` / `PrivateHome` — now user-overridable
+- user **constraints** that *narrow* the routed set — e.g. "only write to X", "only read from Y", per-relay enable/disable
+
+```go
+type SessionRelays struct {
+    mu    sync.RWMutex
+    roles map[string]Role // url → bitmask, scoped to THIS session
+}
+```
+
+`Role` is a bitmask shared across the routing code:
+
+```go
+type Role uint16
+const (
+    RoleOutbox Role = 1 << iota
+    RoleInbox
+    RoleDMInbox
+    RolePrivateInbox
+    RolePrivateHome
+    RoleProxy
+    RoleBroadcast
+    RoleIndexer
+    RoleSearch
+    RoleLocal
+    RoleTrusted
+    RoleFavorite
+    RoleBlocked
+)
+```
+
+When nobody is logged in, routing falls back to §4.1 defaults directly.
+
+### 4.4 Event-derived directory — other users, per target user, TTL-cached
+
+```go
+type UserRelays struct {
+    Outbox       []string
+    Inbox        []string
+    DMInbox      []string
+    PrivateInbox []string
+    FetchedAt    time.Time
+    Negative     bool // cached "no list published" — short TTL
+}
+
+type RelayDirectory struct {
+    mu  sync.RWMutex
+    m   map[string]*UserRelays // pubkey → lists
+    ttl, negTTL time.Duration
+}
+```
+
+This generalizes today's `Mailboxes` (which only has Read/Write/Both). The logged-in user is just the one pubkey whose entry *also* carries the editable, persisted session overlay of §4.3; everyone else is resolve-and-cache only.
+
+---
+
+## 5. Routing table
+
+`Route(op, targetPubkey) []string` composes the session's roles (§4.3) + the target's event-derived roles (§4.4), then **narrows by the session user's constraints** (e.g. "only write to X"). If the session has `Proxy` relays configured, feed-fetch ops short-circuit to proxy. The resolved URLs are then `Acquire`d from the shared pool (§4.2). A reply writes to **both** the author's outbox *and* the target's inbox, so the event lands where the target reads.
+
+| Operation | Relays resolved |
+|---|---|
+| Publish own note | own `Outbox` ∪ `Broadcast` |
+| Reply / react / zap to X | own `Outbox` ∪ X's `Inbox` |
+| Fetch X's notes | X's `Outbox` ∪ `Local` (or `Proxy` if set) |
+| Resolve X's metadata / relay-lists | X's `Outbox` if known, else `Indexer` |
+| DM to X | X's `DMInbox` |
+| Own private / draft events | `PrivateHome` |
+| Search query | `Search` |
+| Background telemetry | `Indexer` only — never the user's relays |
+
+Fallbacks: empty event-derived set ⇒ fall back to `Indexer` (resolve) or `Outbox`→`Indexer` (fetch), so a user with no published list still works.
+
+---
+
+## 6. Hydration
+
+Resolving a target user's event-derived roles:
+
+1. Look up `RelayDirectory` cache. Fresh hit ⇒ return.
+2. Miss/stale ⇒ query `Indexer` relays for that pubkey's kind **10002** (NIP-65) and kind **10050** (NIP-17 DM list) concurrently, first-wins (§7).
+3. Cache positive result with `ttl`; cache "nothing found" with `negTTL` (short) so a flood of unknown pubkeys can't DoS the indexers.
+4. Single-flight per pubkey (reuse the `flights` pattern already in [`fetch.go:17`](../../client/data/fetch.go)).
+
+This is where today's `GetUserRelays` becomes a generic per-target resolver instead of a one-shot "current user" call.
+
+---
+
+## 7. Query semantics (#77 §1, §6)
+
+New helpers alongside `Subscribe`, replacing the serial 5 s pattern:
+
+```go
+// First valid event across relays; keeps the sub open briefly to collect a
+// couple more for replaceable-event recency, then cancels the rest.
+func (c *Client) QueryFirst(ctx, filters, relays, opts) (*nostr.Event, error)
+
+// Streams events as they arrive; caller decides when enough is enough.
+func (c *Client) QueryStream(ctx, filters, relays, opts) (<-chan *nostr.Event, error)
+```
+
+- **Concurrent fan-out**, return on first valid event; brief grace window for replaceable recency; cancel losers via context.
+- **Per-relay timeout:** open cap ~1–2 s, EOSE cap ~4–5 s, each on its own ctx — one dead relay adds at most its own cap (acceptance criterion of #77).
+- **Fix the `GetUserRelays` EOSE bug** and route mailbox + profile fetches through `QueryFirst` concurrently.
+
+---
+
+## 8. Streaming boundary + lazy UI (#77 §2, §3, §7)
+
+- API endpoints (`/api/v1/user/profile`, `/user/relays`, `/events/query`) gain an **optional** SSE / chunked-NDJSON mode (e.g. `Accept: text/event-stream`). **The existing blocking JSON shape stays the default** — no breakage for current callers (acceptance criterion).
+- `/api/v1/cache` response grows `stale` / `refreshing` flags so the UI knows when to shimmer vs. trust the value (#77 §7).
+- UI: server-renders skeletons immediately (name + npub from `parseIdentifier`), small JS hydrates as SSE events land. **Per the project's "Go over JS" rule, keep the hydration layer minimal** — server-rendered placeholders + a thin SSE listener, not a client framework. Reuse `nostr-mill` where it already covers a piece.
+
+---
+
+## 9. AUTH policy (NIP-42)
+
+The client pool does not handle AUTH today. New rule: on an `AUTH` challenge, sign **only if** the relay URL carries `RoleTrusted` in `LocalRoles`; otherwise ignore. Default is refuse.
+
+---
+
+## 10. Config & migration
+
+`MaxConnections: 10` is wrong for an outbox pool. Proposed knobs (these also feed the future dashboard client-config section, #80):
+
+| Knob | Meaning | Default (proposed) |
+|---|---|---|
+| `max_connections` | soft cap on total live sockets; LRU-evict idle over this | 256 |
+| `max_concurrent_dials` | dial semaphore | 16 |
+| `idle_ttl` | evict a 0-lease connection after this | 120 s |
+| `relay_list_ttl` / `relay_list_neg_ttl` | hydration cache | 1 h / 1 min |
+| `open_timeout` / `eose_timeout` | per-relay query caps | 2 s / 5 s |
+
+**Migration / compatibility**
+- `ReplaceRelayConnections` / `SwitchToUserRelays` destructive teardown is **deprecated**, not deleted — kept as thin shims (acquire the URLs, no global swap) until callers migrate.
+- The single global `coreClient` stays; only its pool internals change — it owns the one shared pool (§4.2), not a per-user set.
+- Per-session relay config persists in session cache (enrich `cache.clientRelays[pubkey]` to the full `Role` set); seeded on login from defaults + resolved event-derived relays, editable by the user thereafter.
+- Preserve the recent leak fixes (#93/#94): `signalDone`/`closeOnce` semantics carry over unchanged into the leased connection.
+
+---
+
+## 11. Library API surface & reusability
+
+This is the library grain ships to downstream apps, so the outbox engine must **stand alone** — importable as `github.com/0ceanslim/grain/client/core` (and siblings) without dragging in grain's web layer. A consumer builds their own client on it; they do not reimplement outbox routing.
+
+### Principles
+- **Instance-based, no hidden globals.** The pool, directory, and routing hang off a `*core.Client` the caller constructs. grain's package-level `coreClient` ([`connection/manager.go:10`](../../client/connection/manager.go)) and global cache are then *grain's own* single instance, not a requirement of the library.
+- **No HTTP/cookie coupling in core.** The per-session relay config (§4.3) is a library type (`core.UserContext` below), independent of grain's `client/session` cookie machinery. grain's web layer wraps it; a CLI or another app uses it directly.
+- **Pluggable seams** (interfaces, not concrete deps):
+  - `Signer` — sign/encrypt for a pubkey (local key, NIP-07, NIP-46). Read-only callers pass none.
+  - `RelayListStore` — persist/restore the §4.4 directory + §4.3 session config (in-memory default; grain plugs its cache; others plug a DB).
+  - `Logger` — keep the `server/utils/log` abstraction injectable.
+- **`context.Context` on every network method** for cancellation/deadlines.
+- **Exported role/routing types** so callers can inspect and edit assignments (the #56 "expose pool + roles" requirement): `Role`, `UserRelays`, `SessionRelays`, `Route(op, target)`.
+
+### Sketch of the importable surface
+```go
+client := core.NewClient(core.DefaultConfig())       // owns the shared pool (§4.2)
+
+// A user context = the per-session relay config (§4.3) + optional signer.
+uc := client.NewUserContext(pubkey, core.WithSigner(mySigner))
+uc.Relays().Set(url, core.RoleOutbox|core.RoleInbox)  // user edits their own config
+uc.Relays().OnlyWrite(url)                            // "only write to X" constraint
+
+// Routing is automatic; the caller names the intent, not the relays.
+notes, err := uc.FetchNotes(ctx, authorPubkey)        // → author's Outbox
+err = uc.Reply(ctx, parent, content)                  // → own Outbox ∪ parent author's Inbox
+err = uc.PublishDM(ctx, recipient, content)           // → recipient's DMInbox
+profile, err := client.ResolveProfile(ctx, anyPubkey) // → Outbox else Indexer
+```
+grain's `client/api`, `client/data`, `client/session`, and the global `coreClient` become the **reference consumer** of this surface — a worked example of how to build on the library, not part of its import contract.
+
+### Package boundaries
+- `client/core` — the engine (pool, directory, routing, `UserContext`, `Signer`/`RelayListStore` interfaces). Importable, no web deps.
+- `client/cache`, `client/connection`, `client/data`, `client/session`, `client/api` — grain's application layer / reference consumer built on top.
+
+---
+
+## 12. Open research questions
+
+- **NIP-17 DM relay list:** confirm kind **10050** shape before wiring `DMInbox`.
+- **`PrivateInbox`:** #56 says "possibly a new event list; needs research." Confirm kind exists or drop the role to local-only.
+- **`Search` list event:** is there a user-published search-relay list, or is it purely app-config? (#56 flags this.)
+- **Persist `RelayDirectory` across restarts?** Or always cold-resolve from indexers. Cold is simpler; revisit if indexer load is a problem.
+- **`MaxConnections` default** — 256 is a guess; needs a load sanity check.
+
+---
+
+## 13. Phasing (maps to acceptance criteria)
+
+| Phase | Deliverable | Closes |
+|---|---|---|
+| **0** | Fix `GetUserRelays` EOSE bug; parallelize mailbox+profile fetch | #77 latency symptom — shippable alone |
+| **A** | Connection layer reshape: leases, connect-on-demand, idle evict, bounded dials, backoff | #56 lifecycle |
+| **B** | Role tables (4.2/4.3) + hydration (§6) + routing (§5) | #56 routing, proxy override |
+| **C** | `QueryFirst`/`QueryStream` + per-relay timeout/backoff | #77 §1, §6 |
+| **D** | SSE/NDJSON boundary + `cache` warmth flags + lazy UI skeletons | #77 §2, §3, §7 |
+| **E** | AUTH policy for `trusted`; finalize the importable API (§11) — exported role/routing types, `UserContext`, `Signer`/`RelayListStore` seams, instance-based (no required globals) | #56 AUTH + exposure |
+| **F** | **Full rewrite of `docs/client-library-guide.md` for 0.8.0** — outbox quick-start, routing walkthrough, API reference, and a runnable example of a *third-party* client built on the library | library GA docs |
+
+Phases 0–C and E are Go-only and **natively testable** (no cgo — this is client-side, unlike nostrdb). Phase D adds the only JS surface; keep it thin. Phase F is docs. Unit-test routing resolution, lease lifecycle, and role math against a mock relay — and the doc's third-party example should compile in CI so the public API can't silently drift.
+
+---
+
+## 14. Acceptance recap
+
+- **#56:** multi-role pool · per-user hydration w/ TTL · role-aware routing · proxy override · connect-on-demand + idle evict + bounded dials (hundreds of conns) · AUTH only for trusted · pool/roles exposed to callers.
+- **#77:** login→dropdown < 500 ms warm (already mostly via background fetch) · profile first paint name+npub < 500 ms cold · one dead relay ≤ its own per-relay timeout · existing blocking endpoints unchanged.

--- a/docs/docker/Dockerfile.dev
+++ b/docs/docker/Dockerfile.dev
@@ -49,6 +49,20 @@ RUN mkdir -p www/static/mill \
     && curl -fsSL -o www/static/mill/mill.umd.min.js \
         "https://cdn.jsdelivr.net/npm/nostr-mill@${MILL_VERSION}/dist/mill.umd.min.js"
 
+# swagger-ui-dist for the API docs page (/api/docs). Pinned to match the
+# release/test images. Lands in www/static/swagger/ (embedded via //go:embed
+# www/*). Without these the docs shell's JS/CSS 404 and the page renders blank.
+ARG SWAGGER_UI_VERSION=5.17.14
+RUN mkdir -p www/static/swagger \
+    && curl -fsSL -o /tmp/swagger.tgz \
+        "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-${SWAGGER_UI_VERSION}.tgz" \
+    && tar -xzf /tmp/swagger.tgz -C /tmp \
+    && cp /tmp/package/swagger-ui-bundle.js \
+          /tmp/package/swagger-ui-standalone-preset.js \
+          /tmp/package/swagger-ui.css \
+          www/static/swagger/ \
+    && rm -rf /tmp/swagger.tgz /tmp/package
+
 # Self-hosted webfonts (token stacks reference Space Grotesk, JetBrains
 # Mono, Comfortaa). Without them the @font-face declarations 404 and
 # the page falls back to system fonts.
@@ -60,12 +74,15 @@ RUN mkdir -p www/static/fonts \
          done; \
        done
 
-# main.go embeds docs/openapi/swagger.json via //go:embed. The release
-# build runs swag here; the dev image doesn't need a real spec, so a
-# stub keeps the embed directive happy.
+# main.go embeds docs/openapi/swagger.json via //go:embed. Use a real spec if
+# the build context carries one (run `make generate` on the host — it's
+# gitignored but copied in); otherwise write a stub so the embed directive is
+# satisfied without forcing swag into every dev rebuild.
 RUN mkdir -p docs/openapi \
-    && echo '{"swagger":"2.0","info":{"title":"grain dev","version":"dev"},"paths":{}}' \
-        > docs/openapi/swagger.json
+    && if [ ! -s docs/openapi/swagger.json ]; then \
+         echo '{"swagger":"2.0","info":{"title":"grain dev","version":"dev"},"paths":{}}' \
+           > docs/openapi/swagger.json; \
+       fi
 
 # Compile. CGO_ENABLED=1 because nostrdb is a C library.
 RUN CGO_ENABLED=1 go build -buildvcs=false -o /out/grain .

--- a/docs/docker/Dockerfile.dev
+++ b/docs/docker/Dockerfile.dev
@@ -38,7 +38,7 @@ RUN curl -fsSL -o /tmp/tailwindcss \
         https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64-musl \
     && chmod +x /tmp/tailwindcss \
     && (cd www/style && /tmp/tailwindcss -i input.css -o tailwind.min.css --minify) \
-    && sed -i 's|<script src="https://cdn.tailwindcss.com"></script>|<link rel="stylesheet" href="/style/tailwind.min.css">|g' \
+    && sed -i 's|<script src="https://cdn.tailwindcss.com"></script>|<link rel="stylesheet" href="/style/tailwind.min.css?v={{assetVersion}}">|g' \
         www/views/templates/layout.html \
     && rm /tmp/tailwindcss
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	golang.org/x/crypto v0.31.0
 	golang.org/x/net v0.27.0
 )
 
@@ -13,7 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
 
@@ -21,7 +22,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	golang.org/x/time v0.5.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
@@ -48,8 +50,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 // @securityDefinitions.apikey  NostrAuth
 // @in                          header
 // @name                        Authorization
-// @description                 NIP-98 HTTP Auth. Value is `Nostr <base64-encoded-kind-27235-event>` signed by the relay owner.
+// @description                 NIP-98 HTTP Auth (owner-signed kind-27235). In these docs, just click Authorize — "Try it out" then signs each request automatically with your connected signer (mill / NIP-07); no token to paste.
 package main
 
 import (

--- a/server/api/nip86.go
+++ b/server/api/nip86.go
@@ -81,7 +81,7 @@ type nip86IPEntry struct {
 // @Description
 // @Description **Spec methods (writes):** `banpubkey` / `unbanpubkey` / `allowpubkey` / `unallowpubkey` (params: `[pubkey, reason?]`), `allowkind` / `disallowkind` (params: `[kind:int]`), `blockip` / `unblockip` (params: `[ip-or-cidr, reason?]`), `changerelayname` / `changerelaydescription` / `changerelayicon` (params: `[value:string]`).
 // @Description
-// @Description **Grain vendor extensions (writes):** `grain_updateserver`, `grain_updateratelimit`, `grain_updateeventpurge`, `grain_updatelogging`, `grain_updateauth`, `grain_updatebackuprelay`, `grain_updateresourcelimits`, `grain_updateeventtimeconstraints`, `grain_updatewhitelistconfig`, `grain_updateblacklistconfig`. Each takes the full section blob as `params[0]` (same shape the matching GET endpoint returns) and stages it to disk; the response is `{ok:true, restart_pending:true}`. Operator clicks Apply → dashboard calls `grain_reloadconfig`.
+// @Description **Grain vendor extensions (writes):** `grain_updateserver`, `grain_updateratelimit`, `grain_updateeventpurge`, `grain_updatelogging`, `grain_updateauth`, `grain_updatebackuprelay`, `grain_updateclient`, `grain_updateresourcelimits`, `grain_updateeventtimeconstraints`, `grain_updatewhitelistconfig`, `grain_updateblacklistconfig`. Each takes the full section blob as `params[0]` (same shape the matching GET endpoint returns) and stages it to disk; the response is `{ok:true, restart_pending:true}`. Operator clicks Apply → dashboard calls `grain_reloadconfig`.
 // @Description
 // @Description **Grain vendor extensions (ops + reads):** `grain_reloadconfig` (triggers restart), `grain_refreshcache` (synchronous whitelist + blacklist cache refresh), `grain_whitelistconfig` / `grain_blacklistconfig` (full-struct reads — the blacklist read overlays IP fields from config.yml so the dashboard sees one coherent shape), `grain_stats_overview` (server counters + list/cache stats).
 // @Description
@@ -278,6 +278,7 @@ func supportedNIP86Methods() []string {
 		"grain_updatelogging",
 		"grain_updateauth",
 		"grain_updatebackuprelay",
+		"grain_updateclient",
 		"grain_updateresourcelimits",
 		"grain_updateeventtimeconstraints",
 		"grain_updatewhitelistconfig",

--- a/server/api/nip86.go
+++ b/server/api/nip86.go
@@ -209,6 +209,8 @@ func dispatchNIP86(req nip86Request, signer string) (any, string) {
 		return runUpdateAuth(req.Params, signer)
 	case "grain_updatebackuprelay":
 		return runUpdateBackupRelay(req.Params, signer)
+	case "grain_updateclient":
+		return runUpdateClient(req.Params, signer)
 	case "grain_updateresourcelimits":
 		return runUpdateResourceLimits(req.Params, signer)
 	case "grain_updateeventtimeconstraints":

--- a/server/api/nip86_grain.go
+++ b/server/api/nip86_grain.go
@@ -133,6 +133,18 @@ func runUpdateBackupRelay(params []any, signer string) (any, string) {
 	return updateResult(), ""
 }
 
+func runUpdateClient(params []any, signer string) (any, string) {
+	var cc cfgType.ClientConfig
+	if err := paramJSON(params, 0, &cc); err != nil {
+		return nil, err.Error()
+	}
+	if err := config.UpdateClientConfig(cc); err != nil {
+		return nil, err.Error()
+	}
+	log.RelayAPI().Info("NIP-86 grain_updateclient", "signer", signer, "client_tag", cc.ClientTag.Enabled)
+	return updateResult(), ""
+}
+
 func runUpdateResourceLimits(params []any, signer string) (any, string) {
 	var rl cfgType.ResourceLimits
 	if err := paramJSON(params, 0, &rl); err != nil {

--- a/server/startup.go
+++ b/server/startup.go
@@ -456,7 +456,11 @@ func initRoot(w http.ResponseWriter, r *http.Request) {
 		// Let API and auth endpoints fall through to be handled by registered endpoints
 		http.NotFound(w, r)
 	case strings.HasPrefix(r.URL.Path, "/views/") || strings.HasPrefix(r.URL.Path, "/static/") || strings.HasPrefix(r.URL.Path, "/style/"):
-		// Serve actual static files from embedded FS (CSS, JS, view templates, etc.)
+		// Serve actual static files from embedded FS (CSS, JS, view templates, etc.).
+		// no-cache so a rebuilt binary's updated assets are picked up on the next
+		// load without a manual hard-refresh: the bytes are embedded in the binary,
+		// so the same URL serves new content after every build.
+		w.Header().Set("Cache-Control", "no-cache")
 		subFS, _ := fs.Sub(client.GetEmbeddedWWW(), "www")
 		fileServer := http.FileServer(http.FS(subFS))
 		http.StripPrefix("/", fileServer).ServeHTTP(w, r)

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -23,11 +23,15 @@ RUN find server/db/nostrdb -type f \! -name '*.o' \! -name '*.a' \! -name '*.png
 RUN cd server/db/nostrdb && bash build.sh
 
 # Generate the OpenAPI spec from swag annotations. main.go embeds
-# docs/openapi/swagger.json via //go:embed, so a missing file fails
-# the build with a clear "no matching files found" error. This step
-# is the build-time half of the contract; the runtime half lives in
-# server/api/docs.
+# docs/openapi/swagger.json via //go:embed — and `swag init` itself runs
+# `go list` over the module, which fails on that missing embed BEFORE swag
+# can generate it (chicken-and-egg: go list then can't resolve cross-package
+# types like core.KnownRelayStatus). Seed a placeholder so `go list` succeeds;
+# swag overwrites it with the real spec. Build-time half of the contract; the
+# runtime half lives in server/api/docs.
 RUN go install github.com/swaggo/swag/cmd/swag@v1.16.4 \
+    && mkdir -p docs/openapi \
+    && printf '%s' '{"swagger":"2.0","info":{"title":"grain","version":"dev"},"paths":{}}' > docs/openapi/swagger.json \
     && swag init --parseDependency --parseInternal -g main.go -o docs/openapi -ot json
 
 # Bundle swagger-ui-dist for the API docs page. The version is pinned

--- a/www/static/css/swagger-overrides.css
+++ b/www/static/css/swagger-overrides.css
@@ -232,11 +232,18 @@
   border-bottom-color: var(--color-border);
 }
 
-/* Servers / scheme selector */
-.swagger-ui .scheme-container {
-  background: var(--color-surface);
-  border-color: var(--color-border);
-  box-shadow: none;
+/* Auth UI. Protected requests are signed automatically by the connected signer
+ * (the requestInterceptor in api-docs.html), so the manual Authorize modal is
+ * redundant — and swagger's default dialog isn't themed, so it reads badly
+ * against the dark palette. Hide the Authorize bar + the auth dialog; the
+ * per-operation lock icons stay as inert "needs owner auth" indicators. */
+.swagger-ui .scheme-container,
+.swagger-ui .dialog-ux {
+  display: none !important;
+}
+
+.swagger-ui .authorization__btn {
+  pointer-events: none;
 }
 
 /* Mobile breathing room — Swagger UI's default `wrapper` is wide */

--- a/www/static/js/admin.js
+++ b/www/static/js/admin.js
@@ -442,7 +442,7 @@
     // etc.): show the reconnect indicator and refuse this action.
     // The indicator wires its own click → restore/showAuthModal.
     showReconnectIndicator(true);
-    throw new Error("signer not connected — click the Reconnect indicator");
+    throw new Error("Signer not connected — click the 🔑 Reconnect signer button (top-right).");
   }
   window.adminEnsureSigner = ensureSigner;
 
@@ -488,6 +488,20 @@
   window.addEventListener("grain:signer-ready", () => {
     showReconnectIndicator(false);
   });
+
+  // On load, reflect signer state up front: after claim the signer often needs a
+  // manual reconnect (extension can't be woken silently). Try a silent restore;
+  // if it's still missing, surface the Reconnect pill immediately rather than
+  // waiting for the first action to fail with an error.
+  (async function reflectSignerOnLoad() {
+    if (window.grainSigner && typeof window.grainSigner.signEvent === "function") return;
+    if (typeof window.restoreSigner === "function") {
+      try {
+        if (await window.restoreSigner()) return;
+      } catch (e) {}
+    }
+    showReconnectIndicator(true);
+  })();
 
   // expandDotted converts a flat blob with keys like
   // "pubkey_whitelist.enabled" into a nested object the server's

--- a/www/static/js/blossom-upload.js
+++ b/www/static/js/blossom-upload.js
@@ -144,9 +144,11 @@
     const overlay = document.createElement("div");
     overlay.className = "fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60";
     const card = document.createElement("div");
-    card.className = "w-full max-w-md p-5 border rounded-xl bg-surface border-border shadow-lg";
+    card.className = "w-full max-w-md p-6 border shadow-lg rounded-xl bg-surface border-border";
     overlay.appendChild(card);
+    let previewUrl = "";
     function close() {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
       overlay.remove();
     }
     overlay.addEventListener("click", (e) => {
@@ -175,6 +177,13 @@
       return;
     }
 
+    // Image preview (the name + size stay below it).
+    let previewHtml = "";
+    if (file.type && file.type.indexOf("image/") === 0) {
+      previewUrl = URL.createObjectURL(file);
+      previewHtml = `<img src="${previewUrl}" alt="" class="object-contain w-full mb-3 rounded max-h-44 bg-surface-inset" />`;
+    }
+
     const options = all
       .map((s, i) => {
         const tags = [s.kind, s.cost, s.retention].filter(Boolean).join(" · ");
@@ -183,42 +192,80 @@
       .join("");
 
     card.innerHTML =
-      `<h3 class="mb-1 text-lg font-semibold text-text">Upload file</h3>` +
+      `<h3 class="mb-3 text-lg font-semibold text-text">Upload file</h3>` +
+      previewHtml +
       `<p class="mb-3 text-xs text-text-muted">${esc(file.name)} · ${fmtSize(file.size)}</p>` +
       `<label class="block mb-1 text-xs font-medium text-text-secondary">Upload to</label>` +
-      `<select data-ref="server" class="w-full px-3 py-2 mb-2 text-sm border rounded-lg bg-surface-elevated text-text border-border">${options}</select>` +
-      `<label class="flex items-center gap-2 mb-1 text-sm cursor-pointer text-text">` +
-      `<input data-ref="mirror" type="checkbox" />Mirror to my other servers</label>` +
-      `<p data-ref="ephemeral" class="hidden mb-2 text-xs text-warning">⚠ This server is ephemeral — uploads may be deleted after a while.</p>` +
+      `<select data-ref="server" class="w-full px-3 py-2 mb-3 text-sm border rounded-lg bg-surface-elevated text-text border-border">${options}</select>` +
+      `<label class="flex items-center gap-2 text-sm cursor-pointer text-text">` +
+      `<input data-ref="mirror" type="checkbox" /> Mirror to other servers</label>` +
+      `<div data-ref="mirrorList" class="hidden p-2 mt-2 space-y-1.5 border rounded-lg border-border bg-surface-inset"></div>` +
+      `<p data-ref="ephemeral" class="hidden mt-2 text-xs text-warning">⚠ This server is ephemeral — uploads may be deleted after a while.</p>` +
       `<div data-ref="progress" class="hidden h-1.5 my-3 overflow-hidden rounded bg-surface-inset"><div data-ref="bar" class="h-full bg-accent" style="width:0%"></div></div>` +
-      `<p data-ref="status" class="mt-2 mb-3 text-xs text-text-secondary"></p>` +
+      `<p data-ref="status" class="mt-3 mb-4 text-xs text-text-secondary"></p>` +
       `<div class="flex justify-end gap-2">` +
-      `<button data-ref="cancel" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Cancel</button>` +
+      `<button data-ref="cancel" class="px-4 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Cancel</button>` +
       `<button data-ref="go" class="px-4 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Upload</button>` +
       `</div>`;
 
     const $ = (ref) => card.querySelector('[data-ref="' + ref + '"]');
     const sel = $("server"),
       mirror = $("mirror"),
+      mirrorList = $("mirrorList"),
       ephemeral = $("ephemeral"),
       progress = $("progress"),
       bar = $("bar"),
       status = $("status"),
       go = $("go");
 
+    // Per-server mirror selection: list the OTHER servers (relative to the chosen
+    // primary) with individual checkboxes, default all on, plus a Select all.
+    function renderMirrorList() {
+      const primary = Number(sel.value);
+      const others = [];
+      for (let i = 0; i < all.length; i++) if (i !== primary) others.push(i);
+      if (!others.length) {
+        mirrorList.innerHTML = `<p class="text-xs text-text-muted">No other servers to mirror to.</p>`;
+        return;
+      }
+      mirrorList.innerHTML =
+        `<label class="flex items-center gap-2 text-xs cursor-pointer text-text-secondary"><input data-ref="mirrorAll" type="checkbox" checked /> Select all</label>` +
+        others
+          .map(
+            (i) =>
+              `<label class="flex items-center gap-2 text-xs cursor-pointer text-text"><input type="checkbox" data-mirror-idx="${i}" checked /> ${esc(shortUrl(all[i].url))}</label>`
+          )
+          .join("");
+      const allCb = mirrorList.querySelector('[data-ref="mirrorAll"]');
+      allCb.onchange = () => {
+        mirrorList.querySelectorAll("[data-mirror-idx]").forEach((cb) => (cb.checked = allCb.checked));
+      };
+    }
+
     function reflectServer() {
       const s = all[Number(sel.value)];
       ephemeral.classList.toggle("hidden", !(s && s.retention === "ephemeral"));
-      const others = all.length > 1;
-      mirror.disabled = !others;
-      mirror.parentElement.classList.toggle("opacity-50", !others);
+      const hasOthers = all.length > 1;
+      mirror.disabled = !hasOthers;
+      mirror.parentElement.classList.toggle("opacity-50", !hasOthers);
+      if (mirror.checked) renderMirrorList(); // keep the list in sync with the primary
     }
     sel.onchange = reflectServer;
+    mirror.onchange = () => {
+      mirrorList.classList.toggle("hidden", !mirror.checked);
+      if (mirror.checked) renderMirrorList();
+    };
     reflectServer();
     $("cancel").onclick = close;
 
     go.onclick = async function () {
       const server = all[Number(sel.value)];
+      const mirrorTargets =
+        mirror.checked && !mirror.disabled
+          ? Array.from(mirrorList.querySelectorAll("[data-mirror-idx]:checked")).map(
+              (cb) => all[Number(cb.getAttribute("data-mirror-idx"))]
+            )
+          : [];
       go.disabled = true;
       sel.disabled = true;
       progress.classList.remove("hidden");
@@ -230,15 +277,12 @@
         const url = await uploadTo(file, server, hash, (p) => {
           bar.style.width = Math.round(p * 100) + "%";
         });
-        if (mirror.checked && all.length > 1) {
-          status.textContent = "Mirroring…";
-          for (let i = 0; i < all.length; i++) {
-            if (i === Number(sel.value)) continue;
-            try {
-              await uploadTo(file, all[i], hash, null);
-            } catch (e) {
-              /* best-effort mirror */
-            }
+        for (const t of mirrorTargets) {
+          status.textContent = "Mirroring to " + shortUrl(t.url) + "…";
+          try {
+            await uploadTo(file, t, hash, null);
+          } catch (e) {
+            /* best-effort mirror */
           }
         }
         status.textContent = "✓ Uploaded";

--- a/www/static/js/blossom-upload.js
+++ b/www/static/js/blossom-upload.js
@@ -137,6 +137,19 @@
     return n < 1024 * 1024 ? Math.round(n / 1024) + " KB" : (n / 1024 / 1024).toFixed(1) + " MB";
   }
 
+  // Navigate to Settings and scroll to the media-servers section (settings.js
+  // reads window.__grainScrollTarget once the content is visible). Mirrors
+  // header.html's openRelaySettings so it works from any page, SPA or not.
+  function openMediaSettings() {
+    window.__grainScrollTarget = "media-servers-section";
+    if (typeof window.htmx === "undefined") {
+      window.location.href = "/settings";
+      return;
+    }
+    window.history.pushState({}, "", "/settings");
+    window.htmx.ajax("GET", "/views/settings.html", { target: "#main-content" });
+  }
+
   function showModal(file, servers, onUrl, opts, fetchOk) {
     const all = [].concat((servers && servers.blossom) || [], (servers && servers.nip96) || []);
     const hasAny = servers && servers.hasAny && all.length > 0;
@@ -166,12 +179,16 @@
         `<div class="flex flex-wrap justify-end gap-2">` +
         `<button data-act="cancel" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Close</button>` +
         `<button data-act="recheck" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Re-check</button>` +
-        `<a href="/settings" class="px-3 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Open settings</a>` +
+        `<button data-act="settings" class="px-3 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Open settings</button>` +
         `</div>`;
       card.querySelector('[data-act="cancel"]').onclick = close;
       card.querySelector('[data-act="recheck"]').onclick = function () {
         close();
         open(file, onUrl, Object.assign({}, opts, { refresh: true }));
+      };
+      card.querySelector('[data-act="settings"]').onclick = function () {
+        close();
+        openMediaSettings();
       };
       document.body.appendChild(overlay);
       return;

--- a/www/static/js/blossom-upload.js
+++ b/www/static/js/blossom-upload.js
@@ -275,4 +275,25 @@
   }
 
   window.grainUpload = { pick: pick, open: open, _uploadTo: uploadTo, _sha256Hex: sha256Hex };
+
+  // Declarative wiring: a button with data-upload-target="<css selector>" opens
+  // the picker and writes the resulting URL into the target field (firing input +
+  // change so any framework/handler picks it up). data-upload-accept overrides
+  // the file filter (default image/*). Delegated so it works on dynamically
+  // rendered fields (profile edit form, admin sections).
+  document.addEventListener("click", function (e) {
+    const btn = e.target.closest && e.target.closest("[data-upload-target]");
+    if (!btn) return;
+    e.preventDefault();
+    const target = document.querySelector(btn.getAttribute("data-upload-target"));
+    if (!target) return;
+    pick(
+      function (url) {
+        target.value = url;
+        target.dispatchEvent(new Event("input", { bubbles: true }));
+        target.dispatchEvent(new Event("change", { bubbles: true }));
+      },
+      { accept: btn.getAttribute("data-upload-accept") || "image/*" }
+    );
+  });
 })();

--- a/www/static/js/blossom-upload.js
+++ b/www/static/js/blossom-upload.js
@@ -1,0 +1,278 @@
+// Reusable media upload (#83). Uploads a File to the user's chosen media server
+// — Blossom (BUD-01/02, kind 24242 PUT) or NIP-96 (kind 27235 NIP-98 POST) —
+// signing the auth event with the connected signer (window.grainSigner). Every
+// upload pops a small pre-upload modal: pick the primary server + optionally
+// mirror to the others. Returns the hosted URL to the caller.
+//
+// Public API:
+//   window.grainUpload.pick(onUrl, opts)        — open a file picker, then upload
+//   window.grainUpload.open(file, onUrl, opts)  — upload an already-chosen File
+//   opts: { accept: "image/*", title: "Upload" }
+(function () {
+  "use strict";
+
+  // ── crypto + auth ──────────────────────────────────────────────────────────
+
+  async function sha256Hex(buf) {
+    const digest = await crypto.subtle.digest("SHA-256", buf);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  async function ensureSigner() {
+    if (typeof window.restoreSigner === "function") {
+      try {
+        await window.restoreSigner();
+      } catch (e) {}
+    }
+    return window.grainSigner && typeof window.grainSigner.signEvent === "function"
+      ? window.grainSigner
+      : null;
+  }
+
+  function b64Event(evt) {
+    return btoa(JSON.stringify(evt));
+  }
+
+  // ── Blossom (BUD-01/02) ────────────────────────────────────────────────────
+
+  async function uploadBlossom(file, serverUrl, hash, onProgress) {
+    const signer = await ensureSigner();
+    if (!signer) throw new Error("No signer connected");
+    const auth = await signer.signEvent({
+      kind: 24242,
+      created_at: Math.floor(Date.now() / 1000),
+      content: "Upload " + file.name,
+      tags: [
+        ["t", "upload"],
+        ["x", hash],
+        ["expiration", String(Math.floor(Date.now() / 1000) + 3600)],
+      ],
+    });
+    const base = serverUrl.replace(/\/+$/, "");
+    const desc = await xhrSend("PUT", base + "/upload", file, {
+      Authorization: "Nostr " + b64Event(auth),
+    }, onProgress);
+    const json = JSON.parse(desc);
+    if (!json || !json.url) throw new Error("Server returned no blob URL");
+    return json.url;
+  }
+
+  // ── NIP-96 ──────────────────────────────────────────────────────────────────
+
+  async function uploadNIP96(file, serverUrl, hash, onProgress) {
+    const signer = await ensureSigner();
+    if (!signer) throw new Error("No signer connected");
+    // Discover the API endpoint (BUD-style well-known).
+    const base = serverUrl.replace(/\/+$/, "");
+    let apiUrl = base;
+    try {
+      const wk = await fetch(base + "/.well-known/nostr/nip96.json");
+      if (wk.ok) {
+        const cfg = await wk.json();
+        if (cfg && cfg.api_url) apiUrl = cfg.api_url;
+      }
+    } catch (e) {
+      /* fall back to the base URL */
+    }
+    const auth = await signer.signEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      content: "",
+      tags: [
+        ["u", apiUrl],
+        ["method", "POST"],
+        ["payload", hash],
+      ],
+    });
+    const form = new FormData();
+    form.append("file", file);
+    const respText = await xhrSend("POST", apiUrl, form, {
+      Authorization: "Nostr " + b64Event(auth),
+    }, onProgress);
+    const json = JSON.parse(respText);
+    // NIP-96 returns nip94_event with a ["url", <url>] tag.
+    const tags = (json && json.nip94_event && json.nip94_event.tags) || [];
+    const urlTag = tags.find((t) => t[0] === "url");
+    if (!urlTag) throw new Error(json && json.message ? json.message : "Upload failed");
+    return urlTag[1];
+  }
+
+  // xhrSend wraps XMLHttpRequest so we get upload progress for large files.
+  function xhrSend(method, url, body, headers, onProgress) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open(method, url, true);
+      Object.keys(headers || {}).forEach((k) => xhr.setRequestHeader(k, headers[k]));
+      if (xhr.upload && onProgress) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) onProgress(e.loaded / e.total);
+        };
+      }
+      xhr.onload = () =>
+        xhr.status >= 200 && xhr.status < 300
+          ? resolve(xhr.responseText)
+          : reject(new Error("HTTP " + xhr.status + (xhr.responseText ? ": " + xhr.responseText.slice(0, 200) : "")));
+      xhr.onerror = () => reject(new Error("Network error (CORS or server unreachable)"));
+      xhr.send(body);
+    });
+  }
+
+  async function uploadTo(file, server, hash, onProgress) {
+    return server.kind === "nip96"
+      ? uploadNIP96(file, server.url, hash, onProgress)
+      : uploadBlossom(file, server.url, hash, onProgress);
+  }
+
+  // ── Pre-upload modal ──────────────────────────────────────────────────────
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]);
+  }
+  function shortUrl(u) {
+    return String(u || "").replace(/^https?:\/\//, "").replace(/\/$/, "");
+  }
+  function fmtSize(n) {
+    return n < 1024 * 1024 ? Math.round(n / 1024) + " KB" : (n / 1024 / 1024).toFixed(1) + " MB";
+  }
+
+  function showModal(file, servers, onUrl, opts) {
+    const all = [].concat((servers && servers.blossom) || [], (servers && servers.nip96) || []);
+    const hasAny = servers && servers.hasAny && all.length > 0;
+
+    const overlay = document.createElement("div");
+    overlay.className = "fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60";
+    const card = document.createElement("div");
+    card.className = "w-full max-w-md p-5 border rounded-xl bg-surface border-border shadow-lg";
+    overlay.appendChild(card);
+    function close() {
+      overlay.remove();
+    }
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) close();
+    });
+
+    if (!hasAny) {
+      card.innerHTML =
+        `<h3 class="mb-2 text-lg font-semibold text-text">No media server set up</h3>` +
+        `<p class="mb-4 text-sm text-text-muted">Add a Blossom or NIP-96 server in Settings → Media servers before uploading.</p>` +
+        `<div class="flex justify-end gap-2">` +
+        `<button data-act="cancel" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Close</button>` +
+        `<a href="/settings" class="px-3 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Open settings</a>` +
+        `</div>`;
+      card.querySelector('[data-act="cancel"]').onclick = close;
+      document.body.appendChild(overlay);
+      return;
+    }
+
+    const options = all
+      .map((s, i) => {
+        const tags = [s.kind, s.cost, s.retention].filter(Boolean).join(" · ");
+        return `<option value="${i}"${s.primary ? " selected" : ""}>${esc(shortUrl(s.url))}${tags ? " — " + esc(tags) : ""}</option>`;
+      })
+      .join("");
+
+    card.innerHTML =
+      `<h3 class="mb-1 text-lg font-semibold text-text">Upload file</h3>` +
+      `<p class="mb-3 text-xs text-text-muted">${esc(file.name)} · ${fmtSize(file.size)}</p>` +
+      `<label class="block mb-1 text-xs font-medium text-text-secondary">Upload to</label>` +
+      `<select data-ref="server" class="w-full px-3 py-2 mb-2 text-sm border rounded-lg bg-surface-elevated text-text border-border">${options}</select>` +
+      `<label class="flex items-center gap-2 mb-1 text-sm cursor-pointer text-text">` +
+      `<input data-ref="mirror" type="checkbox" />Mirror to my other servers</label>` +
+      `<p data-ref="ephemeral" class="hidden mb-2 text-xs text-warning">⚠ This server is ephemeral — uploads may be deleted after a while.</p>` +
+      `<div data-ref="progress" class="hidden h-1.5 my-3 overflow-hidden rounded bg-surface-inset"><div data-ref="bar" class="h-full bg-accent" style="width:0%"></div></div>` +
+      `<p data-ref="status" class="mt-2 mb-3 text-xs text-text-secondary"></p>` +
+      `<div class="flex justify-end gap-2">` +
+      `<button data-ref="cancel" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Cancel</button>` +
+      `<button data-ref="go" class="px-4 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Upload</button>` +
+      `</div>`;
+
+    const $ = (ref) => card.querySelector('[data-ref="' + ref + '"]');
+    const sel = $("server"),
+      mirror = $("mirror"),
+      ephemeral = $("ephemeral"),
+      progress = $("progress"),
+      bar = $("bar"),
+      status = $("status"),
+      go = $("go");
+
+    function reflectServer() {
+      const s = all[Number(sel.value)];
+      ephemeral.classList.toggle("hidden", !(s && s.retention === "ephemeral"));
+      const others = all.length > 1;
+      mirror.disabled = !others;
+      mirror.parentElement.classList.toggle("opacity-50", !others);
+    }
+    sel.onchange = reflectServer;
+    reflectServer();
+    $("cancel").onclick = close;
+
+    go.onclick = async function () {
+      const server = all[Number(sel.value)];
+      go.disabled = true;
+      sel.disabled = true;
+      progress.classList.remove("hidden");
+      status.textContent = "Hashing…";
+      try {
+        const buf = await file.arrayBuffer();
+        const hash = await sha256Hex(buf);
+        status.textContent = "Uploading to " + shortUrl(server.url) + "…";
+        const url = await uploadTo(file, server, hash, (p) => {
+          bar.style.width = Math.round(p * 100) + "%";
+        });
+        if (mirror.checked && all.length > 1) {
+          status.textContent = "Mirroring…";
+          for (let i = 0; i < all.length; i++) {
+            if (i === Number(sel.value)) continue;
+            try {
+              await uploadTo(file, all[i], hash, null);
+            } catch (e) {
+              /* best-effort mirror */
+            }
+          }
+        }
+        status.textContent = "✓ Uploaded";
+        onUrl(url);
+        setTimeout(close, 700);
+      } catch (e) {
+        go.disabled = false;
+        sel.disabled = false;
+        progress.classList.add("hidden");
+        status.textContent = "Upload failed: " + (e && e.message ? e.message : e);
+      }
+    };
+
+    document.body.appendChild(overlay);
+  }
+
+  // ── Public entry points ──────────────────────────────────────────────────────
+
+  function pick(onUrl, opts) {
+    opts = opts || {};
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = opts.accept || "image/*";
+    input.style.display = "none";
+    input.onchange = () => {
+      if (input.files && input.files[0]) open(input.files[0], onUrl, opts);
+      input.remove();
+    };
+    document.body.appendChild(input);
+    input.click();
+  }
+
+  async function open(file, onUrl, opts) {
+    opts = opts || {};
+    let servers;
+    try {
+      const r = await fetch("/api/v1/user/media-servers");
+      servers = r.ok ? await r.json() : null;
+    } catch (e) {
+      servers = null;
+    }
+    showModal(file, servers, onUrl, opts);
+  }
+
+  window.grainUpload = { pick: pick, open: open, _uploadTo: uploadTo, _sha256Hex: sha256Hex };
+})();

--- a/www/static/js/blossom-upload.js
+++ b/www/static/js/blossom-upload.js
@@ -137,7 +137,7 @@
     return n < 1024 * 1024 ? Math.round(n / 1024) + " KB" : (n / 1024 / 1024).toFixed(1) + " MB";
   }
 
-  function showModal(file, servers, onUrl, opts) {
+  function showModal(file, servers, onUrl, opts, fetchOk) {
     const all = [].concat((servers && servers.blossom) || [], (servers && servers.nip96) || []);
     const hasAny = servers && servers.hasAny && all.length > 0;
 
@@ -154,14 +154,23 @@
     });
 
     if (!hasAny) {
+      const failed = !fetchOk;
       card.innerHTML =
-        `<h3 class="mb-2 text-lg font-semibold text-text">No media server set up</h3>` +
-        `<p class="mb-4 text-sm text-text-muted">Add a Blossom or NIP-96 server in Settings → Media servers before uploading.</p>` +
-        `<div class="flex justify-end gap-2">` +
+        (failed
+          ? `<h3 class="mb-2 text-lg font-semibold text-text">Couldn't load your media servers</h3>` +
+            `<p class="mb-4 text-sm text-text-muted">Make sure you're signed in, then re-check.</p>`
+          : `<h3 class="mb-2 text-lg font-semibold text-text">No media server set up</h3>` +
+            `<p class="mb-4 text-sm text-text-muted">If you just added one it may not have synced yet — re-check, or add one in Settings → Media servers.</p>`) +
+        `<div class="flex flex-wrap justify-end gap-2">` +
         `<button data-act="cancel" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Close</button>` +
+        `<button data-act="recheck" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Re-check</button>` +
         `<a href="/settings" class="px-3 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Open settings</a>` +
         `</div>`;
       card.querySelector('[data-act="cancel"]').onclick = close;
+      card.querySelector('[data-act="recheck"]').onclick = function () {
+        close();
+        open(file, onUrl, Object.assign({}, opts, { refresh: true }));
+      };
       document.body.appendChild(overlay);
       return;
     }
@@ -264,14 +273,16 @@
 
   async function open(file, onUrl, opts) {
     opts = opts || {};
-    let servers;
+    let servers = null,
+      fetchOk = false;
     try {
-      const r = await fetch("/api/v1/user/media-servers");
-      servers = r.ok ? await r.json() : null;
-    } catch (e) {
-      servers = null;
-    }
-    showModal(file, servers, onUrl, opts);
+      const r = await fetch("/api/v1/user/media-servers" + (opts.refresh ? "?refresh=1" : ""));
+      if (r.ok) {
+        servers = await r.json();
+        fetchOk = true;
+      }
+    } catch (e) {}
+    showModal(file, servers, onUrl, opts, fetchOk);
   }
 
   window.grainUpload = { pick: pick, open: open, _uploadTo: uploadTo, _sha256Hex: sha256Hex };

--- a/www/static/js/client-tag.js
+++ b/www/static/js/client-tag.js
@@ -1,0 +1,15 @@
+// Per-user client-tag preference (#99), persisted client-side and sent with each
+// build request to override the server default. Absent = on (the default).
+(function () {
+  "use strict";
+  var KEY = "grain.clientTag"; // "on" | "off"
+  window.grainClientTag = {
+    // enabled() is the value to send with build requests. Default on.
+    enabled: function () {
+      return localStorage.getItem(KEY) !== "off";
+    },
+    set: function (on) {
+      localStorage.setItem(KEY, on ? "on" : "off");
+    },
+  };
+})();

--- a/www/static/js/dashboard.js
+++ b/www/static/js/dashboard.js
@@ -602,22 +602,24 @@ const dashboardManager = {
       return `<div class="text-center text-text-secondary text-sm">No NIPs specified</div>`;
     }
 
-    const nipLinks = supported_nips
-      .slice(0, 12)
-      .map((nip) => {
-        const nipNum = String(nip).padStart(2, "0");
-        return `<a href="https://github.com/nostr-protocol/nips/blob/master/${nipNum}.md" target="_blank" class="inline-flex px-2 py-1 text-xs font-medium bg-info-dim text-info rounded-full hover:opacity-80 transition-colors">NIP-${nipNum}</a>`;
-      })
-      .join("");
+    const nipLink = (nip) => {
+      const nipNum = String(nip).padStart(2, "0");
+      return `<a href="https://github.com/nostr-protocol/nips/blob/master/${nipNum}.md" target="_blank" class="inline-flex px-2 py-1 text-xs font-medium bg-info-dim text-info rounded-full hover:opacity-80 transition-colors">NIP-${nipNum}</a>`;
+    };
 
-    const remaining =
-      supported_nips.length > 12
-        ? `<span class="text-xs text-text-secondary">+${
-            supported_nips.length - 12
-          } more</span>`
-        : "";
+    const shown = supported_nips.slice(0, 12).map(nipLink).join("");
+    const hidden = supported_nips.slice(12);
+    if (hidden.length === 0) return shown;
 
-    return nipLinks + remaining;
+    // "+N more" reveals the rest in place and removes itself — no extra
+    // page or modal for a handful of badges.
+    const moreId = "nips-more-" + Math.random().toString(36).slice(2, 8);
+    const hiddenLinks = `<span id="${moreId}" class="hidden">${hidden
+      .map(nipLink)
+      .join("")}</span>`;
+    const moreBtn = `<button type="button" onclick="document.getElementById('${moreId}').classList.remove('hidden');this.remove();" class="inline-flex px-2 py-1 text-xs font-medium bg-surface-elevated text-text-secondary rounded-full hover:text-text transition-colors cursor-pointer">+${hidden.length} more</button>`;
+
+    return shown + hiddenLinks + moreBtn;
   },
 
   // Helper function to create tags links
@@ -664,7 +666,7 @@ const dashboardManager = {
               ? "bg-success-dim text-success"
               : "bg-surface-elevated text-text-secondary"
           } rounded-full">
-            ${authOn ? "Enabled" : "Disabled"}
+            ${authOn ? "Required" : "Not required"}
           </div>
           ${
             authOn && authData.relay_url

--- a/www/static/js/feed.js
+++ b/www/static/js/feed.js
@@ -3,19 +3,28 @@
  *
  * grain IS a nostr relay, so the browser connects to it directly over WebSocket,
  * asks for recent + live events of all kinds, and renders a compact feed: author
- * avatar, readable kind label, relative time, and (for kind 1) a text snippet.
- * Click a row to open the event page; click the avatar to open the author's
- * profile. The row UI is the reusable part — an outbox feed (the #77 streaming
- * primitive, many relays) would swap the source but reuse this rendering.
+ * avatar + name, readable kind label, relative time, and (for kind 1) a text
+ * snippet. The list stays short — a small page is backfilled and newest events
+ * sort to the top; scrolling to the bottom lazy-loads older events. Click a row
+ * to open the event page; click the avatar or name to open the author's profile.
+ * The row UI is the reusable part — an outbox feed (the #77 streaming primitive,
+ * many relays) would swap the source but reuse this rendering.
  */
 (function () {
-  const LIMIT = 50; // recent events to backfill
-  const MAX_ROWS = 100; // cap the DOM
+  const PAGE = 15; // events per page (initial backfill + each load-older)
+  const MAX_ROWS = 300; // generous DOM ceiling; live events only trim at the top
   const SNIPPET = 140; // kind-1 text cut (the classic 140)
 
   let kinds = {};
   const seen = {};
   const profiles = {}; // hex pubkey -> { picture, name } | "pending"
+
+  // Pagination state (module-level so it survives reconnects).
+  let oldestTs = 0; // oldest created_at currently loaded — the `until` cursor
+  let loadingMore = false;
+  let exhausted = false; // relay has no older events
+  let olderSub = null; // id of the in-flight load-older subscription
+  let olderCount = 0; // events received in the current load-older page
 
   function esc(s) {
     return String(s == null ? "" : s)
@@ -51,11 +60,16 @@
     }
     return `<div class="flex items-center justify-center w-8 h-8 text-xs rounded-full shrink-0 bg-surface-elevated text-text-muted">${esc((pubkey || "").slice(0, 2))}</div>`;
   }
+  function nameFor(pubkey) {
+    const p = profiles[pubkey];
+    if (p && p.name) return p.name;
+    return (pubkey || "").slice(0, 8) + "…"; // short hex until the profile resolves
+  }
 
   function init() {
     const box = document.getElementById("relay-stream-list");
     if (!box) return;
-    box.innerHTML = `<div class="px-3 py-4 text-sm text-text-muted">Connecting to this relay…</div>`;
+    box.innerHTML = `<div id="feed-loading" class="px-3 py-4 text-sm text-text-muted">Connecting to this relay…</div>`;
     fetch("/api/v1/kinds")
       .then((r) => (r.ok ? r.json() : {}))
       .then((m) => {
@@ -69,6 +83,7 @@
     closeWs();
     const box = document.getElementById("relay-stream-list");
     if (!box) return;
+    attachScroll(box);
     const proto = location.protocol === "https:" ? "wss://" : "ws://";
     let sock;
     try {
@@ -78,11 +93,10 @@
       return;
     }
     window.__feedWs = sock;
-    const sub = "feed-" + Math.random().toString(36).slice(2, 8);
-    let got = false;
+    const liveSub = "feed-" + Math.random().toString(36).slice(2, 8);
 
     sock.onopen = function () {
-      sock.send(JSON.stringify(["REQ", sub, { limit: LIMIT }]));
+      sock.send(JSON.stringify(["REQ", liveSub, { limit: PAGE }]));
     };
     sock.onmessage = function (e) {
       let msg;
@@ -92,13 +106,22 @@
         return;
       }
       if (msg[0] === "EVENT" && msg[2]) {
-        if (!got) {
-          got = true;
-          box.innerHTML = "";
+        document.getElementById("feed-loading")?.remove();
+        const isOlder = msg[1] === olderSub;
+        if (isOlder) olderCount++;
+        insertEvent(box, msg[2], isOlder);
+      } else if (msg[0] === "EOSE") {
+        if (msg[1] === olderSub) {
+          // Load-older page complete: an empty page means we've hit the end.
+          if (olderCount === 0) exhausted = true;
+          try {
+            sock.send(JSON.stringify(["CLOSE", olderSub]));
+          } catch (_) {}
+          olderSub = null;
+          loadingMore = false;
+        } else if (box.children.length === 0) {
+          box.innerHTML = `<div class="px-3 py-4 text-sm text-text-muted">No recent events on this relay yet — new ones will appear here.</div>`;
         }
-        addEvent(box, msg[2]);
-      } else if (msg[0] === "EOSE" && !got) {
-        box.innerHTML = `<div class="px-3 py-4 text-sm text-text-muted">No recent events on this relay yet — new ones will appear here.</div>`;
       }
     };
     sock.onclose = function () {
@@ -121,12 +144,34 @@
     }
   }
 
-  function addEvent(box, ev) {
+  function insertEvent(box, ev, isOlder) {
     if (!ev || !ev.id || seen[ev.id]) return;
     seen[ev.id] = true;
-    box.insertAdjacentHTML("afterbegin", row(ev));
-    while (box.children.length > MAX_ROWS) box.removeChild(box.lastChild);
+    const ts = ev.created_at || 0;
+    if (oldestTs === 0 || ts < oldestTs) oldestTs = ts;
+    insertSorted(box, ev);
+    // Trim only when the user is viewing the newest events, so scrolling
+    // down to read (and lazy-load) older ones never yanks rows away.
+    if (!isOlder && box.scrollTop < 40) {
+      while (box.children.length > MAX_ROWS) box.removeChild(box.lastChild);
+    }
     resolveProfile(ev.pubkey);
+  }
+
+  // Insert in created_at order, newest first. Live events land at the top;
+  // lazy-loaded older events land at the bottom — regardless of arrival order.
+  function insertSorted(box, ev) {
+    const html = row(ev);
+    const ts = ev.created_at || 0;
+    const rows = box.children;
+    for (let i = 0; i < rows.length; i++) {
+      const childTs = parseInt(rows[i].getAttribute("data-ts") || "0", 10);
+      if (ts >= childTs) {
+        rows[i].insertAdjacentHTML("beforebegin", html);
+        return;
+      }
+    }
+    box.insertAdjacentHTML("beforeend", html);
   }
 
   function row(ev) {
@@ -134,11 +179,12 @@
     const when = relTime(ev.created_at);
     const text = ev.kind === 1 ? snippet(ev.content) : "";
     return (
-      `<div class="flex items-start gap-2.5 px-3 py-2 border-b cursor-pointer border-border hover:bg-surface-elevated" data-eid="${esc(ev.id)}">` +
+      `<div class="flex items-start gap-2.5 px-3 py-2 border-b cursor-pointer border-border hover:bg-surface-elevated" data-eid="${esc(ev.id)}" data-ts="${ev.created_at || 0}">` +
       `<span data-pubkey="${esc(ev.pubkey)}" class="shrink-0 cursor-pointer" title="View profile">${avatar(ev.pubkey)}</span>` +
       `<div class="flex-1 min-w-0">` +
-      `<div class="flex items-center gap-1.5 text-xs text-text-secondary">` +
-      `<span class="font-medium text-text">${esc(label)}</span><span>·</span><span>${esc(when)}</span></div>` +
+      `<div class="flex items-center gap-1.5 text-xs">` +
+      `<span data-name="${esc(ev.pubkey)}" data-profile="${esc(ev.pubkey)}" class="font-medium truncate max-w-[12rem] text-text cursor-pointer hover:underline" title="View profile">${esc(nameFor(ev.pubkey))}</span>` +
+      `<span class="text-text-secondary">${esc(label)}</span><span class="text-text-secondary">·</span><span class="text-text-secondary">${esc(when)}</span></div>` +
       (text ? `<div class="mt-0.5 text-sm break-words text-text">${esc(text)}</div>` : "") +
       `</div></div>`
     );
@@ -164,22 +210,43 @@
         box.querySelectorAll('[data-pubkey="' + cssEsc(pubkey) + '"]').forEach(function (el) {
           el.innerHTML = avatar(pubkey);
         });
+        box.querySelectorAll('[data-name="' + cssEsc(pubkey) + '"]').forEach(function (el) {
+          el.textContent = nameFor(pubkey);
+        });
       }
     } catch (_) {
       profiles[pubkey] = {};
     }
   }
 
-  // Delegated click: avatar -> profile, rest of the row -> event page. One
+  // Lazy-load older events when the user scrolls near the bottom.
+  function loadOlder() {
+    const sock = window.__feedWs;
+    if (loadingMore || exhausted || oldestTs === 0) return;
+    if (!sock || sock.readyState !== 1) return;
+    loadingMore = true;
+    olderCount = 0;
+    olderSub = "more-" + Math.random().toString(36).slice(2, 8);
+    sock.send(JSON.stringify(["REQ", olderSub, { until: oldestTs - 1, limit: PAGE }]));
+  }
+  function attachScroll(box) {
+    if (box.__feedScroll) return; // each home swap mounts a fresh box element
+    box.__feedScroll = true;
+    box.addEventListener("scroll", function () {
+      if (box.scrollTop + box.clientHeight >= box.scrollHeight - 60) loadOlder();
+    });
+  }
+
+  // Delegated click: avatar/name -> profile, rest of the row -> event page. One
   // listener, re-queried each click, so it survives SPA navigation.
   if (window.__feedClick) document.removeEventListener("click", window.__feedClick);
   window.__feedClick = function (e) {
     const root = document.getElementById("relay-stream-list");
     if (!root || !e.target.closest) return;
-    const av = e.target.closest("[data-pubkey]");
-    if (av && root.contains(av)) {
+    const prof = e.target.closest("[data-pubkey]") || e.target.closest("[data-profile]");
+    if (prof && root.contains(prof)) {
       e.stopPropagation();
-      window.location.href = "/p/" + av.getAttribute("data-pubkey");
+      window.location.href = "/p/" + (prof.getAttribute("data-pubkey") || prof.getAttribute("data-profile"));
       return;
     }
     const r = e.target.closest("[data-eid]");

--- a/www/static/js/feed.js
+++ b/www/static/js/feed.js
@@ -1,0 +1,193 @@
+/**
+ * Live relay event stream (homepage).
+ *
+ * grain IS a nostr relay, so the browser connects to it directly over WebSocket,
+ * asks for recent + live events of all kinds, and renders a compact feed: author
+ * avatar, readable kind label, relative time, and (for kind 1) a text snippet.
+ * Click a row to open the event page; click the avatar to open the author's
+ * profile. The row UI is the reusable part — an outbox feed (the #77 streaming
+ * primitive, many relays) would swap the source but reuse this rendering.
+ */
+(function () {
+  const LIMIT = 50; // recent events to backfill
+  const MAX_ROWS = 100; // cap the DOM
+  const SNIPPET = 140; // kind-1 text cut (the classic 140)
+
+  let kinds = {};
+  const seen = {};
+  const profiles = {}; // hex pubkey -> { picture, name } | "pending"
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+  function cssEsc(s) {
+    return String(s).replace(/["\\]/g, "\\$&");
+  }
+  function kindName(k) {
+    return kinds[String(k)] || "Kind " + k;
+  }
+  function relTime(ts) {
+    const s = Math.floor(Date.now() / 1000) - (ts || 0);
+    if (s < 5) return "just now";
+    if (s < 60) return s + "s";
+    if (s < 3600) return Math.floor(s / 60) + "m";
+    if (s < 86400) return Math.floor(s / 3600) + "h";
+    if (s < 2592000) return Math.floor(s / 86400) + "d";
+    return new Date((ts || 0) * 1000).toLocaleDateString();
+  }
+  function snippet(content) {
+    let t = (content || "").replace(/\s+/g, " ").trim();
+    if (t.length > SNIPPET) t = t.slice(0, SNIPPET) + "…";
+    return t;
+  }
+  function avatar(pubkey) {
+    const p = profiles[pubkey];
+    if (p && p.picture) {
+      return `<img src="${esc(p.picture)}" alt="" class="object-cover w-8 h-8 rounded-full shrink-0 bg-surface-elevated" />`;
+    }
+    return `<div class="flex items-center justify-center w-8 h-8 text-xs rounded-full shrink-0 bg-surface-elevated text-text-muted">${esc((pubkey || "").slice(0, 2))}</div>`;
+  }
+
+  function init() {
+    const box = document.getElementById("relay-stream-list");
+    if (!box) return;
+    box.innerHTML = `<div class="px-3 py-4 text-sm text-text-muted">Connecting to this relay…</div>`;
+    fetch("/api/v1/kinds")
+      .then((r) => (r.ok ? r.json() : {}))
+      .then((m) => {
+        kinds = m || {};
+      })
+      .catch(() => {})
+      .finally(() => connect());
+  }
+
+  function connect() {
+    closeWs();
+    const box = document.getElementById("relay-stream-list");
+    if (!box) return;
+    const proto = location.protocol === "https:" ? "wss://" : "ws://";
+    let sock;
+    try {
+      sock = new WebSocket(proto + location.host);
+    } catch (e) {
+      box.innerHTML = `<div class="px-3 py-4 text-sm text-danger">Couldn't connect to the relay.</div>`;
+      return;
+    }
+    window.__feedWs = sock;
+    const sub = "feed-" + Math.random().toString(36).slice(2, 8);
+    let got = false;
+
+    sock.onopen = function () {
+      sock.send(JSON.stringify(["REQ", sub, { limit: LIMIT }]));
+    };
+    sock.onmessage = function (e) {
+      let msg;
+      try {
+        msg = JSON.parse(e.data);
+      } catch (_) {
+        return;
+      }
+      if (msg[0] === "EVENT" && msg[2]) {
+        if (!got) {
+          got = true;
+          box.innerHTML = "";
+        }
+        addEvent(box, msg[2]);
+      } else if (msg[0] === "EOSE" && !got) {
+        box.innerHTML = `<div class="px-3 py-4 text-sm text-text-muted">No recent events on this relay yet — new ones will appear here.</div>`;
+      }
+    };
+    sock.onclose = function () {
+      // Reconnect while the feed is still on screen.
+      if (window.__feedWs === sock) {
+        window.__feedWs = null;
+        setTimeout(function () {
+          if (document.getElementById("relay-stream-list")) connect();
+        }, 3000);
+      }
+    };
+    sock.onerror = function () {};
+  }
+  function closeWs() {
+    if (window.__feedWs) {
+      try {
+        window.__feedWs.close();
+      } catch (e) {}
+      window.__feedWs = null;
+    }
+  }
+
+  function addEvent(box, ev) {
+    if (!ev || !ev.id || seen[ev.id]) return;
+    seen[ev.id] = true;
+    box.insertAdjacentHTML("afterbegin", row(ev));
+    while (box.children.length > MAX_ROWS) box.removeChild(box.lastChild);
+    resolveProfile(ev.pubkey);
+  }
+
+  function row(ev) {
+    const label = kindName(ev.kind);
+    const when = relTime(ev.created_at);
+    const text = ev.kind === 1 ? snippet(ev.content) : "";
+    return (
+      `<div class="flex items-start gap-2.5 px-3 py-2 border-b cursor-pointer border-border hover:bg-surface-elevated" data-eid="${esc(ev.id)}">` +
+      `<span data-pubkey="${esc(ev.pubkey)}" class="shrink-0 cursor-pointer" title="View profile">${avatar(ev.pubkey)}</span>` +
+      `<div class="flex-1 min-w-0">` +
+      `<div class="flex items-center gap-1.5 text-xs text-text-secondary">` +
+      `<span class="font-medium text-text">${esc(label)}</span><span>·</span><span>${esc(when)}</span></div>` +
+      (text ? `<div class="mt-0.5 text-sm break-words text-text">${esc(text)}</div>` : "") +
+      `</div></div>`
+    );
+  }
+
+  async function resolveProfile(pubkey) {
+    if (!pubkey || profiles[pubkey]) return;
+    profiles[pubkey] = "pending";
+    try {
+      const r = await fetch("/api/v1/user/profile?pubkey=" + encodeURIComponent(pubkey));
+      if (!r.ok) {
+        profiles[pubkey] = {};
+        return;
+      }
+      const ev = await r.json();
+      let content = {};
+      try {
+        content = JSON.parse((ev && ev.content) || "{}");
+      } catch (_) {}
+      profiles[pubkey] = { picture: content.picture || "", name: content.display_name || content.name || "" };
+      const box = document.getElementById("relay-stream-list");
+      if (box) {
+        box.querySelectorAll('[data-pubkey="' + cssEsc(pubkey) + '"]').forEach(function (el) {
+          el.innerHTML = avatar(pubkey);
+        });
+      }
+    } catch (_) {
+      profiles[pubkey] = {};
+    }
+  }
+
+  // Delegated click: avatar -> profile, rest of the row -> event page. One
+  // listener, re-queried each click, so it survives SPA navigation.
+  if (window.__feedClick) document.removeEventListener("click", window.__feedClick);
+  window.__feedClick = function (e) {
+    const root = document.getElementById("relay-stream-list");
+    if (!root || !e.target.closest) return;
+    const av = e.target.closest("[data-pubkey]");
+    if (av && root.contains(av)) {
+      e.stopPropagation();
+      window.location.href = "/p/" + av.getAttribute("data-pubkey");
+      return;
+    }
+    const r = e.target.closest("[data-eid]");
+    if (r && root.contains(r)) {
+      window.location.href = "/e/" + r.getAttribute("data-eid");
+    }
+  };
+  document.addEventListener("click", window.__feedClick);
+
+  init();
+})();

--- a/www/static/js/grain-stream.js
+++ b/www/static/js/grain-stream.js
@@ -1,0 +1,51 @@
+/**
+ * Live update channel (SSE).
+ *
+ * Opens a single EventSource to /api/v1/stream when a session exists and
+ * re-dispatches each message as a `grain:stream` CustomEvent on window, so any
+ * page (relay manager, profile, media servers) can react to live updates
+ * without managing its own connection. Loaded app-wide so the connection
+ * survives SPA navigation. (#87 live-sync, #77 streaming fetch.)
+ */
+(function () {
+  let es = null;
+
+  function connect() {
+    if (es) return;
+    try {
+      es = new EventSource("/api/v1/stream");
+      es.onmessage = function (e) {
+        let msg;
+        try {
+          msg = JSON.parse(e.data);
+        } catch (err) {
+          return;
+        }
+        window.dispatchEvent(new CustomEvent("grain:stream", { detail: msg }));
+      };
+      es.onerror = function () {
+        // EventSource auto-reconnects; nothing to do.
+      };
+    } catch (e) {
+      /* EventSource unsupported — degrade silently */
+    }
+  }
+
+  function disconnect() {
+    if (es) {
+      try {
+        es.close();
+      } catch (e) {}
+      es = null;
+    }
+  }
+
+  window.grainStream = { connect: connect, disconnect: disconnect };
+
+  // Connect only when logged in, so logged-out pages don't spin retrying a 401.
+  fetch("/api/v1/session")
+    .then(function (r) {
+      if (r.ok) connect();
+    })
+    .catch(function () {});
+})();

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -255,6 +255,29 @@
     }
   }
 
+  // fetch with a hard timeout so a stalled connection can't leave the section
+  // spinning forever — on failure we render a retry instead of an endless spinner.
+  function fetchTimeout(url, ms) {
+    const ctrl = new AbortController();
+    const id = setTimeout(() => ctrl.abort(), ms || 15000);
+    return fetch(url, { signal: ctrl.signal }).finally(() => clearTimeout(id));
+  }
+
+  function renderListError(msg) {
+    ["ms-blossom-list", "ms-nip96-list"].forEach((id) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.innerHTML =
+        '<div class="flex items-center justify-between gap-2 p-3 text-sm border border-dashed rounded-lg text-text-muted border-border-strong">' +
+        "<span>" + esc(msg) + "</span>" +
+        '<button data-ms-retry class="px-2 py-1 text-xs rounded shrink-0 text-text bg-surface-overlay hover:bg-surface-hover">Retry</button>' +
+        "</div>";
+    });
+    document.querySelectorAll("[data-ms-retry]").forEach((b) => {
+      b.onclick = initMediaServers;
+    });
+  }
+
   async function initMediaServers() {
     const sec = document.getElementById("media-servers-section");
     if (!sec) return;
@@ -269,8 +292,8 @@
     });
     try {
       const [meRes, sugRes] = await Promise.all([
-        fetch("/api/v1/user/media-servers"),
-        fetch("/api/v1/media-servers/suggested"),
+        fetchTimeout("/api/v1/user/media-servers", 15000),
+        fetchTimeout("/api/v1/media-servers/suggested", 15000),
       ]);
       if (meRes.ok) {
         const me = await meRes.json();
@@ -295,7 +318,11 @@
       renderAll();
     } catch (e) {
       console.error("Media servers init failed:", e);
-      setStatus("blossom", "Couldn't load your media servers.");
+      renderListError(
+        e && e.name === "AbortError"
+          ? "Timed out loading your media servers."
+          : "Couldn't load your media servers."
+      );
     }
   }
 

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -242,7 +242,13 @@
       if (res && res.accepted) {
         if (kind === "nip96") MS.orig.nip96 = MS.nip96.slice();
         else MS.orig.blossom = MS.blossom.slice();
-        setStatus(kind, "Saved.");
+        setStatus(kind, "✓ Saved — published to your relays.");
+      } else if (res) {
+        // Signed + sent, but no relay stored it (e.g. nowhere good to route a
+        // 10063/10096 yet). The toast lists the per-relay reasons.
+        setStatus(kind, "Signed, but no relay accepted it yet — see the toast.");
+      } else {
+        setStatus(kind, "Publish failed — see the toast or the browser console.");
       }
     } finally {
       if (btn) btn.disabled = false;

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -226,7 +226,11 @@
       const resp = await fetch("/api/v1/user/media-servers/build", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kind: numericKind, servers: list }),
+        body: JSON.stringify({
+          kind: numericKind,
+          servers: list,
+          client_tag: window.grainClientTag ? window.grainClientTag.enabled() : true,
+        }),
       });
       if (!resp.ok) {
         setStatus(kind, "Couldn't build the list: " + (await resp.text()));

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -258,6 +258,15 @@
   async function initMediaServers() {
     const sec = document.getElementById("media-servers-section");
     if (!sec) return;
+    // Loading state while the lists resolve from the relays (a few seconds cold).
+    ["ms-blossom-list", "ms-nip96-list"].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el)
+        el.innerHTML =
+          '<div class="flex items-center gap-2 px-3 py-3 text-sm text-text-muted">' +
+          '<span class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>' +
+          "Fetching your media servers…</div>";
+    });
     try {
       const [meRes, sugRes] = await Promise.all([
         fetch("/api/v1/user/media-servers"),

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -317,6 +317,39 @@
     }
   };
 
+  // Live-sync (#87): re-pull a media list when it changes here or in another
+  // client. Re-wire on each load (the handler closes over this module's state).
+  if (window.__msStreamHandler)
+    window.removeEventListener("grain:stream", window.__msStreamHandler);
+  window.__msStreamHandler = function (e) {
+    const m = e.detail || {};
+    if (m.type !== "list-updated" || (m.kind !== 10063 && m.kind !== 10096)) return;
+    fetch("/api/v1/user/media-servers")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((me) => {
+        if (!me) return;
+        if (m.kind === 10063) {
+          MS.blossom = (me.blossom || []).map((x) => {
+            setInfo(x.url, x);
+            return x.url;
+          });
+          MS.orig.blossom = MS.blossom.slice();
+          renderList("blossom");
+          renderSuggested("blossom");
+        } else {
+          MS.nip96 = (me.nip96 || []).map((x) => {
+            setInfo(x.url, x);
+            return x.url;
+          });
+          MS.orig.nip96 = MS.nip96.slice();
+          renderList("nip96");
+          renderSuggested("nip96");
+        }
+      })
+      .catch(function () {});
+  };
+  window.addEventListener("grain:stream", window.__msStreamHandler);
+
   // The script ships inside the HTMX-swapped settings view, so the section is
   // already in the DOM when this runs.
   if (document.getElementById("media-servers-section")) initMediaServers();

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -1,0 +1,299 @@
+/**
+ * Media servers settings section (#83).
+ *
+ * Renders the logged-in user's Blossom (kind 10063) and NIP-96 (kind 10096)
+ * server lists, plus grain's recommended quick-adds, and lets them add / remove
+ * / reorder. Save & sign rebuilds each changed list (preserving non-server tags
+ * via the build endpoint), signs it with the user's signer, and publishes it
+ * through the outbox. List order is meaningful: the first entry is the primary
+ * upload target, the rest are mirrors.
+ */
+(function () {
+  const MS = {
+    blossom: [], // ordered base URLs the user has (your list)
+    nip96: [],
+    orig: { blossom: [], nip96: [] }, // as loaded — to detect changes on save
+    info: {}, // url -> { cost, retention, mirror, name, note, cta, kind, known }
+    suggested: { blossom: [], nip96: [] },
+  };
+  let msDrag = null;
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+  function display(u) {
+    return String(u || "").replace(/^https?:\/\//, "");
+  }
+  function cap(s) {
+    return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+  }
+
+  // Light client-side normalisation for dedupe; the server re-normalises
+  // authoritatively when it builds the event.
+  function norm(u) {
+    let s = (u || "").trim();
+    if (!s) return "";
+    if (!/:\/\//.test(s)) s = "https://" + s;
+    try {
+      const url = new URL(s);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+      return url.protocol + "//" + url.host.toLowerCase() + url.pathname.replace(/\/+$/, "");
+    } catch (e) {
+      return "";
+    }
+  }
+
+  function setInfo(url, info) {
+    if (url) MS.info[url] = Object.assign(MS.info[url] || {}, info);
+  }
+  function listFor(kind) {
+    return kind === "nip96" ? MS.nip96 : MS.blossom;
+  }
+  function setStatus(msg) {
+    const el = document.getElementById("ms-status");
+    if (el) el.textContent = msg || "";
+  }
+
+  function chip(label, variant) {
+    const styles = {
+      primary: "bg-accent-dim text-accent",
+      free: "bg-success-dim text-success",
+      paid: "bg-warning-dim text-warning",
+      permanent: "bg-surface-inset text-text-secondary",
+      ephemeral: "bg-warning-dim text-warning",
+    };
+    const cls = styles[variant] || "bg-surface-inset text-text-secondary";
+    return `<span class="px-2 py-0.5 text-xs rounded ${cls}">${esc(label)}</span>`;
+  }
+
+  function chipsFor(url, isPrimary) {
+    const info = MS.info[url] || {};
+    const out = [];
+    if (isPrimary) out.push(chip("Primary", "primary"));
+    if (info.cost) out.push(chip(cap(info.cost), info.cost));
+    if (info.retention) out.push(chip(cap(info.retention), info.retention));
+    return out.join("");
+  }
+
+  function yourRow(kind, url, idx) {
+    return (
+      `<div class="flex items-center gap-3 p-2.5 border rounded-lg bg-surface-elevated border-border" data-idx="${idx}">` +
+      `<span class="cursor-grab select-none text-text-muted" draggable="true" data-grip title="Drag to reorder">⠿</span>` +
+      `<div class="flex-1 min-w-0">` +
+      `<div class="text-sm font-medium truncate text-text">${esc(display(url))}</div>` +
+      `<div class="flex flex-wrap gap-1.5 mt-1">${chipsFor(url, idx === 0)}</div>` +
+      `</div>` +
+      `<button data-remove class="px-1 text-lg leading-none text-text-muted hover:text-danger" title="Remove">×</button>` +
+      `</div>`
+    );
+  }
+
+  function recRow(kind, info) {
+    const chips = [];
+    if (info.cost) chips.push(chip(cap(info.cost), info.cost));
+    if (info.retention) chips.push(chip(cap(info.retention), info.retention));
+    const cta = info.cta
+      ? ` <a href="${esc(info.cta)}" target="_blank" rel="noopener" class="text-accent">membership ↗</a>`
+      : "";
+    return (
+      `<div class="flex items-center gap-3 p-2.5 border rounded-lg bg-surface-elevated border-border">` +
+      `<div class="flex-1 min-w-0">` +
+      `<div class="text-sm font-medium truncate text-text">${esc(display(info.url))}</div>` +
+      `<div class="flex flex-wrap gap-1.5 mt-1">${chips.join("")}</div>` +
+      `<div class="mt-1 text-xs text-text-muted">${esc(info.note || "")}${cta}</div>` +
+      `</div>` +
+      `<button data-add data-kind="${esc(kind)}" data-url="${esc(info.url)}" class="px-3 py-1 text-xs rounded-lg whitespace-nowrap text-text bg-surface-overlay hover:bg-surface-hover">+ Add</button>` +
+      `</div>`
+    );
+  }
+
+  function emptyState(kind) {
+    const msg =
+      kind === "nip96"
+        ? "No NIP-96 servers. Prefer Blossom above — add one here only if you need an HTTP host."
+        : "No Blossom servers yet. Add one from the recommended list below, or paste a URL.";
+    return `<div class="p-4 text-sm text-center border border-dashed rounded-lg text-text-muted border-border-strong">${msg}</div>`;
+  }
+
+  function renderList(kind) {
+    const box = document.getElementById("ms-" + kind + "-list");
+    if (!box) return;
+    const list = listFor(kind);
+    if (list.length === 0) {
+      box.innerHTML = emptyState(kind);
+      return;
+    }
+    box.innerHTML = list.map((url, i) => yourRow(kind, url, i)).join("");
+    box.querySelectorAll("[data-grip]").forEach((g) => {
+      g.ondragstart = (e) => {
+        msDrag = { kind: kind, from: +g.closest("[data-idx]").dataset.idx };
+        if (e.dataTransfer) e.dataTransfer.setData("text/plain", "");
+      };
+    });
+    box.querySelectorAll("[data-idx]").forEach((row) => {
+      row.ondragover = (e) => e.preventDefault();
+      row.ondrop = (e) => {
+        e.preventDefault();
+        if (msDrag && msDrag.kind === kind) moveServer(kind, msDrag.from, +row.dataset.idx);
+        msDrag = null;
+      };
+    });
+    box.querySelectorAll("[data-remove]").forEach((b) => {
+      b.onclick = () => {
+        list.splice(+b.closest("[data-idx]").dataset.idx, 1);
+        renderAll();
+      };
+    });
+  }
+
+  function renderSuggested(kind) {
+    const box = document.getElementById("ms-" + kind + "-suggested");
+    if (!box) return;
+    const have = new Set(listFor(kind));
+    const recs = (kind === "nip96" ? MS.suggested.nip96 : MS.suggested.blossom).filter(
+      (info) => !have.has(info.url)
+    );
+    box.innerHTML =
+      recs.map((info) => recRow(kind, info)).join("") ||
+      `<p class="text-xs text-text-muted">All recommended servers added.</p>`;
+    box.querySelectorAll("[data-add]").forEach((b) => {
+      b.onclick = () => addServer(b.dataset.kind, b.dataset.url);
+    });
+  }
+
+  function renderAll() {
+    renderList("blossom");
+    renderSuggested("blossom");
+    renderList("nip96");
+    renderSuggested("nip96");
+  }
+
+  function addServer(kind, url) {
+    const u = norm(url);
+    if (!u) return;
+    const list = listFor(kind);
+    if (list.indexOf(u) >= 0) return; // already present
+    list.push(u);
+    renderAll();
+  }
+
+  function moveServer(kind, from, to) {
+    if (from == null || to == null || from === to) return;
+    const list = listFor(kind);
+    const [item] = list.splice(from, 1);
+    list.splice(to, 0, item);
+    renderAll();
+  }
+
+  function sameList(a, b) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+  }
+
+  async function msSave() {
+    if (!window.grainPublish) {
+      setStatus("Publish helper not loaded — reload the page.");
+      return;
+    }
+    const changed = [];
+    if (!sameList(MS.blossom, MS.orig.blossom)) changed.push({ kind: 10063, servers: MS.blossom });
+    if (!sameList(MS.nip96, MS.orig.nip96)) changed.push({ kind: 10096, servers: MS.nip96 });
+    if (changed.length === 0) {
+      setStatus("No changes to save.");
+      return;
+    }
+
+    const btn = document.getElementById("ms-save-btn");
+    if (btn) btn.disabled = true;
+    try {
+      for (const c of changed) {
+        const label = c.kind === 10063 ? "Blossom" : "NIP-96";
+        setStatus("Building your " + label + " list…");
+        const resp = await fetch("/api/v1/user/media-servers/build", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(c),
+        });
+        if (!resp.ok) {
+          setStatus("Couldn't build the " + label + " list: " + (await resp.text()));
+          return;
+        }
+        const unsigned = await resp.json();
+        const res = await window.grainPublish.signAndPublish(unsigned, {
+          title: "Publishing " + label + " list…",
+          status: setStatus,
+        });
+        if (res && res.accepted) {
+          if (c.kind === 10063) MS.orig.blossom = MS.blossom.slice();
+          else MS.orig.nip96 = MS.nip96.slice();
+        } else {
+          return; // toast already explained the failure; stop before the next list
+        }
+      }
+      setStatus("Saved.");
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  async function initMediaServers() {
+    const sec = document.getElementById("media-servers-section");
+    if (!sec) return;
+    try {
+      const [meRes, sugRes] = await Promise.all([
+        fetch("/api/v1/user/media-servers"),
+        fetch("/api/v1/media-servers/suggested"),
+      ]);
+      if (meRes.ok) {
+        const me = await meRes.json();
+        MS.blossom = (me.blossom || []).map((e) => {
+          setInfo(e.url, e);
+          return e.url;
+        });
+        MS.nip96 = (me.nip96 || []).map((e) => {
+          setInfo(e.url, e);
+          return e.url;
+        });
+      }
+      if (sugRes.ok) {
+        const sug = await sugRes.json();
+        (sug || []).forEach((info) => {
+          setInfo(info.url, info);
+          (info.kind === "nip96" ? MS.suggested.nip96 : MS.suggested.blossom).push(info);
+        });
+      }
+      MS.orig.blossom = MS.blossom.slice();
+      MS.orig.nip96 = MS.nip96.slice();
+      renderAll();
+    } catch (e) {
+      console.error("Media servers init failed:", e);
+      setStatus("Couldn't load your media servers.");
+    }
+  }
+
+  // Public handlers (referenced from settings.html).
+  window.initMediaServers = initMediaServers;
+  window.msSave = msSave;
+  window.msAddBlossomFromInput = function () {
+    const i = document.getElementById("ms-blossom-input");
+    if (i && i.value.trim()) {
+      addServer("blossom", i.value);
+      i.value = "";
+    }
+  };
+  window.msAddNip96FromInput = function () {
+    const i = document.getElementById("ms-nip96-input");
+    if (i && i.value.trim()) {
+      addServer("nip96", i.value);
+      i.value = "";
+    }
+  };
+
+  // The script ships inside the HTMX-swapped settings view, so the section is
+  // already in the DOM when this runs.
+  if (document.getElementById("media-servers-section")) initMediaServers();
+})();

--- a/www/static/js/media-servers.js
+++ b/www/static/js/media-servers.js
@@ -53,8 +53,8 @@
   function listFor(kind) {
     return kind === "nip96" ? MS.nip96 : MS.blossom;
   }
-  function setStatus(msg) {
-    const el = document.getElementById("ms-status");
+  function setStatus(kind, msg) {
+    const el = document.getElementById("ms-" + kind + "-status");
     if (el) el.textContent = msg || "";
   }
 
@@ -63,11 +63,11 @@
       primary: "bg-accent-dim text-accent",
       free: "bg-success-dim text-success",
       paid: "bg-warning-dim text-warning",
-      permanent: "bg-surface-inset text-text-secondary",
+      permanent: "text-text-secondary border border-border-strong",
       ephemeral: "bg-warning-dim text-warning",
     };
-    const cls = styles[variant] || "bg-surface-inset text-text-secondary";
-    return `<span class="px-2 py-0.5 text-xs rounded ${cls}">${esc(label)}</span>`;
+    const cls = styles[variant] || "text-text-secondary border border-border-strong";
+    return `<span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded ${cls}">${esc(label)}</span>`;
   }
 
   function chipsFor(url, isPrimary) {
@@ -79,15 +79,26 @@
     return out.join("");
   }
 
+  // The small info line under the chips (capability note + optional CTA link).
+  function noteFor(url) {
+    const info = MS.info[url] || {};
+    if (!info.note) return "";
+    const cta = info.cta
+      ? ` <a href="${esc(info.cta)}" target="_blank" rel="noopener" class="text-accent hover:underline">membership ↗</a>`
+      : "";
+    return `<div class="mt-1 text-xs leading-snug text-text-muted">${esc(info.note)}${cta}</div>`;
+  }
+
   function yourRow(kind, url, idx) {
     return (
-      `<div class="flex items-center gap-3 p-2.5 border rounded-lg bg-surface-elevated border-border" data-idx="${idx}">` +
-      `<span class="cursor-grab select-none text-text-muted" draggable="true" data-grip title="Drag to reorder">⠿</span>` +
+      `<div class="flex items-center gap-2.5 px-3 py-2 border rounded-lg bg-surface-elevated border-border" data-idx="${idx}">` +
+      `<span class="text-lg cursor-grab select-none shrink-0 text-text-muted" draggable="true" data-grip title="Drag to reorder">⠿</span>` +
       `<div class="flex-1 min-w-0">` +
-      `<div class="text-sm font-medium truncate text-text">${esc(display(url))}</div>` +
-      `<div class="flex flex-wrap gap-1.5 mt-1">${chipsFor(url, idx === 0)}</div>` +
+      `<a href="${esc(url)}" target="_blank" rel="noopener" class="block text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(display(url))}</a>` +
+      `<div class="flex flex-wrap items-center gap-1 mt-1">${chipsFor(url, idx === 0)}</div>` +
+      noteFor(url) +
       `</div>` +
-      `<button data-remove class="px-1 text-lg leading-none text-text-muted hover:text-danger" title="Remove">×</button>` +
+      `<button data-remove class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Remove">×</button>` +
       `</div>`
     );
   }
@@ -97,16 +108,16 @@
     if (info.cost) chips.push(chip(cap(info.cost), info.cost));
     if (info.retention) chips.push(chip(cap(info.retention), info.retention));
     const cta = info.cta
-      ? ` <a href="${esc(info.cta)}" target="_blank" rel="noopener" class="text-accent">membership ↗</a>`
+      ? ` <a href="${esc(info.cta)}" target="_blank" rel="noopener" class="text-accent hover:underline">membership ↗</a>`
       : "";
     return (
-      `<div class="flex items-center gap-3 p-2.5 border rounded-lg bg-surface-elevated border-border">` +
+      `<div class="flex items-center gap-2.5 px-3 py-2 border rounded-lg bg-surface-elevated border-border">` +
       `<div class="flex-1 min-w-0">` +
-      `<div class="text-sm font-medium truncate text-text">${esc(display(info.url))}</div>` +
-      `<div class="flex flex-wrap gap-1.5 mt-1">${chips.join("")}</div>` +
-      `<div class="mt-1 text-xs text-text-muted">${esc(info.note || "")}${cta}</div>` +
+      `<a href="${esc(info.url)}" target="_blank" rel="noopener" class="block text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(display(info.url))}</a>` +
+      `<div class="flex flex-wrap items-center gap-1 mt-1">${chips.join("")}</div>` +
+      `<div class="mt-1 text-xs leading-snug text-text-muted">${esc(info.note || "")}${cta}</div>` +
       `</div>` +
-      `<button data-add data-kind="${esc(kind)}" data-url="${esc(info.url)}" class="px-3 py-1 text-xs rounded-lg whitespace-nowrap text-text bg-surface-overlay hover:bg-surface-hover">+ Add</button>` +
+      `<button data-add data-kind="${esc(kind)}" data-url="${esc(info.url)}" class="px-3 py-1 text-xs rounded-lg shrink-0 whitespace-nowrap text-text bg-surface-overlay hover:bg-surface-hover">+ Add</button>` +
       `</div>`
     );
   }
@@ -194,47 +205,45 @@
     return a.every((v, i) => v === b[i]);
   }
 
-  async function msSave() {
+  async function msSave(kind) {
     if (!window.grainPublish) {
-      setStatus("Publish helper not loaded — reload the page.");
+      setStatus(kind, "Publish helper not loaded — reload the page.");
       return;
     }
-    const changed = [];
-    if (!sameList(MS.blossom, MS.orig.blossom)) changed.push({ kind: 10063, servers: MS.blossom });
-    if (!sameList(MS.nip96, MS.orig.nip96)) changed.push({ kind: 10096, servers: MS.nip96 });
-    if (changed.length === 0) {
-      setStatus("No changes to save.");
+    const numericKind = kind === "nip96" ? 10096 : 10063;
+    const label = kind === "nip96" ? "NIP-96" : "Blossom";
+    const list = listFor(kind);
+    const orig = kind === "nip96" ? MS.orig.nip96 : MS.orig.blossom;
+    if (sameList(list, orig)) {
+      setStatus(kind, "No changes to save.");
       return;
     }
 
-    const btn = document.getElementById("ms-save-btn");
+    const btn = document.getElementById("ms-" + kind + "-save");
     if (btn) btn.disabled = true;
     try {
-      for (const c of changed) {
-        const label = c.kind === 10063 ? "Blossom" : "NIP-96";
-        setStatus("Building your " + label + " list…");
-        const resp = await fetch("/api/v1/user/media-servers/build", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(c),
-        });
-        if (!resp.ok) {
-          setStatus("Couldn't build the " + label + " list: " + (await resp.text()));
-          return;
-        }
-        const unsigned = await resp.json();
-        const res = await window.grainPublish.signAndPublish(unsigned, {
-          title: "Publishing " + label + " list…",
-          status: setStatus,
-        });
-        if (res && res.accepted) {
-          if (c.kind === 10063) MS.orig.blossom = MS.blossom.slice();
-          else MS.orig.nip96 = MS.nip96.slice();
-        } else {
-          return; // toast already explained the failure; stop before the next list
-        }
+      setStatus(kind, "Building your " + label + " list…");
+      const resp = await fetch("/api/v1/user/media-servers/build", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: numericKind, servers: list }),
+      });
+      if (!resp.ok) {
+        setStatus(kind, "Couldn't build the list: " + (await resp.text()));
+        return;
       }
-      setStatus("Saved.");
+      const unsigned = await resp.json();
+      const res = await window.grainPublish.signAndPublish(unsigned, {
+        title: "Publishing " + label + " list…",
+        status: function (m) {
+          setStatus(kind, m);
+        },
+      });
+      if (res && res.accepted) {
+        if (kind === "nip96") MS.orig.nip96 = MS.nip96.slice();
+        else MS.orig.blossom = MS.blossom.slice();
+        setStatus(kind, "Saved.");
+      }
     } finally {
       if (btn) btn.disabled = false;
     }
@@ -271,7 +280,7 @@
       renderAll();
     } catch (e) {
       console.error("Media servers init failed:", e);
-      setStatus("Couldn't load your media servers.");
+      setStatus("blossom", "Couldn't load your media servers.");
     }
   }
 

--- a/www/static/js/navigation.js
+++ b/www/static/js/navigation.js
@@ -189,6 +189,12 @@
     const menu = document.getElementById("user-dropdown-menu");
     if (!menu) return;
     if (menu.classList.contains("hidden")) {
+      // Close any other open header dropdown (theme, relay pool). Their
+      // triggers call stopPropagation, so the document-level outside-click
+      // handlers can't see this click — coordinate explicitly via an event.
+      window.dispatchEvent(
+        new CustomEvent("grain:dropdown-open", { detail: "profile" })
+      );
       positionDropdown();
       menu.classList.remove("hidden");
       // Refresh profile section every open so a new display
@@ -201,6 +207,11 @@
     }
   };
   window.closeUserDropdown = closeDropdown;
+
+  // When another header dropdown opens, close this one.
+  window.addEventListener("grain:dropdown-open", function (e) {
+    if (e.detail !== "profile") closeDropdown();
+  });
 
   function closeDropdown() {
     const menu = document.getElementById("user-dropdown-menu");

--- a/www/static/js/navigation.js
+++ b/www/static/js/navigation.js
@@ -285,6 +285,27 @@
     link.classList.toggle("flex", isOwner);
   }
 
+  // Reveal the "set up your relays" banner for a logged-in user with no NIP-65
+  // relay list yet (new identity). Deterministic: shown only when logged in and
+  // the list is empty, hidden otherwise.
+  async function maybeRevealRelaysBanner(sessionPubkey) {
+    const banner = document.getElementById("no-relays-banner");
+    if (!banner) return;
+    if (!sessionPubkey) {
+      banner.classList.add("hidden");
+      return;
+    }
+    try {
+      const r = await fetch("/api/v1/user/relay-lists");
+      if (!r.ok) return;
+      const d = await r.json();
+      const hasRelays = d && Array.isArray(d.nip65) && d.nip65.length > 0;
+      banner.classList.toggle("hidden", hasRelays);
+    } catch (_) {
+      /* leave hidden on error */
+    }
+  }
+
   function applyDropdownProfile(info) {
     if (!info) return;
     const nameEl = document.getElementById("user-dropdown-name");
@@ -292,6 +313,7 @@
     const pfpWrap = document.getElementById("user-dropdown-pfp-wrap");
     if (!nameEl || !npubEl || !pfpWrap) return;
     maybeRevealAdminLink(info.pubkey);
+    maybeRevealRelaysBanner(info.pubkey);
     const c = info.content || {};
     const display =
       c.display_name ||

--- a/www/static/js/nostr-publish.js
+++ b/www/static/js/nostr-publish.js
@@ -45,7 +45,7 @@
     if (r.sent === false) return { icon: "✗", cls: "text-danger", note: r.message || "failed to send" };
     if (r.reason) return { icon: "✗", cls: "text-danger", note: r.reason };
     if (r.pending) return { icon: "•", cls: "text-text-muted", note: "waiting…" };
-    return { icon: "•", cls: "text-warning", note: "no response" };
+    return { icon: "•", cls: "text-warning", note: "sent · no confirmation" };
   }
 
   function makePublishToast(initialTitle) {

--- a/www/static/js/nostr-publish.js
+++ b/www/static/js/nostr-publish.js
@@ -74,12 +74,29 @@
     let total = 0;
     let accepted = 0;
     let timer = null;
+    let autoMs = 0;
     let expanded = false;
 
     function dismiss() {
       if (timer) clearTimeout(timer);
       if (t.parentNode) t.parentNode.removeChild(t);
     }
+    // Auto-dismiss after a delay, paused while the pointer is over the toast so
+    // the per-relay detail stays readable. Re-armed on mouse-leave.
+    function scheduleDismiss(ms) {
+      autoMs = ms;
+      if (timer) clearTimeout(timer);
+      if (ms > 0) timer = setTimeout(dismiss, ms);
+    }
+    t.addEventListener("mouseenter", function () {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    });
+    t.addEventListener("mouseleave", function () {
+      if (autoMs > 0 && t.parentNode) scheduleDismiss(autoMs);
+    });
     function setExpanded(on) {
       expanded = on;
       body.style.display = on ? "block" : "none";
@@ -141,8 +158,9 @@
           setIcon("•", "text-warning");
           titleEl.textContent = `No relay accepted (0/${total})`;
         }
-        // Persist by default; only a fully clean success fades on its own.
-        if (total > 0 && accepted === total) timer = setTimeout(dismiss, 15000);
+        // A fully clean success fades quickly; a partial / empty result lingers
+        // longer (so the per-relay detail can be read) then clears itself.
+        scheduleDismiss(total > 0 && accepted === total ? 15000 : 30000);
       },
       fail(message) {
         setIcon("✗", "text-danger");
@@ -150,6 +168,7 @@
         body.innerHTML =
           `<div class="text-danger break-all" style="padding:0.25rem 0.75rem;font-size:0.75rem;">${escAttr(message || "")}</div>`;
         setExpanded(true);
+        scheduleDismiss(45000);
       },
       dismiss,
     };

--- a/www/static/js/nostr-publish.js
+++ b/www/static/js/nostr-publish.js
@@ -1,0 +1,148 @@
+/**
+ * Shared client-side publish helper.
+ *
+ * window.grainPublish.signAndPublish(unsigned, { status, onAccepted })
+ *   Signs an unsigned event with the user's signer (NIP-07 / NIP-46 / Amber /
+ *   key via mill), publishes it through grain's outbox-routed /api/v1/events/
+ *   publish, and shows a small bottom-right toast with per-relay OK results.
+ *   Returns { signed, result, accepted } on success, or null on failure (the
+ *   toast surfaces the error). onAccepted(signed, result) fires once at least
+ *   one relay stores the event.
+ *
+ * Kept generic so the profile editor, media-server settings, and the media
+ * uploader can share one toast instead of each rolling their own.
+ */
+(function () {
+  function escAttr(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  // One per-relay line in the expanded toast.
+  function relayLine(r) {
+    const url = r.RelayURL || r.relayURL || "";
+    const sent = r.Success || r.success;
+    const ok = r.Accepted || r.accepted;
+    const reason = r.Reason || r.reason || "";
+    const msg = r.Message || r.message || "";
+    let icon, cls, note;
+    if (ok) {
+      icon = "✓"; cls = "text-success"; note = reason;
+    } else if (!sent) {
+      icon = "✗"; cls = "text-danger"; note = msg || "failed to send";
+    } else if (reason) {
+      icon = "✗"; cls = "text-danger"; note = reason; // relay rejected it
+    } else {
+      icon = "•"; cls = "text-warning"; note = "no response";
+    }
+    return (
+      `<div class="flex items-start gap-2 text-xs">` +
+      `<span class="${cls}">${icon}</span>` +
+      `<span class="flex-1 min-w-0"><span class="font-mono break-all">${escAttr(url)}</span>` +
+      (note ? `<span class="block text-text-secondary">${escAttr(note)}</span>` : "") +
+      `</span></div>`
+    );
+  }
+
+  // Small, bottom-right toast. Spinner while sending; then the accepted count.
+  // Click the header to expand per-relay detail; dismiss with the ×.
+  function makePublishToast(initialTitle) {
+    const t = document.createElement("div");
+    t.className =
+      "fixed z-50 overflow-hidden text-sm border rounded-lg shadow-lg bottom-4 right-4 w-72 bg-surface border-border";
+    t.innerHTML =
+      `<div class="flex items-center gap-2 px-3 py-2 cursor-pointer" data-head>` +
+      `<span data-icon class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>` +
+      `<span data-title class="flex-1 font-medium text-text">${escAttr(initialTitle || "Publishing…")}</span>` +
+      `<button data-close class="px-1 text-text-secondary hover:text-text" title="Dismiss">×</button>` +
+      `</div>` +
+      `<div data-body class="hidden px-3 pb-2 space-y-1 overflow-y-auto border-t max-h-48 border-border"></div>`;
+    document.body.appendChild(t);
+
+    const body = t.querySelector("[data-body]");
+    let timer = null;
+    const dismiss = () => {
+      if (timer) clearTimeout(timer);
+      if (document.body.contains(t)) document.body.removeChild(t);
+    };
+    t.querySelector("[data-close]").onclick = (e) => {
+      e.stopPropagation();
+      dismiss();
+    };
+    t.querySelector("[data-head]").onclick = () => body.classList.toggle("hidden");
+
+    function setIcon(text, cls) {
+      const icon = t.querySelector("[data-icon]");
+      icon.className = cls;
+      icon.textContent = text;
+    }
+
+    return {
+      status(text) {
+        const el = t.querySelector("[data-title]");
+        if (el) el.textContent = text;
+      },
+      update(result) {
+        const relays = result.results || [];
+        const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
+        setIcon(accepted > 0 ? "✓" : "•", accepted > 0 ? "text-success" : "text-warning");
+        t.querySelector("[data-title]").textContent =
+          `Accepted by ${accepted}/${relays.length} relays`;
+        body.innerHTML =
+          relays.map(relayLine).join("") ||
+          '<span class="text-xs text-text-secondary">No relays targeted.</span>';
+        timer = setTimeout(dismiss, 12000);
+      },
+      fail(msg) {
+        setIcon("✗", "text-danger");
+        t.querySelector("[data-title]").textContent = "Publish failed";
+        body.innerHTML = `<span class="text-xs break-all text-danger">${escAttr(msg || "")}</span>`;
+        body.classList.remove("hidden");
+        timer = setTimeout(dismiss, 12000);
+      },
+      dismiss,
+    };
+  }
+
+  async function signAndPublish(unsigned, opts) {
+    opts = opts || {};
+    const status = typeof opts.status === "function" ? opts.status : function () {};
+    status("");
+    // Create the toast up front so the user gets feedback even when the signer
+    // step itself fails (that used to throw before any toast appeared).
+    const toast = makePublishToast(opts.title);
+    try {
+      toast.status("Waiting for your signer…");
+      if (typeof window.restoreSigner === "function") await window.restoreSigner();
+      if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
+        throw new Error("No signer available — log in with a signing method.");
+      }
+      const signed = await window.grainSigner.signEvent(unsigned);
+
+      toast.status("Publishing…");
+      const resp = await fetch("/api/v1/events/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: signed }),
+      });
+      const result = await resp.json();
+      if (!resp.ok || !result.success) {
+        toast.fail(result.error || "publish failed");
+        return null;
+      }
+      toast.update(result);
+      const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
+      if (accepted && typeof opts.onAccepted === "function") opts.onAccepted(signed, result);
+      return { signed, result, accepted };
+    } catch (err) {
+      console.error("Publish failed:", err);
+      toast.fail(err.message || String(err));
+      return null;
+    }
+  }
+
+  window.grainPublish = { signAndPublish, makePublishToast, escAttr };
+})();

--- a/www/static/js/nostr-publish.js
+++ b/www/static/js/nostr-publish.js
@@ -1,107 +1,155 @@
 /**
- * Shared client-side publish helper.
+ * Shared client-side publish helper with a live broadcast toast.
  *
- * window.grainPublish.signAndPublish(unsigned, { status, onAccepted })
+ * window.grainPublish.signAndPublish(unsigned, { title, onAccepted })
  *   Signs an unsigned event with the user's signer (NIP-07 / NIP-46 / Amber /
- *   key via mill), publishes it through grain's outbox-routed /api/v1/events/
- *   publish, and shows a small bottom-right toast with per-relay OK results.
- *   Returns { signed, result, accepted } on success, or null on failure (the
- *   toast surfaces the error). onAccepted(signed, result) fires once at least
- *   one relay stores the event.
+ *   key via mill), POSTs it to the streaming publish endpoint, and drives a
+ *   small bottom-right toast that counts up live as each relay answers — a
+ *   spinner + x/N pill, expandable to the per-relay accept / reject / no-response
+ *   detail. The toast persists until dismissed (it only auto-fades on a fully
+ *   clean success). Returns { signed, results, accepted } or null on failure.
  *
- * Kept generic so the profile editor, media-server settings, and the media
- * uploader can share one toast instead of each rolling their own.
+ * Shared so the profile editor, media-server settings, the relay manager, and
+ * the media uploader all get the same toast.
  */
 (function () {
   function escAttr(s) {
-    return String(s)
+    return String(s == null ? "" : s)
       .replace(/&/g, "&amp;")
       .replace(/"/g, "&quot;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;");
   }
-
-  // One per-relay line in the expanded toast.
-  function relayLine(r) {
-    const url = r.RelayURL || r.relayURL || "";
-    const sent = r.Success || r.success;
-    const ok = r.Accepted || r.accepted;
-    const reason = r.Reason || r.reason || "";
-    const msg = r.Message || r.message || "";
-    let icon, cls, note;
-    if (ok) {
-      icon = "✓"; cls = "text-success"; note = reason;
-    } else if (!sent) {
-      icon = "✗"; cls = "text-danger"; note = msg || "failed to send";
-    } else if (reason) {
-      icon = "✗"; cls = "text-danger"; note = reason; // relay rejected it
-    } else {
-      icon = "•"; cls = "text-warning"; note = "no response";
-    }
-    return (
-      `<div class="flex items-start gap-2 text-xs">` +
-      `<span class="${cls}">${icon}</span>` +
-      `<span class="flex-1 min-w-0"><span class="font-mono break-all">${escAttr(url)}</span>` +
-      (note ? `<span class="block text-text-secondary">${escAttr(note)}</span>` : "") +
-      `</span></div>`
-    );
+  function shortRelay(u) {
+    return String(u || "").replace(/^wss?:\/\//, "").replace(/\/$/, "");
   }
 
-  // Small, bottom-right toast. Spinner while sending; then the accepted count.
-  // Click the header to expand per-relay detail; dismiss with the ×.
+  // Singleton bottom-right stack so multiple publishes (e.g. Blossom then
+  // NIP-96) sit above each other instead of overlapping.
+  function toastStack() {
+    let el = document.getElementById("grain-toast-stack");
+    if (!el) {
+      el = document.createElement("div");
+      el.id = "grain-toast-stack";
+      el.style.cssText =
+        "position:fixed;right:1rem;bottom:1rem;z-index:2147483000;display:flex;" +
+        "flex-direction:column;gap:0.5rem;align-items:flex-end;pointer-events:none;";
+      document.body.appendChild(el);
+    }
+    return el;
+  }
+
+  // Maps a per-relay result to its icon/colour/note.
+  function statusBits(r) {
+    if (r.accepted) return { icon: "✓", cls: "text-success", note: r.reason || "" };
+    if (r.sent === false) return { icon: "✗", cls: "text-danger", note: r.message || "failed to send" };
+    if (r.reason) return { icon: "✗", cls: "text-danger", note: r.reason };
+    if (r.pending) return { icon: "•", cls: "text-text-muted", note: "waiting…" };
+    return { icon: "•", cls: "text-warning", note: "no response" };
+  }
+
   function makePublishToast(initialTitle) {
     const t = document.createElement("div");
-    t.className =
-      "fixed z-50 overflow-hidden text-sm border rounded-lg shadow-lg bottom-4 right-4 w-72 bg-surface border-border";
+    // Inline layout so the toast is visible regardless of utility-class
+    // availability or any stacking context on the host page.
+    t.style.cssText =
+      "pointer-events:auto;width:18rem;max-width:90vw;overflow:hidden;" +
+      "background:var(--color-surface);border:1px solid var(--color-border);" +
+      "border-radius:0.75rem;box-shadow:var(--shadow-lg);font-size:0.875rem;";
     t.innerHTML =
-      `<div class="flex items-center gap-2 px-3 py-2 cursor-pointer" data-head>` +
-      `<span data-icon class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>` +
-      `<span data-title class="flex-1 font-medium text-text">${escAttr(initialTitle || "Publishing…")}</span>` +
-      `<button data-close class="px-1 text-text-secondary hover:text-text" title="Dismiss">×</button>` +
+      `<div data-head style="display:flex;align-items:center;gap:0.5rem;padding:0.5rem 0.75rem;cursor:pointer;">` +
+      `<span data-icon class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin" style="flex:none;"></span>` +
+      `<span data-title class="text-text" style="flex:1;min-width:0;font-weight:500;">${escAttr(initialTitle || "Broadcasting…")}</span>` +
+      `<button data-toggle title="Details" class="text-text-secondary hover:text-text" style="flex:none;padding:0 0.25rem;">▾</button>` +
+      `<button data-close title="Dismiss" class="text-text-secondary hover:text-text" style="flex:none;padding:0 0.25rem;">×</button>` +
       `</div>` +
-      `<div data-body class="hidden px-3 pb-2 space-y-1 overflow-y-auto border-t max-h-48 border-border"></div>`;
-    document.body.appendChild(t);
+      `<div data-body style="display:none;border-top:1px solid var(--color-border);max-height:12rem;overflow-y:auto;padding:0.25rem 0;"></div>`;
+    toastStack().appendChild(t);
 
+    const titleEl = t.querySelector("[data-title]");
+    const iconEl = t.querySelector("[data-icon]");
+    const toggleEl = t.querySelector("[data-toggle]");
     const body = t.querySelector("[data-body]");
+    const rows = {};
+    let total = 0;
+    let accepted = 0;
     let timer = null;
-    const dismiss = () => {
-      if (timer) clearTimeout(timer);
-      if (document.body.contains(t)) document.body.removeChild(t);
-    };
-    t.querySelector("[data-close]").onclick = (e) => {
-      e.stopPropagation();
-      dismiss();
-    };
-    t.querySelector("[data-head]").onclick = () => body.classList.toggle("hidden");
+    let expanded = false;
 
-    function setIcon(text, cls) {
-      const icon = t.querySelector("[data-icon]");
-      icon.className = cls;
-      icon.textContent = text;
+    function dismiss() {
+      if (timer) clearTimeout(timer);
+      if (t.parentNode) t.parentNode.removeChild(t);
+    }
+    function setExpanded(on) {
+      expanded = on;
+      body.style.display = on ? "block" : "none";
+      toggleEl.textContent = on ? "▴" : "▾";
+    }
+    t.querySelector("[data-close]").onclick = (e) => { e.stopPropagation(); dismiss(); };
+    toggleEl.onclick = (e) => { e.stopPropagation(); setExpanded(!expanded); };
+    t.querySelector("[data-head]").onclick = () => setExpanded(!expanded);
+
+    function setIcon(symbol, cls) {
+      iconEl.className = cls;
+      iconEl.style.cssText = "flex:none;width:1rem;text-align:center;font-weight:700;";
+      iconEl.textContent = symbol;
+    }
+    function rowFor(url) {
+      if (rows[url]) return rows[url];
+      const row = document.createElement("div");
+      row.style.cssText = "display:flex;align-items:flex-start;gap:0.5rem;padding:0.2rem 0.75rem;font-size:0.75rem;";
+      row.innerHTML =
+        `<span data-ri style="flex:none;width:0.9rem;text-align:center;"></span>` +
+        `<span style="flex:1;min-width:0;"><span data-ru class="font-mono break-all"></span>` +
+        `<span data-rn class="block text-text-secondary"></span></span>`;
+      row.querySelector("[data-ru]").textContent = shortRelay(url);
+      body.appendChild(row);
+      rows[url] = row;
+      return row;
+    }
+    function paint(url, bits) {
+      const row = rowFor(url);
+      const ri = row.querySelector("[data-ri]");
+      ri.className = bits.cls;
+      ri.textContent = bits.icon;
+      const rn = row.querySelector("[data-rn]");
+      rn.textContent = bits.note || "";
+      rn.style.display = bits.note ? "block" : "none";
     }
 
     return {
       status(text) {
-        const el = t.querySelector("[data-title]");
-        if (el) el.textContent = text;
+        titleEl.textContent = text;
       },
-      update(result) {
-        const relays = result.results || [];
-        const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
-        setIcon(accepted > 0 ? "✓" : "•", accepted > 0 ? "text-success" : "text-warning");
-        t.querySelector("[data-title]").textContent =
-          `Accepted by ${accepted}/${relays.length} relays`;
-        body.innerHTML =
-          relays.map(relayLine).join("") ||
-          '<span class="text-xs text-text-secondary">No relays targeted.</span>';
-        timer = setTimeout(dismiss, 12000);
+      start(relays) {
+        relays = relays || [];
+        total = relays.length;
+        relays.forEach((u) => paint(u, statusBits({ pending: true })));
+        titleEl.textContent = total ? `Broadcasting… 0/${total}` : "Broadcasting…";
       },
-      fail(msg) {
+      addResult(msg) {
+        if (!msg.relayURL) return;
+        paint(msg.relayURL, statusBits(msg));
+        if (msg.accepted) accepted++;
+        titleEl.textContent = `Broadcasting… ${accepted}/${total}`;
+      },
+      done() {
+        if (accepted > 0) {
+          setIcon("✓", "text-success");
+          titleEl.textContent = `Sent to ${accepted}/${total} relays`;
+        } else {
+          setIcon("•", "text-warning");
+          titleEl.textContent = `No relay accepted (0/${total})`;
+        }
+        // Persist by default; only a fully clean success fades on its own.
+        if (total > 0 && accepted === total) timer = setTimeout(dismiss, 15000);
+      },
+      fail(message) {
         setIcon("✗", "text-danger");
-        t.querySelector("[data-title]").textContent = "Publish failed";
-        body.innerHTML = `<span class="text-xs break-all text-danger">${escAttr(msg || "")}</span>`;
-        body.classList.remove("hidden");
-        timer = setTimeout(dismiss, 12000);
+        titleEl.textContent = "Publish failed";
+        body.innerHTML =
+          `<div class="text-danger break-all" style="padding:0.25rem 0.75rem;font-size:0.75rem;">${escAttr(message || "")}</div>`;
+        setExpanded(true);
       },
       dismiss,
     };
@@ -109,10 +157,6 @@
 
   async function signAndPublish(unsigned, opts) {
     opts = opts || {};
-    const status = typeof opts.status === "function" ? opts.status : function () {};
-    status("");
-    // Create the toast up front so the user gets feedback even when the signer
-    // step itself fails (that used to throw before any toast appeared).
     const toast = makePublishToast(opts.title);
     try {
       toast.status("Waiting for your signer…");
@@ -122,21 +166,53 @@
       }
       const signed = await window.grainSigner.signEvent(unsigned);
 
-      toast.status("Publishing…");
-      const resp = await fetch("/api/v1/events/publish", {
+      toast.status("Broadcasting…");
+      const resp = await fetch("/api/v1/events/publish/stream", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ event: signed }),
       });
-      const result = await resp.json();
-      if (!resp.ok || !result.success) {
-        toast.fail(result.error || "publish failed");
+      if (!resp.ok) {
+        const txt = await resp.text().catch(() => "");
+        toast.fail(txt || "HTTP " + resp.status);
         return null;
       }
-      toast.update(result);
-      const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
-      if (accepted && typeof opts.onAccepted === "function") opts.onAccepted(signed, result);
-      return { signed, result, accepted };
+      if (!resp.body) {
+        toast.fail("No response stream.");
+        return null;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      const results = [];
+      let acceptedAny = false;
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          let m;
+          try {
+            m = JSON.parse(line);
+          } catch (e) {
+            continue;
+          }
+          if (m.type === "start") toast.start(m.relays || []);
+          else if (m.type === "result") {
+            results.push(m);
+            if (m.accepted) acceptedAny = true;
+            toast.addResult(m);
+          } else if (m.type === "done") toast.done();
+        }
+      }
+
+      if (acceptedAny && typeof opts.onAccepted === "function") opts.onAccepted(signed, results);
+      return { signed, results, accepted: acceptedAny };
     } catch (err) {
       console.error("Publish failed:", err);
       toast.fail(err.message || String(err));

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -558,7 +558,11 @@
       const buildResp = await fetch("/api/v1/user/profile/build", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ event: profileData.profile, edits }),
+        body: JSON.stringify({
+          event: profileData.profile,
+          edits,
+          client_tag: window.grainClientTag ? window.grainClientTag.enabled() : true,
+        }),
       });
       if (!buildResp.ok) throw new Error(await buildResp.text());
       const unsigned = await buildResp.json();

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -137,6 +137,11 @@
     // Update external identities from event tags (NIP-39)
     updateExternalIdentities(profile);
 
+    // Keep the parsed content for the editor's diff, and reveal the Edit button
+    // if this is the logged-in user's own profile.
+    profileData.content = profileContent;
+    checkOwnProfile();
+
     console.log("Profile component display complete");
   }
 
@@ -184,9 +189,10 @@
       showElement("profile-website-container");
     }
 
-    // Lightning address
-    if (profileContent.lud16) {
-      setElementText("profile-lightning", profileContent.lud16);
+    // Lightning address (lud16 preferred; lud06 LNURL as fallback)
+    const lightning = profileContent.lud16 || profileContent.lud06;
+    if (lightning) {
+      setElementText("profile-lightning", lightning);
       showElement("profile-lightning-container");
     }
   }
@@ -457,6 +463,138 @@
       if (btn) btn.textContent = "view event json";
     }
   };
+
+  // ── Profile editing (own profile only) ─────────────────────────
+  // Editable kind-0 content fields. The input id is edit-<field> where <field>
+  // is the content key, so we map both ways generically.
+  const EDITABLE_FIELDS = [
+    "name", "display_name", "about", "picture", "banner", "nip05", "lud16", "website",
+  ];
+
+  // Reveal the Edit button only when the logged-in user is viewing their own
+  // profile (session pubkey === this profile's pubkey).
+  async function checkOwnProfile() {
+    try {
+      const r = await fetch("/api/v1/session", { cache: "no-store" });
+      if (!r.ok) return;
+      const sess = await r.json();
+      const mine =
+        sess &&
+        sess.publicKey &&
+        sess.publicKey.toLowerCase() === (profileData.pubkey || "").toLowerCase();
+      if (mine) showElement("profile-edit-btn");
+    } catch (_) {
+      /* not logged in — leave the Edit button hidden */
+    }
+  }
+
+  window.toggleProfileEdit = function () {
+    const panel = document.getElementById("profile-edit-panel");
+    if (!panel) return;
+    const opening = panel.classList.contains("hidden");
+    if (opening) {
+      const content = profileData.content || {};
+      EDITABLE_FIELDS.forEach((f) => {
+        const el = document.getElementById("edit-" + f);
+        if (el) el.value = content[f] != null ? String(content[f]) : "";
+      });
+      setElementText("profile-save-status", "");
+    }
+    panel.classList.toggle("hidden");
+  };
+
+  window.saveProfile = async function () {
+    const status = (m) => setElementText("profile-save-status", m);
+    const content = profileData.content || {};
+
+    // Collect ONLY the fields the user actually changed, so we add tags for
+    // exactly those and leave everything else in the kind-0 untouched.
+    const edits = {};
+    EDITABLE_FIELDS.forEach((f) => {
+      const el = document.getElementById("edit-" + f);
+      if (!el) return;
+      const newVal = el.value.trim();
+      const oldVal = content[f] != null ? String(content[f]) : "";
+      if (newVal !== oldVal) edits[f] = newVal;
+    });
+    if (Object.keys(edits).length === 0) {
+      status("No changes to save.");
+      return;
+    }
+
+    const saveBtn = document.getElementById("profile-save-btn");
+    if (saveBtn) saveBtn.disabled = true;
+    try {
+      // 1. Server merges the edits over the existing event → unsigned kind-0.
+      status("Assembling event…");
+      const buildResp = await fetch("/api/v1/user/profile/build", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: profileData.profile, edits }),
+      });
+      if (!buildResp.ok) throw new Error(await buildResp.text());
+      const unsigned = await buildResp.json();
+
+      // 2. Sign client-side with the user's signer.
+      status("Waiting for your signer…");
+      if (typeof window.restoreSigner === "function") await window.restoreSigner();
+      if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
+        throw new Error("No signer available — log in with a signing method.");
+      }
+      const signed = await window.grainSigner.signEvent(unsigned);
+
+      // 3. Publish via the outbox.
+      status("Publishing…");
+      const pubResp = await fetch("/api/v1/events/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: signed }),
+      });
+      const result = await pubResp.json();
+      if (!pubResp.ok || !result.success) {
+        throw new Error(result.error || "publish failed");
+      }
+
+      showPublishToast(result);
+      status("");
+      window.toggleProfileEdit();
+      setTimeout(() => window.refreshProfile(), 1000);
+    } catch (err) {
+      console.error("Save profile failed:", err);
+      status("Error: " + (err.message || err));
+    } finally {
+      if (saveBtn) saveBtn.disabled = false;
+    }
+  };
+
+  // Toast listing the relays an event was published to. Per-relay accept/reject
+  // (NIP-20 OK) is a follow-up; for now this reflects send success per relay.
+  function showPublishToast(result) {
+    const relays = result.results || [];
+    const ok = relays.filter((r) => r.Success || r.success).length;
+    const lines = relays
+      .map((r) => {
+        const url = r.RelayURL || r.relayURL || "";
+        const good = r.Success || r.success;
+        return `<div class="flex items-center gap-2"><span class="${
+          good ? "text-success" : "text-danger"
+        }">${good ? "✓" : "✗"}</span><span class="font-mono text-xs break-all">${url}</span></div>`;
+      })
+      .join("");
+
+    const toast = document.createElement("div");
+    toast.className =
+      "fixed z-50 max-w-sm p-4 border rounded-lg shadow-lg top-4 right-4 bg-surface border-border";
+    toast.innerHTML = `
+      <div class="mb-2 font-semibold text-text">Published to ${ok}/${relays.length} relays</div>
+      <div class="space-y-1 overflow-y-auto max-h-48">${
+        lines || '<span class="text-xs text-text-secondary">No relays targeted.</span>'
+      }</div>`;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      if (document.body.contains(toast)) document.body.removeChild(toast);
+    }, 6000);
+  }
 
   // Utility functions
   function showElement(elementId) {

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -573,40 +573,41 @@
   // outbox, show the OK toast, and hydrate the page in place once a relay
   // accepts. Throws on failure (the caller surfaces the error).
   async function signAndPublish(unsigned, status, onAccepted) {
-    status("Waiting for your signer…");
-    if (typeof window.restoreSigner === "function") await window.restoreSigner();
-    if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
-      throw new Error("No signer available — log in with a signing method.");
-    }
-    const signed = await window.grainSigner.signEvent(unsigned);
-
-    status(""); // the toast takes over from here
-    const toast = makePublishToast(); // small bottom-right toast, spinner while sending
-
-    let result;
+    // Create the toast UP FRONT so the user always gets feedback — including
+    // when the signer is unavailable, which used to throw before any toast and
+    // left the user staring at nothing.
+    status("");
+    const toast = makePublishToast();
     try {
+      toast.status("Waiting for your signer…");
+      if (typeof window.restoreSigner === "function") await window.restoreSigner();
+      if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
+        throw new Error("No signer available — log in with a signing method.");
+      }
+      const signed = await window.grainSigner.signEvent(unsigned);
+
+      toast.status("Publishing…");
       const pubResp = await fetch("/api/v1/events/publish", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ event: signed }),
       });
-      result = await pubResp.json();
+      const result = await pubResp.json();
       if (!pubResp.ok || !result.success) {
         toast.fail(result.error || "publish failed");
         return;
       }
-    } catch (err) {
-      toast.fail(err.message || String(err));
-      return;
-    }
 
-    toast.update(result);
-    if ((result.results || []).some((r) => r.Accepted || r.accepted)) {
-      // At least one relay stored it — hydrate the page in place from the event
-      // we just signed; no reload.
-      profileData.profile = signed;
-      displayProfile(signed);
-      if (onAccepted) onAccepted();
+      toast.update(result);
+      if ((result.results || []).some((r) => r.Accepted || r.accepted)) {
+        // At least one relay stored it — hydrate the page in place; no reload.
+        profileData.profile = signed;
+        displayProfile(signed);
+        if (onAccepted) onAccepted();
+      }
+    } catch (err) {
+      console.error("Publish failed:", err);
+      toast.fail(err.message || String(err));
     }
   }
 
@@ -825,6 +826,10 @@
     }
 
     return {
+      status(text) {
+        const el = t.querySelector("[data-title]");
+        if (el) el.textContent = text;
+      },
       update(result) {
         const relays = result.results || [];
         const accepted = relays.filter((r) => r.Accepted || r.accepted).length;

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -482,9 +482,12 @@
         sess &&
         sess.publicKey &&
         sess.publicKey.toLowerCase() === (profileData.pubkey || "").toLowerCase();
-      if (mine) showElement("profile-edit-btn");
+      if (mine) {
+        showElement("profile-edit-btn");
+        showElement("profile-advanced-btn");
+      }
     } catch (_) {
-      /* not logged in — leave the Edit button hidden */
+      /* not logged in — leave the Edit buttons hidden */
     }
   }
 
@@ -525,7 +528,7 @@
     const saveBtn = document.getElementById("profile-save-btn");
     if (saveBtn) saveBtn.disabled = true;
     try {
-      // 1. Server merges the edits over the existing event → unsigned kind-0.
+      // Server merges the edits over the existing event → unsigned kind-0.
       status("Assembling event…");
       const buildResp = await fetch("/api/v1/user/profile/build", {
         method: "POST",
@@ -534,45 +537,218 @@
       });
       if (!buildResp.ok) throw new Error(await buildResp.text());
       const unsigned = await buildResp.json();
-
-      // 2. Sign client-side with the user's signer.
-      status("Waiting for your signer…");
-      if (typeof window.restoreSigner === "function") await window.restoreSigner();
-      if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
-        throw new Error("No signer available — log in with a signing method.");
-      }
-      const signed = await window.grainSigner.signEvent(unsigned);
-
-      // 3. Publish via the outbox.
-      status("Publishing…");
-      const pubResp = await fetch("/api/v1/events/publish", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ event: signed }),
-      });
-      const result = await pubResp.json();
-      if (!pubResp.ok || !result.success) {
-        throw new Error(result.error || "publish failed");
-      }
-
-      showPublishToast(result);
-
-      const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
-      if (accepted) {
-        // At least one relay stored it — hydrate the UI in place from the event
-        // we just signed, no page reload needed (we already have the data).
-        status("");
-        window.toggleProfileEdit();
-        profileData.profile = signed;
-        displayProfile(signed);
-      } else {
-        status("Sent, but no relay has accepted it yet — see the toast.");
-      }
+      await signAndPublish(unsigned, status, () => window.toggleProfileEdit());
     } catch (err) {
       console.error("Save profile failed:", err);
       status("Error: " + (err.message || err));
     } finally {
       if (saveBtn) saveBtn.disabled = false;
+    }
+  };
+
+  // Shared: sign an unsigned event with the user's signer, publish via the
+  // outbox, show the OK toast, and hydrate the page in place once a relay
+  // accepts. Throws on failure (the caller surfaces the error).
+  async function signAndPublish(unsigned, status, onAccepted) {
+    status("Waiting for your signer…");
+    if (typeof window.restoreSigner === "function") await window.restoreSigner();
+    if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
+      throw new Error("No signer available — log in with a signing method.");
+    }
+    const signed = await window.grainSigner.signEvent(unsigned);
+
+    status("Publishing…");
+    const pubResp = await fetch("/api/v1/events/publish", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: signed }),
+    });
+    const result = await pubResp.json();
+    if (!pubResp.ok || !result.success) {
+      throw new Error(result.error || "publish failed");
+    }
+
+    showPublishToast(result);
+    const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
+    if (accepted) {
+      status("");
+      profileData.profile = signed;
+      displayProfile(signed); // re-parses content + re-renders the page in place
+      if (onAccepted) onAccepted();
+    } else {
+      status("Sent, but no relay has accepted it yet — see the toast.");
+    }
+  }
+
+  // ── Advanced editor: full control over content fields and tags ──
+  let advState = { content: [], tags: [] };
+  let advDragFrom = null;
+
+  function escAttr(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  window.toggleAdvancedEdit = function () {
+    const panel = document.getElementById("profile-advanced-panel");
+    if (!panel) return;
+    const opening = panel.classList.contains("hidden");
+    if (opening) {
+      hideElement("profile-edit-panel"); // don't show both editors at once
+      loadAdvState();
+      setElementText("adv-status", "");
+    }
+    panel.classList.toggle("hidden");
+  };
+
+  function loadAdvState() {
+    const evt = profileData.profile || {};
+    const content = profileData.content || {};
+    advState.content = Object.keys(content).map((k) => ({
+      key: k,
+      value: content[k] == null ? "" : String(content[k]),
+    }));
+    advState.tags = (evt.tags || []).map((t) => t.slice());
+    const id = profileData.identifier || profileData.pubkey || "";
+    setElementText("adv-meta", `kind 0 · ${id} · created_at: set on sign`);
+    renderAdvContent();
+    renderAdvTags();
+  }
+
+  function renderAdvContent() {
+    const box = document.getElementById("adv-content");
+    if (!box) return;
+    box.innerHTML = "";
+    advState.content.forEach((row, i) => {
+      const div = document.createElement("div");
+      div.className = "flex items-center gap-2";
+      div.innerHTML =
+        `<input value="${escAttr(row.key)}" placeholder="field" class="w-1/3 px-2 py-1 text-sm border rounded bg-surface-elevated text-text border-border" data-ck="${i}" />` +
+        `<input value="${escAttr(row.value)}" placeholder="value" class="flex-1 px-2 py-1 text-sm border rounded bg-surface-elevated text-text border-border" data-cv="${i}" />` +
+        `<button class="px-2 text-danger hover:opacity-80" data-cdel="${i}" title="Remove">×</button>`;
+      box.appendChild(div);
+    });
+    box.querySelectorAll("[data-ck]").forEach((el) => {
+      el.oninput = () => (advState.content[+el.dataset.ck].key = el.value);
+    });
+    box.querySelectorAll("[data-cv]").forEach((el) => {
+      el.oninput = () => (advState.content[+el.dataset.cv].value = el.value);
+    });
+    box.querySelectorAll("[data-cdel]").forEach((el) => {
+      el.onclick = () => {
+        advState.content.splice(+el.dataset.cdel, 1);
+        renderAdvContent();
+      };
+    });
+  }
+
+  function renderAdvTags() {
+    const box = document.getElementById("adv-tags");
+    if (!box) return;
+    box.innerHTML = "";
+    advState.tags.forEach((tag, i) => {
+      const row = document.createElement("div");
+      row.className = "flex items-center gap-2 p-1 rounded bg-surface-elevated";
+      row.dataset.row = i;
+      row.ondragover = (e) => e.preventDefault();
+      row.ondrop = (e) => {
+        e.preventDefault();
+        advMoveTag(advDragFrom, i);
+      };
+      const els = tag
+        .map(
+          (el, j) =>
+            `<input value="${escAttr(el)}" class="px-2 py-1 text-sm border rounded bg-surface text-text border-border" data-te="${i}_${j}" />`
+        )
+        .join("");
+      row.innerHTML =
+        `<span class="cursor-grab select-none text-text-secondary" draggable="true" title="Drag to reorder" data-grip="${i}">⠿</span>` +
+        `<div class="flex flex-wrap items-center flex-1 gap-1">${els}` +
+        `<button class="px-1 text-xs text-accent hover:opacity-80" data-teadd="${i}" title="Add element">+</button></div>` +
+        `<button class="px-2 text-danger hover:opacity-80" data-tdel="${i}" title="Remove tag">×</button>`;
+      box.appendChild(row);
+    });
+    box.querySelectorAll("[data-grip]").forEach((el) => {
+      el.ondragstart = (e) => {
+        advDragFrom = +el.dataset.grip;
+        // Firefox won't start a drag unless some data is set.
+        if (e.dataTransfer) e.dataTransfer.setData("text/plain", "");
+      };
+    });
+    box.querySelectorAll("[data-te]").forEach((el) => {
+      el.oninput = () => {
+        const [i, j] = el.dataset.te.split("_").map(Number);
+        advState.tags[i][j] = el.value;
+      };
+    });
+    box.querySelectorAll("[data-teadd]").forEach((el) => {
+      el.onclick = () => {
+        advState.tags[+el.dataset.teadd].push("");
+        renderAdvTags();
+      };
+    });
+    box.querySelectorAll("[data-tdel]").forEach((el) => {
+      el.onclick = () => {
+        advState.tags.splice(+el.dataset.tdel, 1);
+        renderAdvTags();
+      };
+    });
+  }
+
+  function advMoveTag(from, to) {
+    if (from == null || from === to) return;
+    const [item] = advState.tags.splice(from, 1);
+    advState.tags.splice(to, 0, item);
+    advDragFrom = null;
+    renderAdvTags();
+  }
+
+  window.advAddContent = function () {
+    advState.content.push({ key: "", value: "" });
+    renderAdvContent();
+  };
+  window.advAddTag = function () {
+    advState.tags.push(["", ""]);
+    renderAdvTags();
+  };
+
+  window.advSave = async function () {
+    const status = (m) => setElementText("adv-status", m);
+
+    // Content: keep rows with a non-empty key, re-serialized to the content JSON.
+    const content = {};
+    advState.content.forEach((row) => {
+      const k = (row.key || "").trim();
+      if (k) content[k] = row.value;
+    });
+
+    // Tags: trim trailing empty elements, drop empty rows; order is preserved.
+    const tags = advState.tags
+      .map((t) => {
+        const c = t.slice();
+        while (c.length && c[c.length - 1] === "") c.pop();
+        return c;
+      })
+      .filter((t) => t.length > 0);
+
+    // Advanced = full control: assemble the event directly (no server merge).
+    // created_at is stamped now; kind/pubkey are fixed.
+    const unsigned = {
+      kind: 0,
+      pubkey: profileData.pubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      content: JSON.stringify(content),
+      tags: tags,
+    };
+
+    try {
+      await signAndPublish(unsigned, status, () => window.toggleAdvancedEdit());
+    } catch (err) {
+      console.error("Advanced save failed:", err);
+      status("Error: " + (err.message || err));
     }
   };
 

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -636,6 +636,10 @@
       setElementText("adv-status", "");
     }
     panel.classList.toggle("hidden");
+    if (opening) {
+      // Bring the advanced inputs into view (the panel sits below the card).
+      panel.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
   };
 
   function loadAdvState() {

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -295,9 +295,7 @@
 
   // Add external identity link to UI
   function addExternalIdentityLink(platform, identity) {
-    const socialLinksContainer = document.querySelector(
-      ".flex.justify-center.gap-6.mb-8"
-    );
+    const socialLinksContainer = document.getElementById("social-links-container");
     if (!socialLinksContainer) return;
 
     // Platform configuration
@@ -491,19 +489,44 @@
     }
   }
 
+  let pfEditing = false;
+
+  // Flip the page between view and edit: .pf-view elements show when viewing,
+  // .pf-edit when editing. The conditional contact cards live inside a .pf-view
+  // wrapper, so hiding the wrapper doesn't disturb their own visibility.
+  function setEditMode(on) {
+    pfEditing = on;
+    document.querySelectorAll(".pf-view").forEach((e) => e.classList.toggle("hidden", on));
+    document.querySelectorAll(".pf-edit").forEach((e) => e.classList.toggle("hidden", !on));
+  }
+
+  function advPanelOpen() {
+    const p = document.getElementById("profile-advanced-panel");
+    return p && !p.classList.contains("hidden");
+  }
+
   window.toggleProfileEdit = function () {
-    const panel = document.getElementById("profile-edit-panel");
-    if (!panel) return;
-    const opening = panel.classList.contains("hidden");
-    if (opening) {
+    if (!pfEditing) {
+      if (advPanelOpen()) window.toggleAdvancedEdit(); // one editor at a time
       const content = profileData.content || {};
       EDITABLE_FIELDS.forEach((f) => {
         const el = document.getElementById("edit-" + f);
         if (el) el.value = content[f] != null ? String(content[f]) : "";
       });
       setElementText("profile-save-status", "");
+      setEditMode(true);
+    } else {
+      setEditMode(false);
+      // Re-render the view so the contact cards reapply their conditional
+      // visibility (and any saved changes show).
+      if (profileData.profile) displayProfile(profileData.profile);
     }
-    panel.classList.toggle("hidden");
+  };
+
+  window.focusPictureField = function () {
+    if (!pfEditing) window.toggleProfileEdit();
+    const el = document.getElementById("edit-picture");
+    if (el) el.focus();
   };
 
   window.saveProfile = async function () {
@@ -604,7 +627,11 @@
     if (!panel) return;
     const opening = panel.classList.contains("hidden");
     if (opening) {
-      hideElement("profile-edit-panel"); // don't show both editors at once
+      if (pfEditing) {
+        // Leave inline edit first — one editor at a time.
+        setEditMode(false);
+        if (profileData.profile) displayProfile(profileData.profile);
+      }
       loadAdvState();
       setElementText("adv-status", "");
     }

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -46,7 +46,12 @@
         profileData.profile = profile;
         displayProfile(profile);
       } else {
-        throw new Error("Profile not found");
+        // No kind-0 yet (e.g. a brand-new identity). Show an empty profile rather
+        // than an error: the owner gets the Edit button (via checkOwnProfile) to
+        // create one, and a stranger just sees a blank profile.
+        const empty = { pubkey: pubkey, kind: 0, content: "{}", tags: [] };
+        profileData.profile = empty;
+        displayProfile(empty);
       }
     } catch (error) {
       console.error("Failed to load profile:", error);
@@ -83,23 +88,22 @@
   }
 
   async function fetchProfile(pubkey) {
-    try {
-      // Use existing profile API
-      const response = await fetch(
-        `/api/v1/user/profile?pubkey=${encodeURIComponent(pubkey)}`
-      );
-
-      if (!response.ok) {
-        throw new Error(`Profile API returned ${response.status}`);
-      }
-
-      const profile = await response.json();
-      console.log("Profile data loaded:", profile);
-      return profile;
-    } catch (error) {
-      console.error("Failed to fetch profile:", error);
+    // Use existing profile API. A 404 means "no kind-0 published yet" → return
+    // null so the caller shows an empty editable profile. Other failures
+    // (network, 5xx) throw, so the caller errors instead of risking the owner
+    // overwriting a real profile that just failed to load.
+    const response = await fetch(
+      `/api/v1/user/profile?pubkey=${encodeURIComponent(pubkey)}`
+    );
+    if (response.status === 404) {
       return null;
     }
+    if (!response.ok) {
+      throw new Error(`Profile API returned ${response.status}`);
+    }
+    const profile = await response.json();
+    console.log("Profile data loaded:", profile);
+    return profile;
   }
 
   function displayProfile(profile) {
@@ -485,6 +489,12 @@
       if (mine) {
         showElement("profile-edit-btn");
         showElement("profile-advanced-btn");
+        // Brand-new identity (no kind-0 → empty content): drop the owner straight
+        // into the editor so they can set up their profile metadata.
+        const empty = Object.keys(profileData.content || {}).length === 0;
+        if (empty && !pfEditing && typeof window.toggleProfileEdit === "function") {
+          window.toggleProfileEdit();
+        }
       }
     } catch (_) {
       /* not logged in — leave the Edit buttons hidden */

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -573,42 +573,21 @@
   // outbox, show the OK toast, and hydrate the page in place once a relay
   // accepts. Throws on failure (the caller surfaces the error).
   async function signAndPublish(unsigned, status, onAccepted) {
-    // Create the toast UP FRONT so the user always gets feedback — including
-    // when the signer is unavailable, which used to throw before any toast and
-    // left the user staring at nothing.
     status("");
-    const toast = makePublishToast();
-    try {
-      toast.status("Waiting for your signer…");
-      if (typeof window.restoreSigner === "function") await window.restoreSigner();
-      if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
-        throw new Error("No signer available — log in with a signing method.");
-      }
-      const signed = await window.grainSigner.signEvent(unsigned);
-
-      toast.status("Publishing…");
-      const pubResp = await fetch("/api/v1/events/publish", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ event: signed }),
-      });
-      const result = await pubResp.json();
-      if (!pubResp.ok || !result.success) {
-        toast.fail(result.error || "publish failed");
-        return;
-      }
-
-      toast.update(result);
-      if ((result.results || []).some((r) => r.Accepted || r.accepted)) {
-        // At least one relay stored it — hydrate the page in place; no reload.
+    if (!window.grainPublish || typeof window.grainPublish.signAndPublish !== "function") {
+      status("Publish helper not loaded — reload the page.");
+      return;
+    }
+    // Delegate to the shared live broadcast toast (nostr-publish.js); hydrate the
+    // profile in place once at least one relay accepts.
+    await window.grainPublish.signAndPublish(unsigned, {
+      title: "Publishing profile…",
+      onAccepted: function (signed) {
         profileData.profile = signed;
         displayProfile(signed);
         if (onAccepted) onAccepted();
-      }
-    } catch (err) {
-      console.error("Publish failed:", err);
-      toast.fail(err.message || String(err));
-    }
+      },
+    });
   }
 
   // ── Advanced editor: full control over content fields and tags ──
@@ -790,92 +769,6 @@
       status("Error: " + (err.message || err));
     }
   };
-
-  // Publish toast: small, bottom-right. Spinner while sending; then the accepted
-  // count. Click the header to expand per-relay details (accept / reject+reason
-  // / send failure); dismiss anytime with the ×.
-  function makePublishToast() {
-    const t = document.createElement("div");
-    t.className =
-      "fixed z-50 overflow-hidden text-sm border rounded-lg shadow-lg bottom-4 right-4 w-72 bg-surface border-border";
-    t.innerHTML =
-      `<div class="flex items-center gap-2 px-3 py-2 cursor-pointer" data-head>` +
-      `<span data-icon class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>` +
-      `<span data-title class="flex-1 font-medium text-text">Publishing…</span>` +
-      `<button data-close class="px-1 text-text-secondary hover:text-text" title="Dismiss">×</button>` +
-      `</div>` +
-      `<div data-body class="hidden px-3 pb-2 space-y-1 overflow-y-auto border-t max-h-48 border-border"></div>`;
-    document.body.appendChild(t);
-
-    const body = t.querySelector("[data-body]");
-    let timer = null;
-    const dismiss = () => {
-      if (timer) clearTimeout(timer);
-      if (document.body.contains(t)) document.body.removeChild(t);
-    };
-    t.querySelector("[data-close]").onclick = (e) => {
-      e.stopPropagation();
-      dismiss();
-    };
-    t.querySelector("[data-head]").onclick = () => body.classList.toggle("hidden");
-
-    function setIcon(text, cls) {
-      const icon = t.querySelector("[data-icon]");
-      icon.className = cls;
-      icon.textContent = text;
-    }
-
-    return {
-      status(text) {
-        const el = t.querySelector("[data-title]");
-        if (el) el.textContent = text;
-      },
-      update(result) {
-        const relays = result.results || [];
-        const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
-        setIcon(accepted > 0 ? "✓" : "•", accepted > 0 ? "text-success" : "text-warning");
-        t.querySelector("[data-title]").textContent =
-          `Accepted by ${accepted}/${relays.length} relays`;
-        body.innerHTML =
-          relays.map(relayLine).join("") ||
-          '<span class="text-xs text-text-secondary">No relays targeted.</span>';
-        timer = setTimeout(dismiss, 12000);
-      },
-      fail(msg) {
-        setIcon("✗", "text-danger");
-        t.querySelector("[data-title]").textContent = "Publish failed";
-        body.innerHTML = `<span class="text-xs break-all text-danger">${escAttr(msg || "")}</span>`;
-        body.classList.remove("hidden");
-        timer = setTimeout(dismiss, 12000);
-      },
-    };
-  }
-
-  // One per-relay line in the expanded toast.
-  function relayLine(r) {
-    const url = r.RelayURL || r.relayURL || "";
-    const sent = r.Success || r.success;
-    const ok = r.Accepted || r.accepted;
-    const reason = r.Reason || r.reason || "";
-    const msg = r.Message || r.message || "";
-    let icon, cls, note;
-    if (ok) {
-      icon = "✓"; cls = "text-success"; note = reason;
-    } else if (!sent) {
-      icon = "✗"; cls = "text-danger"; note = msg || "failed to send";
-    } else if (reason) {
-      icon = "✗"; cls = "text-danger"; note = reason; // relay rejected it
-    } else {
-      icon = "•"; cls = "text-warning"; note = "no response";
-    }
-    return (
-      `<div class="flex items-start gap-2 text-xs">` +
-      `<span class="${cls}">${icon}</span>` +
-      `<span class="flex-1 min-w-0"><span class="font-mono break-all">${escAttr(url)}</span>` +
-      (note ? `<span class="block text-text-secondary">${escAttr(note)}</span>` : "") +
-      `</span></div>`
-    );
-  }
 
   // Utility functions
   function showElement(elementId) {

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -471,6 +471,7 @@
 
   // Reveal the Edit button only when the logged-in user is viewing their own
   // profile (session pubkey === this profile's pubkey).
+  let pfIsOwn = false;
   async function checkOwnProfile() {
     try {
       const r = await fetch("/api/v1/session", { cache: "no-store" });
@@ -480,6 +481,7 @@
         sess &&
         sess.publicKey &&
         sess.publicKey.toLowerCase() === (profileData.pubkey || "").toLowerCase();
+      pfIsOwn = !!mine;
       if (mine) {
         showElement("profile-edit-btn");
         showElement("profile-advanced-btn");
@@ -821,6 +823,18 @@
       }
     }, 3000);
   }
+
+  // Live-sync (#87): if your own profile (kind 0) changes in another client and
+  // you're viewing it here (and not mid-edit), re-pull it so the page is current.
+  if (window.__pfStreamHandler)
+    window.removeEventListener("grain:stream", window.__pfStreamHandler);
+  window.__pfStreamHandler = function (e) {
+    const m = e.detail || {};
+    if (m.type === "list-updated" && m.kind === 0 && pfIsOwn && !pfEditing) {
+      window.refreshProfile();
+    }
+  };
+  window.addEventListener("grain:stream", window.__pfStreamHandler);
 
   // Initialize when DOM is ready
   if (document.readyState === "loading") {

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -557,26 +557,33 @@
     }
     const signed = await window.grainSigner.signEvent(unsigned);
 
-    status("Publishing…");
-    const pubResp = await fetch("/api/v1/events/publish", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ event: signed }),
-    });
-    const result = await pubResp.json();
-    if (!pubResp.ok || !result.success) {
-      throw new Error(result.error || "publish failed");
+    status(""); // the toast takes over from here
+    const toast = makePublishToast(); // small bottom-right toast, spinner while sending
+
+    let result;
+    try {
+      const pubResp = await fetch("/api/v1/events/publish", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: signed }),
+      });
+      result = await pubResp.json();
+      if (!pubResp.ok || !result.success) {
+        toast.fail(result.error || "publish failed");
+        return;
+      }
+    } catch (err) {
+      toast.fail(err.message || String(err));
+      return;
     }
 
-    showPublishToast(result);
-    const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
-    if (accepted) {
-      status("");
+    toast.update(result);
+    if ((result.results || []).some((r) => r.Accepted || r.accepted)) {
+      // At least one relay stored it — hydrate the page in place from the event
+      // we just signed; no reload.
       profileData.profile = signed;
-      displayProfile(signed); // re-parses content + re-renders the page in place
+      displayProfile(signed);
       if (onAccepted) onAccepted();
-    } else {
-      status("Sent, but no relay has accepted it yet — see the toast.");
     }
   }
 
@@ -752,47 +759,86 @@
     }
   };
 
-  // Toast listing each relay's NIP-20 verdict for the published event:
-  //   ✓ accepted (stored), • sent but no OK yet, ✗ rejected / send failed.
-  function showPublishToast(result) {
-    const relays = result.results || [];
-    const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
-    const lines = relays
-      .map((r) => {
-        const url = r.RelayURL || r.relayURL || "";
-        const sent = r.Success || r.success;
-        const ok = r.Accepted || r.accepted;
-        const reason = r.Reason || r.reason || "";
-        let icon, cls, note;
-        if (ok) {
-          icon = "✓"; cls = "text-success"; note = "";
-        } else if (sent) {
-          icon = "•"; cls = "text-warning"; note = reason || "no response";
-        } else {
-          icon = "✗"; cls = "text-danger"; note = reason || "send failed";
-        }
-        return `<div class="flex items-start gap-2">
-          <span class="${cls}">${icon}</span>
-          <span class="flex-1 min-w-0">
-            <span class="font-mono text-xs break-all">${url}</span>
-            ${note ? `<span class="block text-xs text-text-secondary">${note}</span>` : ""}
-          </span>
-        </div>`;
-      })
-      .join("");
+  // Publish toast: small, bottom-right. Spinner while sending; then the accepted
+  // count. Click the header to expand per-relay details (accept / reject+reason
+  // / send failure); dismiss anytime with the ×.
+  function makePublishToast() {
+    const t = document.createElement("div");
+    t.className =
+      "fixed z-50 overflow-hidden text-sm border rounded-lg shadow-lg bottom-4 right-4 w-72 bg-surface border-border";
+    t.innerHTML =
+      `<div class="flex items-center gap-2 px-3 py-2 cursor-pointer" data-head>` +
+      `<span data-icon class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>` +
+      `<span data-title class="flex-1 font-medium text-text">Publishing…</span>` +
+      `<button data-close class="px-1 text-text-secondary hover:text-text" title="Dismiss">×</button>` +
+      `</div>` +
+      `<div data-body class="hidden px-3 pb-2 space-y-1 overflow-y-auto border-t max-h-48 border-border"></div>`;
+    document.body.appendChild(t);
 
-    const toast = document.createElement("div");
-    toast.className =
-      "fixed z-50 max-w-sm p-4 border rounded-lg shadow-lg top-4 right-4 bg-surface border-border";
-    toast.innerHTML = `
-      <div class="mb-2 font-semibold text-text">Accepted by ${accepted}/${relays.length} relays</div>
-      <div class="space-y-1 overflow-y-auto max-h-48">${
-        lines || '<span class="text-xs text-text-secondary">No relays targeted.</span>'
-      }</div>`;
-    document.body.appendChild(toast);
-    setTimeout(() => {
-      if (document.body.contains(toast)) document.body.removeChild(toast);
-    }, 7000);
+    const body = t.querySelector("[data-body]");
+    let timer = null;
+    const dismiss = () => {
+      if (timer) clearTimeout(timer);
+      if (document.body.contains(t)) document.body.removeChild(t);
+    };
+    t.querySelector("[data-close]").onclick = (e) => {
+      e.stopPropagation();
+      dismiss();
+    };
+    t.querySelector("[data-head]").onclick = () => body.classList.toggle("hidden");
+
+    function setIcon(text, cls) {
+      const icon = t.querySelector("[data-icon]");
+      icon.className = cls;
+      icon.textContent = text;
+    }
+
+    return {
+      update(result) {
+        const relays = result.results || [];
+        const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
+        setIcon(accepted > 0 ? "✓" : "•", accepted > 0 ? "text-success" : "text-warning");
+        t.querySelector("[data-title]").textContent =
+          `Accepted by ${accepted}/${relays.length} relays`;
+        body.innerHTML =
+          relays.map(relayLine).join("") ||
+          '<span class="text-xs text-text-secondary">No relays targeted.</span>';
+        timer = setTimeout(dismiss, 12000);
+      },
+      fail(msg) {
+        setIcon("✗", "text-danger");
+        t.querySelector("[data-title]").textContent = "Publish failed";
+        body.innerHTML = `<span class="text-xs break-all text-danger">${escAttr(msg || "")}</span>`;
+        body.classList.remove("hidden");
+        timer = setTimeout(dismiss, 12000);
+      },
+    };
+  }
+
+  // One per-relay line in the expanded toast.
+  function relayLine(r) {
+    const url = r.RelayURL || r.relayURL || "";
+    const sent = r.Success || r.success;
+    const ok = r.Accepted || r.accepted;
+    const reason = r.Reason || r.reason || "";
+    const msg = r.Message || r.message || "";
+    let icon, cls, note;
+    if (ok) {
+      icon = "✓"; cls = "text-success"; note = reason;
+    } else if (!sent) {
+      icon = "✗"; cls = "text-danger"; note = msg || "failed to send";
+    } else if (reason) {
+      icon = "✗"; cls = "text-danger"; note = reason; // relay rejected it
+    } else {
+      icon = "•"; cls = "text-warning"; note = "no response";
+    }
+    return (
+      `<div class="flex items-start gap-2 text-xs">` +
+      `<span class="${cls}">${icon}</span>` +
+      `<span class="flex-1 min-w-0"><span class="font-mono break-all">${escAttr(url)}</span>` +
+      (note ? `<span class="block text-text-secondary">${escAttr(note)}</span>` : "") +
+      `</span></div>`
+    );
   }
 
   // Utility functions

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -387,7 +387,7 @@
       const bannerImg = document.getElementById("profile-banner-img");
       bannerImg.src = profileContent.banner;
       bannerImg.onload = function () {
-        showElement("profile-banner");
+        showElement("profile-banner-img");
       };
       bannerImg.onerror = function () {
         console.warn("Failed to load profile banner:", profileContent.banner);

--- a/www/static/js/profile-page.js
+++ b/www/static/js/profile-page.js
@@ -556,9 +556,18 @@
       }
 
       showPublishToast(result);
-      status("");
-      window.toggleProfileEdit();
-      setTimeout(() => window.refreshProfile(), 1000);
+
+      const accepted = (result.results || []).some((r) => r.Accepted || r.accepted);
+      if (accepted) {
+        // At least one relay stored it — hydrate the UI in place from the event
+        // we just signed, no page reload needed (we already have the data).
+        status("");
+        window.toggleProfileEdit();
+        profileData.profile = signed;
+        displayProfile(signed);
+      } else {
+        status("Sent, but no relay has accepted it yet — see the toast.");
+      }
     } catch (err) {
       console.error("Save profile failed:", err);
       status("Error: " + (err.message || err));
@@ -567,18 +576,32 @@
     }
   };
 
-  // Toast listing the relays an event was published to. Per-relay accept/reject
-  // (NIP-20 OK) is a follow-up; for now this reflects send success per relay.
+  // Toast listing each relay's NIP-20 verdict for the published event:
+  //   ✓ accepted (stored), • sent but no OK yet, ✗ rejected / send failed.
   function showPublishToast(result) {
     const relays = result.results || [];
-    const ok = relays.filter((r) => r.Success || r.success).length;
+    const accepted = relays.filter((r) => r.Accepted || r.accepted).length;
     const lines = relays
       .map((r) => {
         const url = r.RelayURL || r.relayURL || "";
-        const good = r.Success || r.success;
-        return `<div class="flex items-center gap-2"><span class="${
-          good ? "text-success" : "text-danger"
-        }">${good ? "✓" : "✗"}</span><span class="font-mono text-xs break-all">${url}</span></div>`;
+        const sent = r.Success || r.success;
+        const ok = r.Accepted || r.accepted;
+        const reason = r.Reason || r.reason || "";
+        let icon, cls, note;
+        if (ok) {
+          icon = "✓"; cls = "text-success"; note = "";
+        } else if (sent) {
+          icon = "•"; cls = "text-warning"; note = reason || "no response";
+        } else {
+          icon = "✗"; cls = "text-danger"; note = reason || "send failed";
+        }
+        return `<div class="flex items-start gap-2">
+          <span class="${cls}">${icon}</span>
+          <span class="flex-1 min-w-0">
+            <span class="font-mono text-xs break-all">${url}</span>
+            ${note ? `<span class="block text-xs text-text-secondary">${note}</span>` : ""}
+          </span>
+        </div>`;
       })
       .join("");
 
@@ -586,14 +609,14 @@
     toast.className =
       "fixed z-50 max-w-sm p-4 border rounded-lg shadow-lg top-4 right-4 bg-surface border-border";
     toast.innerHTML = `
-      <div class="mb-2 font-semibold text-text">Published to ${ok}/${relays.length} relays</div>
+      <div class="mb-2 font-semibold text-text">Accepted by ${accepted}/${relays.length} relays</div>
       <div class="space-y-1 overflow-y-auto max-h-48">${
         lines || '<span class="text-xs text-text-secondary">No relays targeted.</span>'
       }</div>`;
     document.body.appendChild(toast);
     setTimeout(() => {
       if (document.body.contains(toast)) document.body.removeChild(toast);
-    }, 6000);
+    }, 7000);
   }
 
   // Utility functions

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -799,7 +799,11 @@
       resp = await fetch("/api/v1/user/relay-list/build", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kind: kind, entries: entries }),
+        body: JSON.stringify({
+          kind: kind,
+          entries: entries,
+          client_tag: window.grainClientTag ? window.grainClientTag.enabled() : true,
+        }),
       });
     } catch (e) {
       setStatus(statusId, "Network error.");

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -1,0 +1,327 @@
+/**
+ * Relay manager settings section (#98).
+ *
+ * Renders the user's relay roles by category and lets them edit + publish each
+ * list. NIP-65 (Outbox/Inbox) is one kind-10002 event shown as two views;
+ * DM/Search/Favorites/Blocked are NIP-17/51 `relay`-tag lists. The fixed-relay
+ * override toggles the outbox model off. Reuses grainPublish (nostr-publish.js)
+ * for the live broadcast toast.
+ *
+ * Data comes from GET /api/v1/user/relay-lists; edits publish via the relay-list
+ * build endpoint + the streaming publish endpoint.
+ */
+(function () {
+  const TAG_CATS = [
+    { key: "dm", kind: 10050 },
+    { key: "search", kind: 10007 },
+    { key: "favorites", kind: 10012 },
+    { key: "blocked", kind: 10006 },
+  ];
+  // App-relay categories not yet wired (rendered as "coming soon").
+  const COMING = [
+    ["Indexer", "seed", "Seed relays grain uses to discover everyone's relay lists."],
+    ["Broadcast", "local", "Event blasters — forward your posts out to many relays."],
+    ["Local", "local", "Same-device / LAN relays, preferred for speed."],
+    ["Trusted", "local", "The only relays grain signs NIP-42 AUTH for."],
+  ];
+
+  const RM = {
+    nip65: [], // [{ url, read, write }]
+    lists: { dm: [], search: [], favorites: [], blocked: [] },
+    encrypted: {}, // key -> true when the list carries NIP-44 private entries (#100)
+    loaded: false,
+  };
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+  function shortRelay(u) {
+    return String(u || "").replace(/^wss?:\/\//, "").replace(/\/$/, "");
+  }
+  function httpish(u) {
+    return String(u || "").replace(/^ws(s?):\/\//, "http$1://");
+  }
+  // Light client-side normalisation for dedupe; the server re-normalises on build.
+  function normWs(u) {
+    let s = (u || "").trim();
+    if (!s) return "";
+    if (!/:\/\//.test(s)) s = "wss://" + s;
+    try {
+      const url = new URL(s);
+      if (url.protocol !== "ws:" && url.protocol !== "wss:") return "";
+      return url.protocol + "//" + url.host.toLowerCase() + url.pathname.replace(/\/+$/, "");
+    } catch (e) {
+      return "";
+    }
+  }
+  function setStatus(id, msg) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = msg || "";
+  }
+
+  function spinnerRow(text) {
+    return (
+      `<div class="flex items-center gap-2 px-3 py-3 text-sm text-text-muted">` +
+      `<span class="inline-block w-4 h-4 border-2 rounded-full border-text-secondary border-t-transparent animate-spin"></span>` +
+      `${esc(text)}</div>`
+    );
+  }
+  function emptyRow(text) {
+    return `<div class="px-3 py-3 text-sm text-center border border-dashed rounded-lg text-text-muted border-border-strong">${esc(text)}</div>`;
+  }
+  // Shown on a NIP-51 list whose event carries NIP-44 private entries grain
+  // can't read yet — so it reads as private rather than empty/broken (#100).
+  function encryptedHint() {
+    return (
+      `<div class="flex items-center gap-2 px-3 py-2 text-xs rounded-lg text-text-muted bg-surface-inset">` +
+      `🔒 This list has encrypted (private) entries — decrypt support coming.</div>`
+    );
+  }
+  function relayRow(url, removeAttr) {
+    return (
+      `<div class="flex items-center gap-2.5 px-3 py-2 border rounded-lg bg-surface-elevated border-border">` +
+      `<a href="${esc(httpish(url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(shortRelay(url))}</a>` +
+      `<button ${removeAttr} class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Remove">×</button>` +
+      `</div>`
+    );
+  }
+
+  function renderNip65() {
+    const ob = document.getElementById("rm-outbox-list");
+    const ib = document.getElementById("rm-inbox-list");
+    if (!ob || !ib) return;
+    if (!RM.loaded) {
+      ob.innerHTML = spinnerRow("Fetching your relays…");
+      ib.innerHTML = spinnerRow("Fetching your relays…");
+      return;
+    }
+    const outbox = RM.nip65.filter((e) => e.write);
+    const inbox = RM.nip65.filter((e) => e.read);
+    ob.innerHTML = outbox.length
+      ? outbox.map((e) => relayRow(e.url, `data-ob="${esc(e.url)}"`)).join("")
+      : emptyRow("No outbox relays yet.");
+    ib.innerHTML = inbox.length
+      ? inbox.map((e) => relayRow(e.url, `data-ib="${esc(e.url)}"`)).join("")
+      : emptyRow("No inbox relays yet.");
+    ob.querySelectorAll("[data-ob]").forEach((b) => {
+      b.onclick = () => nip65Remove(b.getAttribute("data-ob"), "write");
+    });
+    ib.querySelectorAll("[data-ib]").forEach((b) => {
+      b.onclick = () => nip65Remove(b.getAttribute("data-ib"), "read");
+    });
+  }
+
+  function renderTagList(key) {
+    const box = document.getElementById("rm-" + key + "-list");
+    if (!box) return;
+    if (!RM.loaded) {
+      box.innerHTML = spinnerRow("Fetching…");
+      return;
+    }
+    const list = RM.lists[key];
+    const enc = RM.encrypted && RM.encrypted[key];
+    let html = list.length
+      ? list.map((u) => relayRow(u, `data-rm="${esc(u)}"`)).join("")
+      : enc
+      ? ""
+      : emptyRow("None yet.");
+    if (enc) html += encryptedHint();
+    box.innerHTML = html;
+    box.querySelectorAll("[data-rm]").forEach((b) => {
+      b.onclick = () => {
+        const u = b.getAttribute("data-rm");
+        RM.lists[key] = RM.lists[key].filter((x) => x !== u);
+        renderTagList(key);
+      };
+    });
+  }
+
+  function renderApp() {
+    const box = document.getElementById("rm-app-relays");
+    if (!box) return;
+    box.innerHTML = COMING.map(
+      ([title, badge, note]) =>
+        `<div class="opacity-60"><div class="flex items-center gap-2">` +
+        `<span class="text-sm font-medium text-text">${esc(title)}</span>` +
+        `<span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">${esc(badge)}</span>` +
+        `<span class="px-2 py-0.5 ml-auto text-xs rounded bg-surface-inset text-text-muted">coming soon</span></div>` +
+        `<p class="mt-0.5 text-xs text-text-muted">${esc(note)}</p></div>`
+    ).join("");
+  }
+
+  function renderAll() {
+    renderNip65();
+    TAG_CATS.forEach((c) => renderTagList(c.key));
+  }
+
+  function nip65Upsert(url, field) {
+    const u = normWs(url);
+    if (!u) return;
+    let e = RM.nip65.find((x) => x.url === u);
+    if (!e) {
+      e = { url: u, read: false, write: false };
+      RM.nip65.push(e);
+    }
+    e[field] = true;
+    renderNip65();
+  }
+  function nip65Remove(url, field) {
+    const u = normWs(url);
+    const e = RM.nip65.find((x) => x.url === u);
+    if (!e) return;
+    e[field] = false;
+    if (!e.read && !e.write) RM.nip65 = RM.nip65.filter((x) => x.url !== u);
+    renderNip65();
+  }
+
+  async function publishRelayList(kind, entries, statusId) {
+    if (!window.grainPublish) {
+      setStatus(statusId, "Publish helper not loaded — reload the page.");
+      return;
+    }
+    setStatus(statusId, "Building your list…");
+    let resp;
+    try {
+      resp = await fetch("/api/v1/user/relay-list/build", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: kind, entries: entries }),
+      });
+    } catch (e) {
+      setStatus(statusId, "Network error.");
+      return;
+    }
+    if (!resp.ok) {
+      setStatus(statusId, "Couldn't build the list: " + (await resp.text()));
+      return;
+    }
+    const unsigned = await resp.json();
+    const res = await window.grainPublish.signAndPublish(unsigned, { title: "Publishing relay list…" });
+    if (res && res.accepted) setStatus(statusId, "✓ Saved — published to your relays.");
+    else if (res) setStatus(statusId, "Signed, but no relay accepted it yet — see the toast.");
+    else setStatus(statusId, "Publish failed — see the toast or the browser console.");
+  }
+
+  // Public handlers (referenced from settings.html).
+  window.rmAddOutbox = function () {
+    const i = document.getElementById("rm-outbox-input");
+    if (i && i.value.trim()) {
+      nip65Upsert(i.value, "write");
+      i.value = "";
+    }
+  };
+  window.rmAddInbox = function () {
+    const i = document.getElementById("rm-inbox-input");
+    if (i && i.value.trim()) {
+      nip65Upsert(i.value, "read");
+      i.value = "";
+    }
+  };
+  window.rmAdd = function (key) {
+    const i = document.getElementById("rm-" + key + "-input");
+    if (!i || !i.value.trim()) return;
+    const u = normWs(i.value);
+    if (u && RM.lists[key].indexOf(u) < 0) RM.lists[key].push(u);
+    i.value = "";
+    renderTagList(key);
+  };
+  window.rmSaveNip65 = function () {
+    publishRelayList(
+      10002,
+      RM.nip65.map((e) => ({ url: e.url, read: e.read, write: e.write })),
+      "rm-nip65-status"
+    );
+  };
+  window.rmSave = function (key) {
+    const cat = TAG_CATS.find((c) => c.key === key);
+    if (!cat) return;
+    publishRelayList(cat.kind, RM.lists[key].map((u) => ({ url: u })), "rm-" + key + "-status");
+  };
+  window.rmToggleFixed = async function () {
+    const cb = document.getElementById("rm-fixed-toggle");
+    const inputs = document.getElementById("rm-fixed-inputs");
+    if (inputs) inputs.classList.toggle("hidden", !cb.checked);
+    if (!cb.checked) {
+      try {
+        await fetch("/api/v1/client/fixed-relays", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false }),
+        });
+        setStatus("rm-fixed-status", "Outbox model restored.");
+      } catch (e) {}
+    }
+  };
+  window.rmApplyFixed = async function () {
+    const split = (id) =>
+      (document.getElementById(id).value || "").split(/[\s,]+/).map(normWs).filter(Boolean);
+    try {
+      const resp = await fetch("/api/v1/client/fixed-relays", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true, read: split("rm-fixed-read"), write: split("rm-fixed-write") }),
+      });
+      setStatus("rm-fixed-status", resp.ok ? "Fixed relays applied — outbox model OFF." : "Failed to apply.");
+    } catch (e) {
+      setStatus("rm-fixed-status", "Network error.");
+    }
+  };
+
+  function refreshOverview() {
+    fetch("/api/v1/client/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((s) => {
+        if (!s || !s.initialized) return;
+        const box = document.getElementById("rm-overview");
+        if (!box) return;
+        const cells = [
+          ["Known", s.pool_known || 0, "text-text"],
+          ["Connected", s.pool_connected || 0, "text-success"],
+          ["In use", s.pool_leased || 0, "text-text"],
+          ["Pinned", s.pool_pinned || 0, "text-text"],
+        ];
+        box.innerHTML = cells
+          .map(
+            ([l, v, c]) =>
+              `<div class="px-3 py-2 rounded-lg bg-surface-elevated"><div class="text-xs text-text-secondary">${l}</div>` +
+              `<div class="text-xl font-semibold ${c}">${v}</div></div>`
+          )
+          .join("");
+      })
+      .catch(() => {});
+  }
+
+  function init() {
+    if (!document.getElementById("relay-manager-section")) return;
+    renderApp();
+    renderAll(); // spinners while loaded === false
+    refreshOverview();
+    if (window.__rmOverviewTimer) clearInterval(window.__rmOverviewTimer);
+    window.__rmOverviewTimer = setInterval(refreshOverview, 5000);
+
+    fetch("/api/v1/user/relay-lists")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d) {
+          RM.nip65 = d.nip65 || [];
+          RM.lists.dm = d.dm || [];
+          RM.lists.search = d.search || [];
+          RM.lists.favorites = d.favorites || [];
+          RM.lists.blocked = d.blocked || [];
+          RM.encrypted = d.encrypted || {};
+        }
+        RM.loaded = true;
+        renderAll();
+      })
+      .catch(() => {
+        RM.loaded = true;
+        renderAll();
+      });
+  }
+
+  init();
+})();

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -27,7 +27,7 @@
 
   const RM = {
     nip65: [], // [{ url, read, write }]
-    lists: { dm: [], search: [], favorites: [], blocked: [] },
+    lists: { dm: [], search: [], favorites: [], blocked: [], private: [] },
     encrypted: {}, // key -> true when the list carries NIP-44 private entries (#100)
     encryptedContent: {}, // key -> raw encrypted blob; the browser decrypts on demand
     decrypted: {}, // key -> [urls] once the user clicks Decrypt (read-only reveal)
@@ -250,9 +250,37 @@
     ).join("");
   }
 
+  // The Private (10013, NIP-37) list is read-only: NIP-37 keeps relays in the
+  // encrypted content (public entries are rare), so this mostly shows the
+  // decrypt reveal. Editing/re-encrypting waits for the encrypt side.
+  function renderPrivate() {
+    const box = document.getElementById("rm-private-list");
+    if (!box) return;
+    if (!RM.loaded) {
+      box.innerHTML = spinnerRow("Fetching…");
+      return;
+    }
+    const pub = RM.lists.private || [];
+    const enc = RM.encrypted && RM.encrypted.private;
+    let html = pub
+      .map(
+        (u) =>
+          `<div class="flex items-center gap-2 px-3 py-2 text-sm border rounded-lg bg-surface-elevated border-border">` +
+          `<a href="${esc(httpish(u))}" target="_blank" rel="noopener" class="flex-1 min-w-0 truncate text-text hover:text-accent hover:underline">${esc(shortRelay(u))}</a></div>`
+      )
+      .join("");
+    if (enc) html += encryptedSection("private");
+    else if (!pub.length) html += emptyRow("No private relay list.");
+    box.innerHTML = html;
+    box.querySelectorAll("[data-rm-decrypt]").forEach((b) => {
+      b.onclick = () => rmDecrypt(b.getAttribute("data-rm-decrypt"));
+    });
+  }
+
   function renderAll() {
     renderNip65();
     TAG_CATS.forEach((c) => renderTagList(c.key));
+    renderPrivate();
   }
 
   function nip65Upsert(url, field) {
@@ -409,6 +437,7 @@
           RM.lists.search = d.search || [];
           RM.lists.favorites = d.favorites || [];
           RM.lists.blocked = d.blocked || [];
+          RM.lists.private = d.private || [];
           RM.encrypted = d.encrypted || {};
           RM.encryptedContent = d.encrypted_content || {};
           RM.pubkey = d.pubkey || "";
@@ -430,7 +459,7 @@
   window.__rmStreamHandler = function (e) {
     const m = e.detail || {};
     if (m.type !== "list-updated") return;
-    const map = { 10050: "dm", 10007: "search", 10012: "favorites", 10006: "blocked" };
+    const map = { 10050: "dm", 10007: "search", 10012: "favorites", 10006: "blocked", 10013: "private" };
     if (m.kind !== 10002 && !map[m.kind]) return;
     fetch("/api/v1/user/relay-lists")
       .then((r) => (r.ok ? r.json() : null))
@@ -445,7 +474,8 @@
           RM.encrypted = d.encrypted || RM.encrypted;
           RM.encryptedContent = d.encrypted_content || RM.encryptedContent;
           delete RM.decrypted[key]; // changed elsewhere — re-show the Decrypt button
-          renderTagList(key);
+          if (key === "private") renderPrivate();
+          else renderTagList(key);
         }
       })
       .catch(function () {});

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -23,7 +23,7 @@
   // Trusted NIP-42 AUTH are follow-ups).
   const APP_ROLES = [
     { key: "indexer", title: "Indexer", badge: "seed", active: true, note: "Seed relays grain uses to discover everyone's relay lists." },
-    { key: "broadcast", title: "Broadcast", badge: "blast", active: true, note: "Event blasters — your posts mirror out to these too." },
+    { key: "broadcast", title: "Broadcast", badge: "blast", active: true, note: "Every event you publish is also mirrored here — and these are blast/broadcast relays that re-send it onward to many other relays." },
     { key: "local", title: "Local", badge: "local", active: false, note: "Same-device / LAN relays. Stored now; routing preference coming." },
     { key: "trusted", title: "Trusted", badge: "auth", active: false, note: "The only relays grain will sign NIP-42 AUTH for. Stored now; AUTH coming (#101)." },
   ];
@@ -199,6 +199,15 @@
     const st = RM.knownMap[normWs(url)] || RM.knownMap[url] || {};
     return dotMarkup(st.connected, st.pinned);
   }
+  // The NIP-11 expander — a labelled pill button (not a bare chevron) so it's
+  // clear the row opens for more info.
+  function infoToggleBtn(url, expanded) {
+    return (
+      `<button data-relay-info="${esc(url)}" title="${expanded ? "Hide" : "Show"} relay info (NIP-11)" ` +
+      `class="flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium border rounded shrink-0 border-border bg-surface-overlay text-text-secondary hover:text-text hover:bg-surface-hover">` +
+      `<span>info</span><span class="text-[0.65rem] leading-none">${expanded ? "▲" : "▼"}</span></button>`
+    );
+  }
   // The NIP-11 detail block for an expanded relay row — shared everywhere.
   // Lazily filled by rmRelayInfoToggle.
   function relayInfoDetailHTML(url) {
@@ -234,7 +243,7 @@
       `<div class="flex items-center gap-2.5 px-3 py-2">` +
       relayStatusDot(url) +
       `<a href="${esc(httpish(url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(shortRelay(url))}</a>` +
-      `<button data-relay-info="${esc(url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
+      infoToggleBtn(url, expanded) +
       `<button ${removeAttr} class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Remove">×</button>` +
       `</div>` +
       relayInfoDetailHTML(url) +
@@ -472,7 +481,7 @@
       `<option value="search">Search</option><option value="favorites">Favorites</option>` +
       `<option value="blocked">Blocked</option><option value="dm">DM</option>` +
       `</select>` +
-      `<button data-relay-info="${esc(k.url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
+      infoToggleBtn(k.url, expanded) +
       `</div>` +
       relayInfoDetailHTML(k.url) +
       `</div>`

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -37,6 +37,11 @@
     pubkey: "", // session user, for NIP-51 self-decrypt
     app: { indexer: [], broadcast: [], local: [], trusted: [] }, // local-role prefs
     appLoaded: false,
+    known: [], // [{ url, connected, pinned, leased }] — the known-relays browser
+    knownLoaded: false,
+    knownFilter: "",
+    knownInfo: {}, // url -> NIP-11 object | null(pending)
+    knownExpanded: {}, // url -> true
     loaded: false,
   };
 
@@ -337,6 +342,155 @@
   }
   window.rmAppSave = rmAppSave;
 
+  // ── Known-relays browser ──────────────────────────────────────────────
+  // Browse every relay grain has seen (config seeds + your mailboxes + ones
+  // it's connected to), with live pool status and NIP-11 on expand, and stage
+  // any of them into your lists (then Save & sign that list to publish).
+
+  // Which of the user's lists a relay is currently in — for the row badges.
+  function knownInLists(url) {
+    const u = normWs(url);
+    const out = [];
+    const e = RM.nip65.find((x) => x.url === u);
+    if (e && e.write) out.push("outbox");
+    if (e && e.read) out.push("inbox");
+    ["search", "favorites", "blocked", "dm"].forEach((k) => {
+      if ((RM.lists[k] || []).indexOf(u) >= 0) out.push(k);
+    });
+    return out;
+  }
+
+  function knownNip11(info) {
+    if (!info || !Object.keys(info).length)
+      return `<div class="px-3 pb-2 text-xs text-text-muted">No NIP-11 info advertised.</div>`;
+    const nips = (info.supported_nips || []).join(", ");
+    const lim = info.limitation || {};
+    const flags = [];
+    if (lim.auth_required) flags.push("🔒 AUTH required");
+    if (lim.payment_required) flags.push("💰 paid");
+    if (lim.restricted_writes) flags.push("✍ restricted writes");
+    const rows = [];
+    if (info.name) rows.push(`<div class="font-medium text-text">${esc(info.name)}</div>`);
+    if (info.description) rows.push(`<div>${esc(info.description)}</div>`);
+    if (info.software)
+      rows.push(
+        `<div><span class="text-text-muted">software</span> ${esc(info.software)}${info.version ? " · " + esc(info.version) : ""}</div>`
+      );
+    if (nips) rows.push(`<div><span class="text-text-muted">NIPs</span> ${esc(nips)}</div>`);
+    if (flags.length) rows.push(`<div class="text-warning">${esc(flags.join("  ·  "))}</div>`);
+    return `<div class="px-3 pb-2.5 space-y-0.5 text-xs text-text-secondary">${rows.join("")}</div>`;
+  }
+
+  function knownRow(k) {
+    const inLists = knownInLists(k.url);
+    const dotCls = k.connected ? "bg-success" : k.pinned ? "bg-accent" : "bg-text-muted";
+    const dotTitle = k.connected ? "connected" : k.pinned ? "pinned" : "known";
+    const expanded = !!RM.knownExpanded[k.url];
+    const info = RM.knownInfo[k.url];
+    let detail = "";
+    if (expanded)
+      detail =
+        info === null
+          ? `<div class="px-3 pb-2 text-xs text-text-muted">Loading NIP-11…</div>`
+          : knownNip11(info);
+    const badges = inLists
+      .map(
+        (l) =>
+          `<span class="px-1.5 py-0.5 text-xs rounded bg-surface-inset text-text-secondary">${esc(l)}</span>`
+      )
+      .join("");
+    return (
+      `<div class="border rounded-lg bg-surface-elevated border-border">` +
+      `<div class="flex items-center gap-2 px-3 py-2">` +
+      `<span class="w-2 h-2 rounded-full shrink-0 ${dotCls}" title="${dotTitle}"></span>` +
+      `<a href="${esc(httpish(k.url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm truncate text-text hover:text-accent hover:underline" title="${esc(k.url)}">${esc(shortRelay(k.url))}</a>` +
+      badges +
+      `<select data-known-add="${esc(k.url)}" class="px-1 py-1 text-xs border rounded shrink-0 bg-surface-overlay text-text border-border">` +
+      `<option value="">+ list…</option>` +
+      `<option value="outbox">Outbox</option><option value="inbox">Inbox</option>` +
+      `<option value="search">Search</option><option value="favorites">Favorites</option>` +
+      `<option value="blocked">Blocked</option><option value="dm">DM</option>` +
+      `</select>` +
+      `<button data-known-toggle="${esc(k.url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
+      `</div>` +
+      detail +
+      `</div>`
+    );
+  }
+
+  function renderKnown() {
+    const box = document.getElementById("rm-known-list");
+    if (!box) return;
+    if (!RM.knownLoaded) {
+      box.innerHTML = spinnerRow("Loading known relays…");
+      return;
+    }
+    const q = (RM.knownFilter || "").toLowerCase();
+    const filtered = q
+      ? RM.known.filter((k) => k.url.toLowerCase().indexOf(q) >= 0)
+      : RM.known;
+    if (!filtered.length) {
+      box.innerHTML = emptyRow(q ? "No matches." : "No known relays yet.");
+      return;
+    }
+    // Relevance-first: connected, then pinned, then ones already in your lists,
+    // then the rest alphabetically — so the top of 900+ is actually useful.
+    const ranked = filtered.map((k) => ({
+      k,
+      r: k.connected ? 0 : k.pinned ? 1 : knownInLists(k.url).length ? 2 : 3,
+    }));
+    ranked.sort((a, b) => a.r - b.r || a.k.url.localeCompare(b.k.url));
+    const ordered = ranked.map((x) => x.k);
+    const cap = 150;
+    let html = ordered.slice(0, cap).map(knownRow).join("");
+    if (filtered.length > cap)
+      html += `<div class="px-3 py-1.5 text-xs text-text-muted">+${filtered.length - cap} more — type to filter.</div>`;
+    box.innerHTML = html;
+    box.querySelectorAll("[data-known-toggle]").forEach((b) => {
+      b.onclick = () => rmKnownToggle(b.getAttribute("data-known-toggle"));
+    });
+    box.querySelectorAll("[data-known-add]").forEach((s) => {
+      s.onchange = () => {
+        rmKnownAdd(s.getAttribute("data-known-add"), s.value);
+        s.value = "";
+      };
+    });
+  }
+
+  async function rmKnownToggle(url) {
+    RM.knownExpanded[url] = !RM.knownExpanded[url];
+    if (RM.knownExpanded[url] && RM.knownInfo[url] === undefined) {
+      RM.knownInfo[url] = null; // pending — show the loader
+      renderKnown();
+      try {
+        const r = await fetch("/api/v1/relay-info?url=" + encodeURIComponent(url));
+        RM.knownInfo[url] = r.ok ? await r.json() : {};
+      } catch (_) {
+        RM.knownInfo[url] = {};
+      }
+    }
+    renderKnown();
+  }
+
+  function rmKnownAdd(url, target) {
+    if (!target) return;
+    if (target === "outbox" || target === "inbox") {
+      nip65Upsert(url, target === "outbox" ? "write" : "read"); // re-renders NIP-65
+    } else if (RM.lists[target]) {
+      const u = normWs(url);
+      if (u && RM.lists[target].indexOf(u) < 0) {
+        RM.lists[target].push(u);
+        renderTagList(target);
+      }
+    }
+    renderKnown(); // refresh the which-lists badges on this row
+  }
+
+  window.rmKnownSearch = function (v) {
+    RM.knownFilter = v || "";
+    renderKnown();
+  };
+
   // The Private (10013, NIP-37) list is read-only: NIP-37 keeps relays in the
   // encrypted content (public entries are rare), so this mostly shows the
   // decrypt reveal. Editing/re-encrypting waits for the encrypt side.
@@ -554,6 +708,19 @@
       .catch(() => {
         RM.appLoaded = true;
         renderApp();
+      });
+
+    renderKnown(); // initial spinner
+    fetch("/api/v1/client/known-relays")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        RM.known = Array.isArray(d) ? d : [];
+        RM.knownLoaded = true;
+        renderKnown();
+      })
+      .catch(() => {
+        RM.knownLoaded = true;
+        renderKnown();
       });
   }
 

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -29,6 +29,9 @@
     nip65: [], // [{ url, read, write }]
     lists: { dm: [], search: [], favorites: [], blocked: [] },
     encrypted: {}, // key -> true when the list carries NIP-44 private entries (#100)
+    encryptedContent: {}, // key -> raw encrypted blob; the browser decrypts on demand
+    decrypted: {}, // key -> [urls] once the user clicks Decrypt (read-only reveal)
+    pubkey: "", // session user, for NIP-51 self-decrypt
     loaded: false,
   };
 
@@ -73,13 +76,104 @@
   function emptyRow(text) {
     return `<div class="px-3 py-3 text-sm text-center border border-dashed rounded-lg text-text-muted border-border-strong">${esc(text)}</div>`;
   }
-  // Shown on a NIP-51 list whose event carries NIP-44 private entries grain
-  // can't read yet — so it reads as private rather than empty/broken (#100).
-  function encryptedHint() {
+  // NIP-51 list `.content` is encrypted to the author themselves; try NIP-44
+  // then NIP-04 (per NIP-51). Returns null if neither scheme works. The signer
+  // holds the key — grain only ever passes the opaque blob through (#100).
+  async function decryptContent(signer, selfPubkey, content) {
+    if (signer && signer.nip44 && signer.nip44.decrypt) {
+      try {
+        return await signer.nip44.decrypt(selfPubkey, content);
+      } catch (_) {}
+    }
+    if (signer && signer.nip04 && signer.nip04.decrypt) {
+      try {
+        return await signer.nip04.decrypt(selfPubkey, content);
+      } catch (_) {}
+    }
+    return null;
+  }
+  // Pull relay URLs from a decrypted NIP-51 tag array (["relay", url] / ["r", url]).
+  function parseDecryptedRelays(plain) {
+    let tags;
+    try {
+      tags = JSON.parse(plain);
+    } catch (_) {
+      return null;
+    }
+    if (!Array.isArray(tags)) return null;
+    const out = [];
+    for (const t of tags) {
+      if (Array.isArray(t) && (t[0] === "relay" || t[0] === "r") && typeof t[1] === "string") {
+        const u = normWs(t[1]);
+        if (u && out.indexOf(u) < 0) out.push(u);
+      }
+    }
+    return out;
+  }
+  // The private-entries block for a list whose event carries encrypted content:
+  // a Decrypt button, then the revealed entries (read-only) once decrypted (#100).
+  // Read-only on purpose — re-encrypting on save needs the encrypt side (later).
+  function encryptedSection(key) {
+    const dec = RM.decrypted[key];
+    if (dec) {
+      const rows = dec.length
+        ? dec
+            .map(
+              (u) =>
+                `<div class="flex items-center gap-2 px-3 py-2 text-sm border rounded-lg bg-surface-inset border-border">` +
+                `<span class="shrink-0" title="Private (encrypted) entry">🔒</span>` +
+                `<a href="${esc(httpish(u))}" target="_blank" rel="noopener" class="flex-1 min-w-0 truncate text-text hover:text-accent hover:underline">${esc(shortRelay(u))}</a></div>`
+            )
+            .join("")
+        : `<div class="px-3 py-2 text-xs text-text-muted">No private entries.</div>`;
+      return (
+        `<div class="mt-1.5 space-y-1.5">` +
+        `<div class="px-1 text-xs text-text-muted">🔓 Private entries (read-only — editing comes with the encrypt side):</div>` +
+        rows +
+        `</div>`
+      );
+    }
+    if (!RM.encryptedContent[key]) {
+      return (
+        `<div class="flex items-center gap-2 px-3 py-2 text-xs rounded-lg text-text-muted bg-surface-inset">` +
+        `🔒 This list has encrypted (private) entries.</div>`
+      );
+    }
     return (
-      `<div class="flex items-center gap-2 px-3 py-2 text-xs rounded-lg text-text-muted bg-surface-inset">` +
-      `🔒 This list has encrypted (private) entries — decrypt support coming.</div>`
+      `<div class="flex items-center justify-between gap-2 px-3 py-2 text-xs rounded-lg text-text-muted bg-surface-inset">` +
+      `<span>🔒 This list has encrypted (private) entries.</span>` +
+      `<button data-rm-decrypt="${esc(key)}" class="px-2 py-1 rounded shrink-0 text-text bg-surface-overlay hover:bg-surface-hover">🔓 Decrypt</button>` +
+      `</div>`
     );
+  }
+  // Decrypt a list's private entries with the user's signer and reveal them.
+  async function rmDecrypt(key) {
+    const content = RM.encryptedContent[key];
+    if (!content) return;
+    if (typeof window.restoreSigner === "function") {
+      try {
+        await window.restoreSigner();
+      } catch (_) {}
+    }
+    const signer = window.grainSigner;
+    if (!signer) {
+      setStatus("rm-" + key + "-status", "Signer unavailable — reconnect to decrypt.");
+      return;
+    }
+    setStatus("rm-" + key + "-status", "Decrypting…");
+    const plain = await decryptContent(signer, RM.pubkey, content);
+    if (plain == null) {
+      setStatus("rm-" + key + "-status", "Couldn't decrypt — signer declined or no NIP-44 support.");
+      return;
+    }
+    const urls = parseDecryptedRelays(plain);
+    if (urls == null) {
+      setStatus("rm-" + key + "-status", "Decrypted, but couldn't parse the entries.");
+      return;
+    }
+    RM.decrypted[key] = urls;
+    setStatus("rm-" + key + "-status", "");
+    renderTagList(key);
   }
   function relayRow(url, removeAttr) {
     return (
@@ -129,7 +223,7 @@
       : enc
       ? ""
       : emptyRow("None yet.");
-    if (enc) html += encryptedHint();
+    if (enc) html += encryptedSection(key);
     box.innerHTML = html;
     box.querySelectorAll("[data-rm]").forEach((b) => {
       b.onclick = () => {
@@ -137,6 +231,9 @@
         RM.lists[key] = RM.lists[key].filter((x) => x !== u);
         renderTagList(key);
       };
+    });
+    box.querySelectorAll("[data-rm-decrypt]").forEach((b) => {
+      b.onclick = () => rmDecrypt(b.getAttribute("data-rm-decrypt"));
     });
   }
 
@@ -313,6 +410,8 @@
           RM.lists.favorites = d.favorites || [];
           RM.lists.blocked = d.blocked || [];
           RM.encrypted = d.encrypted || {};
+          RM.encryptedContent = d.encrypted_content || {};
+          RM.pubkey = d.pubkey || "";
         }
         RM.loaded = true;
         renderAll();
@@ -344,6 +443,8 @@
           const key = map[m.kind];
           RM.lists[key] = d[key] || [];
           RM.encrypted = d.encrypted || RM.encrypted;
+          RM.encryptedContent = d.encrypted_content || RM.encryptedContent;
+          delete RM.decrypted[key]; // changed elsewhere — re-show the Decrypt button
           renderTagList(key);
         }
       })

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -17,12 +17,15 @@
     { key: "favorites", kind: 10012 },
     { key: "blocked", kind: 10006 },
   ];
-  // App-relay categories not yet wired (rendered as "coming soon").
-  const COMING = [
-    ["Indexer", "seed", "Seed relays grain uses to discover everyone's relay lists."],
-    ["Broadcast", "local", "Event blasters — forward your posts out to many relays."],
-    ["Local", "local", "Same-device / LAN relays, preferred for speed."],
-    ["Trusted", "local", "The only relays grain signs NIP-42 AUTH for."],
+  // App relays — local session preferences (seeded from the operator's config),
+  // edited here and saved to /api/v1/client/app-relays. Indexer + Broadcast affect
+  // routing now; Local + Trusted are stored but inert (Local routing preference and
+  // Trusted NIP-42 AUTH are follow-ups).
+  const APP_ROLES = [
+    { key: "indexer", title: "Indexer", badge: "seed", active: true, note: "Seed relays grain uses to discover everyone's relay lists." },
+    { key: "broadcast", title: "Broadcast", badge: "blast", active: true, note: "Event blasters — your posts mirror out to these too." },
+    { key: "local", title: "Local", badge: "local", active: false, note: "Same-device / LAN relays. Stored now; routing preference coming." },
+    { key: "trusted", title: "Trusted", badge: "auth", active: false, note: "The only relays grain will sign NIP-42 AUTH for. Stored now; AUTH coming (#101)." },
   ];
 
   const RM = {
@@ -32,6 +35,8 @@
     encryptedContent: {}, // key -> raw encrypted blob; the browser decrypts on demand
     decrypted: {}, // key -> [urls] once the user clicks Decrypt (read-only reveal)
     pubkey: "", // session user, for NIP-51 self-decrypt
+    app: { indexer: [], broadcast: [], local: [], trusted: [] }, // local-role prefs
+    appLoaded: false,
     loaded: false,
   };
 
@@ -237,18 +242,100 @@
     });
   }
 
+  function appRow(key, url) {
+    return (
+      `<div class="flex items-center gap-2.5 px-3 py-2 border rounded-lg bg-surface-elevated border-border">` +
+      `<a href="${esc(httpish(url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(shortRelay(url))}</a>` +
+      `<button data-app-remove="${esc(url)}" data-app-key="${esc(key)}" class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Remove">×</button>` +
+      `</div>`
+    );
+  }
+
   function renderApp() {
     const box = document.getElementById("rm-app-relays");
     if (!box) return;
-    box.innerHTML = COMING.map(
-      ([title, badge, note]) =>
-        `<div class="opacity-60"><div class="flex items-center gap-2">` +
-        `<span class="text-sm font-medium text-text">${esc(title)}</span>` +
-        `<span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">${esc(badge)}</span>` +
-        `<span class="px-2 py-0.5 ml-auto text-xs rounded bg-surface-inset text-text-muted">coming soon</span></div>` +
-        `<p class="mt-0.5 text-xs text-text-muted">${esc(note)}</p></div>`
-    ).join("");
+    if (!RM.appLoaded) {
+      box.innerHTML = spinnerRow("Fetching…");
+      return;
+    }
+    box.innerHTML =
+      APP_ROLES.map((rr) => {
+        const list = RM.app[rr.key] || [];
+        const rows = list.length
+          ? list.map((u) => appRow(rr.key, u)).join("")
+          : `<div class="px-3 py-2 text-xs text-text-muted">None.</div>`;
+        return (
+          `<div class="${rr.active ? "" : "opacity-70"}">` +
+          `<div class="flex items-center gap-2">` +
+          `<span class="text-sm font-medium text-text">${esc(rr.title)}</span>` +
+          `<span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">${esc(rr.badge)}</span>` +
+          (rr.active ? "" : `<span class="px-2 py-0.5 ml-auto text-xs rounded bg-surface-inset text-text-muted">stored · inert</span>`) +
+          `</div>` +
+          `<p class="mt-0.5 mb-1.5 text-xs text-text-muted">${esc(rr.note)}</p>` +
+          `<div class="space-y-1.5">${rows}</div>` +
+          `<div class="flex gap-2 mt-2">` +
+          `<input data-app-input="${esc(rr.key)}" type="text" placeholder="Add a relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />` +
+          `<button data-app-add="${esc(rr.key)}" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>` +
+          `</div></div>`
+        );
+      }).join("") +
+      `<div class="flex items-center justify-between gap-3 pt-3 mt-1 border-t border-border">` +
+      `<span class="text-xs text-text-muted">Session preferences — saved to grain, not published as events.</span>` +
+      `<button onclick="rmAppSave()" class="px-4 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save</button>` +
+      `</div>` +
+      `<p id="rm-app-status" class="mt-1 text-xs text-right text-text-secondary"></p>`;
+    box.querySelectorAll("[data-app-add]").forEach((b) => {
+      b.onclick = () => {
+        const key = b.getAttribute("data-app-add");
+        const inp = box.querySelector('[data-app-input="' + key + '"]');
+        if (inp && inp.value.trim()) {
+          rmAppAdd(key, inp.value);
+          inp.value = "";
+        }
+      };
+    });
+    box.querySelectorAll("[data-app-remove]").forEach((b) => {
+      b.onclick = () => rmAppRemove(b.getAttribute("data-app-key"), b.getAttribute("data-app-remove"));
+    });
   }
+
+  function rmAppAdd(key, url) {
+    const u = normWs(url);
+    if (!u || !RM.app[key]) return;
+    if (RM.app[key].indexOf(u) < 0) RM.app[key].push(u);
+    renderApp();
+  }
+  function rmAppRemove(key, url) {
+    if (!RM.app[key]) return;
+    RM.app[key] = RM.app[key].filter((x) => x !== url);
+    renderApp();
+  }
+  async function rmAppSave() {
+    setStatus("rm-app-status", "Saving…");
+    try {
+      const resp = await fetch("/api/v1/client/app-relays", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(RM.app),
+      });
+      if (!resp.ok) {
+        setStatus("rm-app-status", "Save failed: " + (await resp.text()));
+        return;
+      }
+      const d = await resp.json();
+      RM.app = {
+        indexer: d.indexer || [],
+        broadcast: d.broadcast || [],
+        local: d.local || [],
+        trusted: d.trusted || [],
+      };
+      setStatus("rm-app-status", "✓ Saved.");
+      renderApp();
+    } catch (e) {
+      setStatus("rm-app-status", "Save failed.");
+    }
+  }
+  window.rmAppSave = rmAppSave;
 
   // The Private (10013, NIP-37) list is read-only: NIP-37 keeps relays in the
   // encrypted content (public entries are rare), so this mostly shows the
@@ -448,6 +535,25 @@
       .catch(() => {
         RM.loaded = true;
         renderAll();
+      });
+
+    fetch("/api/v1/client/app-relays")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d) {
+          RM.app = {
+            indexer: d.indexer || [],
+            broadcast: d.broadcast || [],
+            local: d.local || [],
+            trusted: d.trusted || [],
+          };
+        }
+        RM.appLoaded = true;
+        renderApp();
+      })
+      .catch(() => {
+        RM.appLoaded = true;
+        renderApp();
       });
   }
 

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -40,8 +40,11 @@
     known: [], // [{ url, connected, pinned, leased }] — the known-relays browser
     knownLoaded: false,
     knownFilter: "",
+    knownMap: {}, // url -> { connected, pinned } — status lookup for in-list rows
     knownInfo: {}, // url -> NIP-11 object | null(pending)
-    knownExpanded: {}, // url -> true
+    knownExpanded: {}, // url -> true (shared by the browser AND in-list rows)
+    knownSort: "relevance", // "relevance" | "ping"
+    knownPing: {}, // url -> ms | -1(unreachable) | "pending"
     loaded: false,
   };
 
@@ -185,11 +188,56 @@
     setStatus("rm-" + key + "-status", "");
     renderTagList(key);
   }
+  // Status dot shared by in-list rows and the known-relays browser.
+  function dotMarkup(connected, pinned) {
+    const cls = connected ? "bg-success" : pinned ? "bg-accent" : "bg-text-muted";
+    const title = connected ? "connected" : pinned ? "pinned" : "known";
+    return `<span class="w-2 h-2 rounded-full shrink-0 ${cls}" title="${title}"></span>`;
+  }
+  // Status dot for an in-list relay, looked up from the known-relays pool status.
+  function relayStatusDot(url) {
+    const st = RM.knownMap[normWs(url)] || RM.knownMap[url] || {};
+    return dotMarkup(st.connected, st.pinned);
+  }
+  // The NIP-11 detail block for an expanded relay row — shared everywhere.
+  // Lazily filled by rmRelayInfoToggle.
+  function relayInfoDetailHTML(url) {
+    if (!RM.knownExpanded[url]) return "";
+    const info = RM.knownInfo[url];
+    return info === null
+      ? `<div class="px-3 pb-2 text-xs text-text-muted">Loading NIP-11…</div>`
+      : knownNip11(info);
+  }
+  // Toggle a relay's NIP-11 detail (shared by in-list rows + the browser).
+  // Fetches lazily, then re-renders both so the row updates wherever it appears.
+  async function rmRelayInfoToggle(url) {
+    RM.knownExpanded[url] = !RM.knownExpanded[url];
+    if (RM.knownExpanded[url] && RM.knownInfo[url] === undefined) {
+      RM.knownInfo[url] = null; // pending
+      renderAll();
+      renderKnown();
+      try {
+        const r = await fetch("/api/v1/relay-info?url=" + encodeURIComponent(url));
+        RM.knownInfo[url] = r.ok ? await r.json() : {};
+      } catch (_) {
+        RM.knownInfo[url] = {};
+      }
+    }
+    renderAll();
+    renderKnown();
+  }
+
   function relayRow(url, removeAttr) {
+    const expanded = !!RM.knownExpanded[url];
     return (
-      `<div class="flex items-center gap-2.5 px-3 py-2 border rounded-lg bg-surface-elevated border-border">` +
+      `<div class="border rounded-lg bg-surface-elevated border-border">` +
+      `<div class="flex items-center gap-2.5 px-3 py-2">` +
+      relayStatusDot(url) +
       `<a href="${esc(httpish(url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm font-medium truncate text-text hover:text-accent hover:underline">${esc(shortRelay(url))}</a>` +
+      `<button data-relay-info="${esc(url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
       `<button ${removeAttr} class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Remove">×</button>` +
+      `</div>` +
+      relayInfoDetailHTML(url) +
       `</div>`
     );
   }
@@ -216,6 +264,14 @@
     });
     ib.querySelectorAll("[data-ib]").forEach((b) => {
       b.onclick = () => nip65Remove(b.getAttribute("data-ib"), "read");
+    });
+    wireRelayInfo(ob);
+    wireRelayInfo(ib);
+  }
+  // Wire the ▾ NIP-11 expanders within a list container.
+  function wireRelayInfo(box) {
+    box.querySelectorAll("[data-relay-info]").forEach((b) => {
+      b.onclick = () => rmRelayInfoToggle(b.getAttribute("data-relay-info"));
     });
   }
 
@@ -245,6 +301,7 @@
     box.querySelectorAll("[data-rm-decrypt]").forEach((b) => {
       b.onclick = () => rmDecrypt(b.getAttribute("data-rm-decrypt"));
     });
+    wireRelayInfo(box);
   }
 
   function appRow(key, url) {
@@ -381,19 +438,22 @@
     return `<div class="px-3 pb-2.5 space-y-0.5 text-xs text-text-secondary">${rows.join("")}</div>`;
   }
 
+  // A latency badge (TCP-connect ms) once a relay has been pinged — green/amber/
+  // red by speed, "—" if unreachable, a spinner while in flight.
+  function pingBadge(url) {
+    const p = RM.knownPing[url];
+    if (p === undefined) return "";
+    if (p === "pending")
+      return `<span class="inline-block w-3 h-3 border rounded-full shrink-0 border-text-secondary border-t-transparent animate-spin" title="pinging…"></span>`;
+    if (p === -1)
+      return `<span class="text-xs shrink-0 text-text-muted" title="unreachable">—</span>`;
+    const cls = p < 150 ? "text-success" : p < 500 ? "text-warning" : "text-danger";
+    return `<span class="font-mono text-xs shrink-0 ${cls}" title="TCP connect latency">${p}ms</span>`;
+  }
+
   function knownRow(k) {
-    const inLists = knownInLists(k.url);
-    const dotCls = k.connected ? "bg-success" : k.pinned ? "bg-accent" : "bg-text-muted";
-    const dotTitle = k.connected ? "connected" : k.pinned ? "pinned" : "known";
     const expanded = !!RM.knownExpanded[k.url];
-    const info = RM.knownInfo[k.url];
-    let detail = "";
-    if (expanded)
-      detail =
-        info === null
-          ? `<div class="px-3 pb-2 text-xs text-text-muted">Loading NIP-11…</div>`
-          : knownNip11(info);
-    const badges = inLists
+    const badges = knownInLists(k.url)
       .map(
         (l) =>
           `<span class="px-1.5 py-0.5 text-xs rounded bg-surface-inset text-text-secondary">${esc(l)}</span>`
@@ -402,8 +462,9 @@
     return (
       `<div class="border rounded-lg bg-surface-elevated border-border">` +
       `<div class="flex items-center gap-2 px-3 py-2">` +
-      `<span class="w-2 h-2 rounded-full shrink-0 ${dotCls}" title="${dotTitle}"></span>` +
+      dotMarkup(k.connected, k.pinned) +
       `<a href="${esc(httpish(k.url))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm truncate text-text hover:text-accent hover:underline" title="${esc(k.url)}">${esc(shortRelay(k.url))}</a>` +
+      pingBadge(k.url) +
       badges +
       `<select data-known-add="${esc(k.url)}" class="px-1 py-1 text-xs border rounded shrink-0 bg-surface-overlay text-text border-border">` +
       `<option value="">+ list…</option>` +
@@ -411,27 +472,32 @@
       `<option value="search">Search</option><option value="favorites">Favorites</option>` +
       `<option value="blocked">Blocked</option><option value="dm">DM</option>` +
       `</select>` +
-      `<button data-known-toggle="${esc(k.url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
+      `<button data-relay-info="${esc(k.url)}" class="px-1 leading-none shrink-0 text-text-secondary hover:text-text" title="NIP-11 info">${expanded ? "▴" : "▾"}</button>` +
       `</div>` +
-      detail +
+      relayInfoDetailHTML(k.url) +
       `</div>`
     );
   }
 
-  function renderKnown() {
-    const box = document.getElementById("rm-known-list");
-    if (!box) return;
-    if (!RM.knownLoaded) {
-      box.innerHTML = spinnerRow("Loading known relays…");
-      return;
-    }
+  // Ping-sort rank: measured latency first (ascending), unknown/pending in the
+  // middle, unreachable last.
+  function pingRank(url) {
+    const p = RM.knownPing[url];
+    if (typeof p === "number") return p < 0 ? 2e6 : p;
+    return 1e6;
+  }
+
+  // The filtered known set in the active sort order — shared by render and the
+  // ping pass so "visible" means the same thing in both.
+  function knownOrdered() {
     const q = (RM.knownFilter || "").toLowerCase();
     const filtered = q
       ? RM.known.filter((k) => k.url.toLowerCase().indexOf(q) >= 0)
       : RM.known;
-    if (!filtered.length) {
-      box.innerHTML = emptyRow(q ? "No matches." : "No known relays yet.");
-      return;
+    if (RM.knownSort === "ping") {
+      return filtered
+        .slice()
+        .sort((a, b) => pingRank(a.url) - pingRank(b.url) || a.url.localeCompare(b.url));
     }
     // Relevance-first: connected, then pinned, then ones already in your lists,
     // then the rest alphabetically — so the top of 900+ is actually useful.
@@ -440,15 +506,29 @@
       r: k.connected ? 0 : k.pinned ? 1 : knownInLists(k.url).length ? 2 : 3,
     }));
     ranked.sort((a, b) => a.r - b.r || a.k.url.localeCompare(b.k.url));
-    const ordered = ranked.map((x) => x.k);
-    const cap = 150;
-    let html = ordered.slice(0, cap).map(knownRow).join("");
-    if (filtered.length > cap)
-      html += `<div class="px-3 py-1.5 text-xs text-text-muted">+${filtered.length - cap} more — type to filter.</div>`;
+    return ranked.map((x) => x.k);
+  }
+
+  const KNOWN_CAP = 150; // rows rendered at once
+  const PING_BATCH = 50; // relays pinged per pass
+
+  function renderKnown() {
+    const box = document.getElementById("rm-known-list");
+    if (!box) return;
+    if (!RM.knownLoaded) {
+      box.innerHTML = spinnerRow("Loading known relays…");
+      return;
+    }
+    const ordered = knownOrdered();
+    if (!ordered.length) {
+      box.innerHTML = emptyRow(RM.knownFilter ? "No matches." : "No known relays yet.");
+      return;
+    }
+    let html = ordered.slice(0, KNOWN_CAP).map(knownRow).join("");
+    if (ordered.length > KNOWN_CAP)
+      html += `<div class="px-3 py-1.5 text-xs text-text-muted">+${ordered.length - KNOWN_CAP} more — type to filter.</div>`;
     box.innerHTML = html;
-    box.querySelectorAll("[data-known-toggle]").forEach((b) => {
-      b.onclick = () => rmKnownToggle(b.getAttribute("data-known-toggle"));
-    });
+    wireRelayInfo(box); // shared ▾ NIP-11 toggles
     box.querySelectorAll("[data-known-add]").forEach((s) => {
       s.onchange = () => {
         rmKnownAdd(s.getAttribute("data-known-add"), s.value);
@@ -457,17 +537,26 @@
     });
   }
 
-  async function rmKnownToggle(url) {
-    RM.knownExpanded[url] = !RM.knownExpanded[url];
-    if (RM.knownExpanded[url] && RM.knownInfo[url] === undefined) {
-      RM.knownInfo[url] = null; // pending — show the loader
-      renderKnown();
-      try {
-        const r = await fetch("/api/v1/relay-info?url=" + encodeURIComponent(url));
-        RM.knownInfo[url] = r.ok ? await r.json() : {};
-      } catch (_) {
-        RM.knownInfo[url] = {};
-      }
+  // Ping the relays currently in view we haven't measured yet, then re-render
+  // (which re-sorts when in "fastest" mode).
+  async function rmKnownPingVisible() {
+    const urls = knownOrdered()
+      .slice(0, PING_BATCH)
+      .map((k) => k.url)
+      .filter((u) => RM.knownPing[u] === undefined);
+    if (!urls.length) return;
+    urls.forEach((u) => (RM.knownPing[u] = "pending"));
+    renderKnown();
+    try {
+      const r = await fetch("/api/v1/relays/ping", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ urls }),
+      });
+      const d = r.ok ? await r.json() : {};
+      urls.forEach((u) => (RM.knownPing[u] = typeof d[u] === "number" ? d[u] : -1));
+    } catch (_) {
+      urls.forEach((u) => (RM.knownPing[u] = -1));
     }
     renderKnown();
   }
@@ -486,9 +575,16 @@
     renderKnown(); // refresh the which-lists badges on this row
   }
 
+  window.rmKnownSort = function (v) {
+    RM.knownSort = v === "ping" ? "ping" : "relevance";
+    renderKnown();
+    if (RM.knownSort === "ping") rmKnownPingVisible();
+  };
+
   window.rmKnownSearch = function (v) {
     RM.knownFilter = v || "";
     renderKnown();
+    if (RM.knownSort === "ping") rmKnownPingVisible();
   };
 
   // The Private (10013, NIP-37) list is read-only: NIP-37 keeps relays in the
@@ -715,8 +811,13 @@
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         RM.known = Array.isArray(d) ? d : [];
+        RM.knownMap = {};
+        RM.known.forEach(
+          (k) => (RM.knownMap[k.url] = { connected: k.connected, pinned: k.pinned })
+        );
         RM.knownLoaded = true;
         renderKnown();
+        renderAll(); // in-list rows now pick up their status dots
       })
       .catch(() => {
         RM.knownLoaded = true;

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -25,7 +25,6 @@
     { key: "indexer", title: "Indexer", badge: "seed", active: true, note: "Seed relays grain uses to discover everyone's relay lists." },
     { key: "broadcast", title: "Broadcast", badge: "blast", active: true, note: "Every event you publish is also mirrored here — and these are blast/broadcast relays that re-send it onward to many other relays." },
     { key: "local", title: "Local", badge: "local", active: false, note: "Same-device / LAN relays. Stored now; routing preference coming." },
-    { key: "trusted", title: "Trusted", badge: "auth", active: false, note: "The only relays grain will sign NIP-42 AUTH for. Stored now; AUTH coming (#101)." },
   ];
 
   const RM = {
@@ -45,6 +44,8 @@
     knownExpanded: {}, // url -> true (shared by the browser AND in-list rows)
     knownSort: "relevance", // "relevance" | "ping"
     knownPing: {}, // url -> ms | -1(unreachable) | "pending"
+    auth: [], // [{ relay, challenge, authed, at }] — NIP-42 AUTH requests
+    authLoaded: false,
     loaded: false,
   };
 
@@ -407,6 +408,127 @@
     }
   }
   window.rmAppSave = rmAppSave;
+
+  // ── NIP-42 AUTH requests ──────────────────────────────────────────────
+  // Relays that challenged grain for AUTH this session. Authenticate signs a
+  // kind-22242 event with the browser signer; grain relays it on the same
+  // connection. A relay stays trusted for the session once answered.
+
+  function authRow(a) {
+    const dotCls = a.authed ? "bg-success" : "bg-warning";
+    const status = a.authed
+      ? `<span class="px-1.5 py-0.5 text-xs rounded shrink-0 bg-surface-inset text-success">trusted · session</span>`
+      : `<span class="px-1.5 py-0.5 text-xs rounded shrink-0 bg-surface-inset text-warning">challenged</span>`;
+    const authBtn = a.authed
+      ? ""
+      : `<button data-auth-go="${esc(a.relay)}" class="px-2.5 py-1 text-xs rounded shrink-0 text-text-on-accent bg-accent hover:opacity-80">Authenticate</button>`;
+    return (
+      `<div class="flex items-center gap-2 px-3 py-2 border rounded-lg bg-surface-elevated border-border">` +
+      `<span class="w-2 h-2 rounded-full shrink-0 ${dotCls}" title="${a.authed ? "authed" : "challenged"}"></span>` +
+      `<a href="${esc(httpish(a.relay))}" target="_blank" rel="noopener" class="flex-1 min-w-0 text-sm truncate text-text hover:text-accent hover:underline">${esc(shortRelay(a.relay))}</a>` +
+      status +
+      authBtn +
+      `<button data-auth-remove="${esc(a.relay)}" class="px-1 text-lg leading-none shrink-0 text-text-muted hover:text-danger" title="Forget for this session">×</button>` +
+      `</div>`
+    );
+  }
+
+  function renderAuth() {
+    const box = document.getElementById("rm-auth-list");
+    if (!box) return;
+    if (!RM.authLoaded) {
+      box.innerHTML = spinnerRow("Checking…");
+      return;
+    }
+    if (!RM.auth.length) {
+      box.innerHTML = emptyRow("No relays have requested authentication this session.");
+      return;
+    }
+    box.innerHTML = RM.auth
+      .slice()
+      .sort((a, b) => Number(a.authed) - Number(b.authed) || a.relay.localeCompare(b.relay))
+      .map(authRow)
+      .join("");
+    box.querySelectorAll("[data-auth-go]").forEach((b) => {
+      b.onclick = () => rmAuthenticate(b.getAttribute("data-auth-go"));
+    });
+    box.querySelectorAll("[data-auth-remove]").forEach((b) => {
+      b.onclick = () => rmAuthRemove(b.getAttribute("data-auth-remove"));
+    });
+  }
+
+  function rmAuthRefresh() {
+    fetch("/api/v1/client/auth-requests")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        RM.auth = Array.isArray(d) ? d : [];
+        RM.authLoaded = true;
+        renderAuth();
+      })
+      .catch(() => {
+        RM.authLoaded = true;
+        renderAuth();
+      });
+  }
+
+  async function rmAuthenticate(relay) {
+    const a = RM.auth.find((x) => x.relay === relay);
+    if (!a || !a.challenge) {
+      rmAuthRefresh();
+      return;
+    }
+    if (typeof window.restoreSigner === "function") {
+      try {
+        await window.restoreSigner();
+      } catch (_) {}
+    }
+    const signer = window.grainSigner;
+    if (!signer || typeof signer.signEvent !== "function") {
+      setStatus("rm-auth-status", "Signer unavailable — reconnect to authenticate.");
+      return;
+    }
+    setStatus("rm-auth-status", "Signing AUTH for " + shortRelay(relay) + "…");
+    let signed;
+    try {
+      signed = await signer.signEvent({
+        kind: 22242,
+        created_at: Math.floor(Date.now() / 1000),
+        content: "",
+        tags: [
+          ["relay", relay],
+          ["challenge", a.challenge],
+        ],
+      });
+    } catch (_) {
+      setStatus("rm-auth-status", "Signing declined.");
+      return;
+    }
+    try {
+      const resp = await fetch("/api/v1/client/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ relay: relay, event: signed }),
+      });
+      const d = resp.ok ? await resp.json() : {};
+      setStatus(
+        "rm-auth-status",
+        d.success ? "✓ Authenticated to " + shortRelay(relay) + "." : "AUTH failed: " + (d.error || "relay unreachable")
+      );
+    } catch (_) {
+      setStatus("rm-auth-status", "AUTH request failed.");
+    }
+    rmAuthRefresh();
+  }
+
+  function rmAuthRemove(relay) {
+    fetch("/api/v1/client/auth/remove", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ relay: relay }),
+    })
+      .catch(function () {})
+      .finally(rmAuthRefresh);
+  }
 
   // ── Known-relays browser ──────────────────────────────────────────────
   // Browse every relay grain has seen (config seeds + your mailboxes + ones
@@ -788,8 +910,13 @@
     renderApp();
     renderAll(); // spinners while loaded === false
     refreshOverview();
+    renderAuth(); // initial spinner
+    rmAuthRefresh();
     if (window.__rmOverviewTimer) clearInterval(window.__rmOverviewTimer);
-    window.__rmOverviewTimer = setInterval(refreshOverview, 5000);
+    window.__rmOverviewTimer = setInterval(() => {
+      refreshOverview();
+      rmAuthRefresh(); // AUTH challenges arrive async during pool activity
+    }, 5000);
 
     fetch("/api/v1/user/relay-lists")
       .then((r) => (r.ok ? r.json() : null))

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -323,5 +323,33 @@
       });
   }
 
+  // Live-sync (#87): when one of our relay lists changes — here or in another
+  // client — re-pull just that list so the page stays current without a reload.
+  // Re-wire on each load (the handler closes over this module's state).
+  if (window.__rmStreamHandler)
+    window.removeEventListener("grain:stream", window.__rmStreamHandler);
+  window.__rmStreamHandler = function (e) {
+    const m = e.detail || {};
+    if (m.type !== "list-updated") return;
+    const map = { 10050: "dm", 10007: "search", 10012: "favorites", 10006: "blocked" };
+    if (m.kind !== 10002 && !map[m.kind]) return;
+    fetch("/api/v1/user/relay-lists")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!d) return;
+        if (m.kind === 10002) {
+          RM.nip65 = d.nip65 || [];
+          renderNip65();
+        } else {
+          const key = map[m.kind];
+          RM.lists[key] = d[key] || [];
+          RM.encrypted = d.encrypted || RM.encrypted;
+          renderTagList(key);
+        }
+      })
+      .catch(function () {});
+  };
+  window.addEventListener("grain:stream", window.__rmStreamHandler);
+
   init();
 })();

--- a/www/static/js/relay-manager.js
+++ b/www/static/js/relay-manager.js
@@ -345,7 +345,7 @@
           `<p class="mt-0.5 mb-1.5 text-xs text-text-muted">${esc(rr.note)}</p>` +
           `<div class="space-y-1.5">${rows}</div>` +
           `<div class="flex gap-2 mt-2">` +
-          `<input data-app-input="${esc(rr.key)}" type="text" placeholder="Add a relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />` +
+          `<input data-app-input="${esc(rr.key)}" type="text" placeholder="Add a relay…" list="rm-known-options" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />` +
           `<button data-app-add="${esc(rr.key)}" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>` +
           `</div></div>`
         );
@@ -424,6 +424,23 @@
       if ((RM.lists[k] || []).indexOf(u) >= 0) out.push(k);
     });
     return out;
+  }
+
+  // Fill the shared <datalist> that every "add a relay" input autocompletes
+  // from. Connected/pinned float up so the native dropdown's top matches are the
+  // useful ones.
+  function populateKnownDatalist() {
+    const dl = document.getElementById("rm-known-options");
+    if (!dl) return;
+    dl.innerHTML = RM.known
+      .slice()
+      .sort((a, b) => {
+        const ra = a.connected ? 0 : a.pinned ? 1 : 2;
+        const rb = b.connected ? 0 : b.pinned ? 1 : 2;
+        return ra - rb || a.url.localeCompare(b.url);
+      })
+      .map((k) => `<option value="${esc(k.url)}"></option>`)
+      .join("");
   }
 
   function knownNip11(info) {
@@ -825,6 +842,7 @@
           (k) => (RM.knownMap[k.url] = { connected: k.connected, pinned: k.pinned })
         );
         RM.knownLoaded = true;
+        populateKnownDatalist(); // autocomplete source for every add-relay input
         renderKnown();
         renderAll(); // in-list rows now pick up their status dots
       })

--- a/www/static/js/settings.js
+++ b/www/static/js/settings.js
@@ -94,7 +94,28 @@ function displaySettings(data) {
 
   // Update key information
   updateKeyInformation(data);
+
+  // If we were sent here to land on a specific section (e.g. "Manage relays"
+  // from the header), scroll to it now that the content is visible.
+  scrollToSettingsTarget();
 }
+
+// Scroll to the section named in window.__grainScrollTarget (set by whatever
+// navigated here), once. Called when the settings content becomes visible —
+// from displaySettings and from the page's watchdog — so it works whether the
+// cache fetch resolved or the watchdog revealed the page.
+function scrollToSettingsTarget() {
+  const id = window.__grainScrollTarget;
+  if (!id) return;
+  window.__grainScrollTarget = null;
+  const el = document.getElementById(id);
+  if (!el) return;
+  // Let layout settle (sections render async) before scrolling.
+  requestAnimationFrame(() => {
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  });
+}
+window.scrollToSettingsTarget = scrollToSettingsTarget;
 
 // Tab switching functionality - updated for new tab names
 function switchRelayTab(tabName) {

--- a/www/static/js/theme.js
+++ b/www/static/js/theme.js
@@ -102,6 +102,10 @@
     }
 
     function openPanel() {
+      // Close any other open header dropdown (profile, relay pool).
+      window.dispatchEvent(
+        new CustomEvent("grain:dropdown-open", { detail: "theme" })
+      );
       panelEl.classList.remove("hidden");
       setTimeout(function () {
         document.addEventListener("click", clickOutside);
@@ -111,6 +115,10 @@
       panelEl.classList.add("hidden");
       document.removeEventListener("click", clickOutside);
     }
+    // When another header dropdown opens, close this one.
+    window.addEventListener("grain:dropdown-open", function (e) {
+      if (e.detail !== "theme") closePanel();
+    });
     function clickOutside(e) {
       if (!panelEl.contains(e.target) && !buttonEl.contains(e.target)) {
         closePanel();

--- a/www/sw.js
+++ b/www/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "grain-v5"; // Bumped so activate purges poisoned older caches
+const CACHE_NAME = "grain-v6"; // Bumped so activate purges poisoned older caches
 const STATIC_CACHE_URLS = [
   "/",
   "/static/js/navigation.js",

--- a/www/views/admin-sections/client.html
+++ b/www/views/admin-sections/client.html
@@ -1,0 +1,117 @@
+{{define "admin-client"}}
+<!-- Built-in Nostr client config (#80) + client-tag policy (#99). Enclosing
+     <details> supplies data-section="client" and data-method="grain_updateclient".
+     Dot is cfgType.ClientConfig.
+
+     index_relays seed the client library's discovery (NIP-65 mailbox + metadata
+     lookups). The client_tag block controls grain's NIP-89 `client` tag default;
+     a logged-in user can still opt out for their own events via Settings. -->
+<form class="grid gap-4 mt-3 sm:grid-cols-2" autocomplete="off">
+  <!-- ── Client tag (#99) ── -->
+  <label class="flex items-start gap-3 sm:col-span-2 p-3 rounded bg-surface-elevated">
+    <input
+      type="checkbox"
+      name="client_tag.enabled"
+      data-shape="bool"
+      {{if .ClientTag.Enabled}}checked{{end}}
+      class="w-4 h-4 mt-0.5 accent-accent"
+    />
+    <span class="flex-1">
+      <span class="block text-sm font-medium text-text">Stamp grain's client tag (default)</span>
+      <span class="block mt-1 text-xs text-text-secondary">
+        When on, events grain authors carry a <span class="font-mono">client</span> tag
+        with the name below. Foreign client tags are always stripped. Users can
+        override this for their own events on the settings page.
+      </span>
+    </span>
+  </label>
+  <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+    <span class="font-medium text-text-secondary">Client tag name</span>
+    <input
+      type="text"
+      name="client_tag.name"
+      value="{{.ClientTag.Name}}"
+      placeholder="grain"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text font-mono"
+    />
+  </label>
+
+  <!-- ── Discovery: index relays ── -->
+  <div class="flex flex-col gap-2 text-sm sm:col-span-2">
+    <span class="font-medium text-text-secondary">Index relays</span>
+    <span class="text-xs text-text-secondary">
+      Discovery seeds — NIP-65 mailbox lookups and profile metadata are resolved
+      through these when no per-user relay set is known.
+    </span>
+    <div data-list="index_relays" data-list-shape="ws_url" class="flex flex-col gap-2">
+      <div class="flex gap-2">
+        <input
+          type="text"
+          data-list-input
+          placeholder="wss://relay.example.com"
+          class="flex-1 px-3 py-2 rounded bg-surface-elevated border border-border text-text font-mono"
+        />
+        <button
+          type="button"
+          data-list-add
+          class="px-3 py-2 text-sm rounded bg-accent text-accent-fg hover:bg-accent-hover"
+        >Add</button>
+      </div>
+      <div data-list-items class="flex flex-col gap-1">
+        {{range .IndexRelays}}
+        <div data-list-item class="flex items-center gap-2 py-1 px-2 rounded bg-surface-elevated">
+          <input type="hidden" name="index_relays" data-shape="string_names" value="{{.}}" />
+          <span class="font-mono text-sm text-text truncate flex-1">{{.}}</span>
+          <button type="button" data-list-remove class="ml-auto px-2 text-text-secondary hover:text-danger" title="Remove">✕</button>
+        </div>
+        {{end}}
+      </div>
+      <span class="text-xs text-text-secondary">
+        Each must start with <span class="font-mono">ws://</span> or <span class="font-mono">wss://</span>.
+      </span>
+    </div>
+  </div>
+
+  <!-- ── Connection settings ── -->
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Connection timeout (s)</span>
+    <input type="number" min="0" name="connection_timeout" data-shape="number" value="{{.ConnectionTimeout}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Read timeout (s)</span>
+    <input type="number" min="0" name="read_timeout" data-shape="number" value="{{.ReadTimeout}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Write timeout (s)</span>
+    <input type="number" min="0" name="write_timeout" data-shape="number" value="{{.WriteTimeout}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Max connections</span>
+    <input type="number" min="0" name="max_connections" data-shape="number" value="{{.MaxConnections}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Retry attempts</span>
+    <input type="number" min="0" name="retry_attempts" data-shape="number" value="{{.RetryAttempts}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm">
+    <span class="font-medium text-text-secondary">Retry delay (s)</span>
+    <input type="number" min="0" name="retry_delay" data-shape="number" value="{{.RetryDelay}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+    <span class="font-medium text-text-secondary">User agent</span>
+    <input type="text" name="user_agent" value="{{.UserAgent}}"
+      class="px-3 py-2 rounded bg-surface-elevated border border-border text-text" />
+  </label>
+  <label class="flex items-center gap-3 sm:col-span-2 p-3 rounded bg-surface-elevated">
+    <input type="checkbox" name="keep_alive" data-shape="bool" {{if .KeepAlive}}checked{{end}}
+      class="w-4 h-4 accent-accent" />
+    <span class="text-sm font-medium text-text">Keep connections alive</span>
+  </label>
+</form>
+{{end}}

--- a/www/views/admin-sections/ops.html
+++ b/www/views/admin-sections/ops.html
@@ -1,11 +1,7 @@
 {{define "admin-ops"}}
-<!-- Ops section. The only section without a single grain_update*
-     method — every action here calls its own NIP-86 method:
-       - relay-identity inputs:  changerelayname / changerelaydescription / changerelayicon
-       - refresh button:          grain_refreshcache
-       - stats area is read-only via grain_stats_overview
-     Each Save / Refresh fires one signed call directly; the
-     section ignores the page-level Save / Apply / pending bar. -->
+<!-- Operations: live stats + one-shot maintenance actions. The relay-identity
+     fields moved to the "Relay information" section. No grain_update* method —
+     stats use grain_stats_overview, refresh uses grain_refreshcache. -->
 <div class="flex flex-col gap-5 mt-3">
   <!-- ─── Live stats ─────────────────────────────────────────── -->
   <fieldset class="p-3 rounded bg-surface-elevated">
@@ -19,134 +15,6 @@
         data-ops-stats-refresh
         class="px-3 py-1.5 text-xs rounded border border-border-strong text-text-secondary hover:bg-surface-hover"
       >↻ refresh</button>
-    </div>
-  </fieldset>
-
-  <!-- ─── Relay identity ────────────────────────────────────── -->
-  <fieldset class="p-3 rounded bg-surface-elevated" data-ops-identity>
-    <legend class="px-2 text-sm font-medium text-text">Relay identity</legend>
-    <p class="mt-1 mb-3 text-xs text-text-secondary">
-      These fields are written to <span class="font-mono">relay_metadata.json</span>
-      and surfaced over NIP-11. Each Save fires one
-      <span class="font-mono">changerelay*</span> NIP-86 call — only changed
-      fields are sent, so the operator signs once per edited field.
-    </p>
-
-    <div class="grid gap-3 sm:grid-cols-2">
-      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
-        <span class="font-medium text-text-secondary">Name</span>
-        <input
-          type="text"
-          data-ops-name
-          data-initial="{{.RelayName}}"
-          value="{{.RelayName}}"
-          class="px-3 py-2 rounded bg-surface border border-border text-text"
-        />
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
-        <span class="font-medium text-text-secondary">Description</span>
-        <textarea
-          rows="3"
-          data-ops-description
-          data-initial="{{.RelayDescription}}"
-          class="px-3 py-2 rounded bg-surface border border-border text-text"
-        >{{.RelayDescription}}</textarea>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm">
-        <span class="font-medium text-text-secondary">Icon URL</span>
-        <input
-          type="text"
-          data-ops-icon
-          data-initial="{{.RelayIcon}}"
-          value="{{.RelayIcon}}"
-          placeholder="https://relay.example.com/icon.png"
-          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
-        />
-        <button type="button" data-upload-target="[data-ops-icon]" data-upload-accept="image/*"
-          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm">
-        <span class="font-medium text-text-secondary">Banner URL</span>
-        <input
-          type="text"
-          data-ops-banner
-          data-initial="{{.RelayBanner}}"
-          value="{{.RelayBanner}}"
-          placeholder="https://relay.example.com/banner.jpg"
-          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
-        />
-        <button type="button" data-upload-target="[data-ops-banner]" data-upload-accept="image/*"
-          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
-        <span class="font-medium text-text-secondary">Contact</span>
-        <input
-          type="text"
-          data-ops-contact
-          data-initial="{{.RelayContact}}"
-          value="{{.RelayContact}}"
-          placeholder="mailto:admin@example.com  or  https://..."
-          class="px-3 py-2 rounded bg-surface border border-border text-text"
-        />
-        <span class="text-xs text-text-secondary">
-          Free-form: an email (<span class="font-mono">mailto:</span>), URL,
-          or a NIP-05 / npub. Surfaced over NIP-11.
-        </span>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm">
-        <span class="font-medium text-text-secondary">Privacy policy URL</span>
-        <input
-          type="text"
-          data-ops-privacy-policy
-          data-initial="{{.RelayPrivacyPolicy}}"
-          value="{{.RelayPrivacyPolicy}}"
-          placeholder="https://relay.example.com/privacy"
-          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
-        />
-        <button type="button" data-upload-target="[data-ops-privacy-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
-          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm">
-        <span class="font-medium text-text-secondary">Terms of service URL</span>
-        <input
-          type="text"
-          data-ops-terms-of-service
-          data-initial="{{.RelayTermsOfService}}"
-          value="{{.RelayTermsOfService}}"
-          placeholder="https://relay.example.com/terms"
-          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
-        />
-        <button type="button" data-upload-target="[data-ops-terms-of-service]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
-          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
-        <span class="font-medium text-text-secondary">Posting policy URL</span>
-        <input
-          type="text"
-          data-ops-posting-policy
-          data-initial="{{.RelayPostingPolicy}}"
-          value="{{.RelayPostingPolicy}}"
-          placeholder="https://relay.example.com/posting-policy"
-          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
-        />
-        <button type="button" data-upload-target="[data-ops-posting-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
-          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
-      </label>
-    </div>
-
-    <div class="flex justify-end mt-3">
-      <button
-        type="button"
-        data-ops-identity-save
-        class="px-3 py-1.5 text-sm rounded bg-accent text-accent-fg hover:bg-accent-hover"
-      >Save changed fields</button>
     </div>
   </fieldset>
 
@@ -237,77 +105,11 @@
     }
 
     statsBtn.addEventListener("click", loadStats);
-    // nip86-submit.js loads AFTER the section's inline script
-    // (script tags at end of admin.html, vs partial body in <main>).
-    // Defer the first fetch until DOM is ready so window.grainNIP86
-    // exists when we call submit().
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", loadStats);
     } else {
-      // Already past DOMContentLoaded — admin.js may have run, but
-      // it's still safe to fire immediately.
       Promise.resolve().then(loadStats);
     }
-
-    // ── Relay identity (diff + per-field changerelay* call) ──
-
-    const FIELDS = [
-      { sel: "[data-ops-name]",              method: "changerelayname" },
-      { sel: "[data-ops-description]",       method: "changerelaydescription" },
-      { sel: "[data-ops-icon]",              method: "changerelayicon" },
-      { sel: "[data-ops-banner]",            method: "changerelaybanner" },
-      { sel: "[data-ops-contact]",           method: "changerelaycontact" },
-      { sel: "[data-ops-privacy-policy]",    method: "changerelayprivacypolicy" },
-      { sel: "[data-ops-terms-of-service]",  method: "changerelaytermsofservice" },
-      { sel: "[data-ops-posting-policy]",    method: "changerelaypostingpolicy" },
-    ];
-
-    panel.querySelector("[data-ops-identity-save]").addEventListener("click", async (ev) => {
-      const btn = ev.currentTarget;
-      // Diff first so we don't need the signer at all when nothing
-      // changed. Avoids surprise mill-modal pops on a clean Save click.
-      const dirty = [];
-      for (const f of FIELDS) {
-        const el = panel.querySelector(f.sel);
-        if (!el) continue;
-        // Normalize: trim trailing whitespace introduced by template
-        // indentation inside <textarea>. The initial-attr keeps the
-        // value as-is so trimming both is consistent.
-        const initial = String(el.dataset.initial || "");
-        const current = String(el.value);
-        if (initial.trim() === current.trim()) continue;
-        dirty.push({ field: f, initial, current });
-      }
-      if (dirty.length === 0) {
-        toast("no changes to save");
-        return;
-      }
-
-      btn.disabled = true;
-      let changed = 0;
-      let failed = 0;
-      try {
-        if (window.adminEnsureSigner) await window.adminEnsureSigner();
-        for (const d of dirty) {
-          try {
-            await window.grainNIP86.submit(d.field.method, [d.current.trim()]);
-            const el = panel.querySelector(d.field.sel);
-            if (el) el.dataset.initial = d.current;
-            changed++;
-          } catch (err) {
-            toast(d.field.method + ": " + (err.message || String(err)), "error");
-            failed++;
-          }
-        }
-        if (changed > 0 && failed === 0) {
-          toast(changed + " field(s) saved");
-        } else if (changed > 0) {
-          toast(changed + " saved, " + failed + " failed", "error");
-        }
-      } finally {
-        btn.disabled = false;
-      }
-    });
 
     // ── Refresh cache ────────────────────────────────────────
 

--- a/www/views/admin-sections/ops.html
+++ b/www/views/admin-sections/ops.html
@@ -110,6 +110,9 @@
     } else {
       Promise.resolve().then(loadStats);
     }
+    // After claim the first load runs before the signer reconnects — re-pull the
+    // stats once it's ready so the operator doesn't have to hit ↻ themselves.
+    window.addEventListener("grain:signer-ready", loadStats);
 
     // ── Refresh cache ────────────────────────────────────────
 

--- a/www/views/admin-sections/ops.html
+++ b/www/views/admin-sections/ops.html
@@ -64,6 +64,8 @@
           placeholder="https://relay.example.com/icon.png"
           class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
         />
+        <button type="button" data-upload-target="[data-ops-icon]" data-upload-accept="image/*"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
       </label>
 
       <label class="flex flex-col gap-1 text-sm">
@@ -76,6 +78,8 @@
           placeholder="https://relay.example.com/banner.jpg"
           class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
         />
+        <button type="button" data-upload-target="[data-ops-banner]" data-upload-accept="image/*"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
       </label>
 
       <label class="flex flex-col gap-1 text-sm sm:col-span-2">
@@ -104,6 +108,8 @@
           placeholder="https://relay.example.com/privacy"
           class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
         />
+        <button type="button" data-upload-target="[data-ops-privacy-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
       </label>
 
       <label class="flex flex-col gap-1 text-sm">
@@ -116,6 +122,8 @@
           placeholder="https://relay.example.com/terms"
           class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
         />
+        <button type="button" data-upload-target="[data-ops-terms-of-service]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
       </label>
 
       <label class="flex flex-col gap-1 text-sm sm:col-span-2">
@@ -128,6 +136,8 @@
           placeholder="https://relay.example.com/posting-policy"
           class="px-3 py-2 rounded bg-surface border border-border text-text font-mono"
         />
+        <button type="button" data-upload-target="[data-ops-posting-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
       </label>
     </div>
 

--- a/www/views/admin-sections/relay-info.html
+++ b/www/views/admin-sections/relay-info.html
@@ -1,0 +1,150 @@
+{{define "admin-relay_info"}}
+<!-- Relay information. The relay-identity fields written to
+     relay_metadata.json and surfaced over NIP-11. Split out of the old
+     Operations section. Dot is OpsSectionData. Each Save fires per-field
+     changerelay* NIP-86 calls — only changed fields are sent, so the operator
+     signs once per edited field. -->
+<div class="flex flex-col gap-5 mt-3">
+  <fieldset class="p-3 rounded bg-surface-elevated" data-ops-identity>
+    <legend class="px-2 text-sm font-medium text-text">Relay identity</legend>
+    <p class="mt-1 mb-3 text-xs text-text-secondary">
+      These fields are written to <span class="font-mono">relay_metadata.json</span>
+      and surfaced over NIP-11.
+    </p>
+
+    <div class="grid gap-3 sm:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+        <span class="font-medium text-text-secondary">Name</span>
+        <input type="text" data-ops-name data-initial="{{.RelayName}}" value="{{.RelayName}}"
+          class="px-3 py-2 rounded bg-surface border border-border text-text" />
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+        <span class="font-medium text-text-secondary">Description</span>
+        <textarea rows="3" data-ops-description data-initial="{{.RelayDescription}}"
+          class="px-3 py-2 rounded bg-surface border border-border text-text">{{.RelayDescription}}</textarea>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium text-text-secondary">Icon URL</span>
+        <input type="text" data-ops-icon data-initial="{{.RelayIcon}}" value="{{.RelayIcon}}"
+          placeholder="https://relay.example.com/icon.png"
+          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono" />
+        <button type="button" data-upload-target="[data-ops-icon]" data-upload-accept="image/*"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium text-text-secondary">Banner URL</span>
+        <input type="text" data-ops-banner data-initial="{{.RelayBanner}}" value="{{.RelayBanner}}"
+          placeholder="https://relay.example.com/banner.jpg"
+          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono" />
+        <button type="button" data-upload-target="[data-ops-banner]" data-upload-accept="image/*"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload image</button>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+        <span class="font-medium text-text-secondary">Contact</span>
+        <input type="text" data-ops-contact data-initial="{{.RelayContact}}" value="{{.RelayContact}}"
+          placeholder="mailto:admin@example.com  or  https://..."
+          class="px-3 py-2 rounded bg-surface border border-border text-text" />
+        <span class="text-xs text-text-secondary">
+          Free-form: an email (<span class="font-mono">mailto:</span>), URL, or a
+          NIP-05 / npub. Surfaced over NIP-11.
+        </span>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium text-text-secondary">Privacy policy URL</span>
+        <input type="text" data-ops-privacy-policy data-initial="{{.RelayPrivacyPolicy}}" value="{{.RelayPrivacyPolicy}}"
+          placeholder="https://relay.example.com/privacy"
+          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono" />
+        <button type="button" data-upload-target="[data-ops-privacy-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="font-medium text-text-secondary">Terms of service URL</span>
+        <input type="text" data-ops-terms-of-service data-initial="{{.RelayTermsOfService}}" value="{{.RelayTermsOfService}}"
+          placeholder="https://relay.example.com/terms"
+          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono" />
+        <button type="button" data-upload-target="[data-ops-terms-of-service]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+        <span class="font-medium text-text-secondary">Posting policy URL</span>
+        <input type="text" data-ops-posting-policy data-initial="{{.RelayPostingPolicy}}" value="{{.RelayPostingPolicy}}"
+          placeholder="https://relay.example.com/posting-policy"
+          class="px-3 py-2 rounded bg-surface border border-border text-text font-mono" />
+        <button type="button" data-upload-target="[data-ops-posting-policy]" data-upload-accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+          class="self-start px-3 py-1.5 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload file</button>
+      </label>
+    </div>
+
+    <div class="flex justify-end mt-3">
+      <button type="button" data-ops-identity-save
+        class="px-3 py-1.5 text-sm rounded bg-accent text-accent-fg hover:bg-accent-hover">Save changed fields</button>
+    </div>
+  </fieldset>
+</div>
+
+<script>
+  (function () {
+    "use strict";
+    const panel = document.querySelector('[data-section="relay_info"]');
+    if (!panel) return;
+    const toast = window.adminToast || function () {};
+
+    const FIELDS = [
+      { sel: "[data-ops-name]", method: "changerelayname" },
+      { sel: "[data-ops-description]", method: "changerelaydescription" },
+      { sel: "[data-ops-icon]", method: "changerelayicon" },
+      { sel: "[data-ops-banner]", method: "changerelaybanner" },
+      { sel: "[data-ops-contact]", method: "changerelaycontact" },
+      { sel: "[data-ops-privacy-policy]", method: "changerelayprivacypolicy" },
+      { sel: "[data-ops-terms-of-service]", method: "changerelaytermsofservice" },
+      { sel: "[data-ops-posting-policy]", method: "changerelaypostingpolicy" },
+    ];
+
+    panel.querySelector("[data-ops-identity-save]").addEventListener("click", async (ev) => {
+      const btn = ev.currentTarget;
+      // Diff first so a clean Save doesn't need the signer (no surprise mill pop).
+      const dirty = [];
+      for (const f of FIELDS) {
+        const el = panel.querySelector(f.sel);
+        if (!el) continue;
+        const initial = String(el.dataset.initial || "");
+        const current = String(el.value);
+        if (initial.trim() === current.trim()) continue;
+        dirty.push({ field: f, current });
+      }
+      if (dirty.length === 0) {
+        toast("no changes to save");
+        return;
+      }
+      btn.disabled = true;
+      let changed = 0,
+        failed = 0;
+      try {
+        if (window.adminEnsureSigner) await window.adminEnsureSigner();
+        for (const d of dirty) {
+          try {
+            await window.grainNIP86.submit(d.field.method, [d.current.trim()]);
+            const el = panel.querySelector(d.field.sel);
+            if (el) el.dataset.initial = d.current;
+            changed++;
+          } catch (err) {
+            toast(d.field.method + ": " + (err.message || String(err)), "error");
+            failed++;
+          }
+        }
+        if (changed > 0 && failed === 0) toast(changed + " field(s) saved");
+        else if (changed > 0) toast(changed + " saved, " + failed + " failed", "error");
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  })();
+</script>
+{{end}}

--- a/www/views/admin.html
+++ b/www/views/admin.html
@@ -56,6 +56,8 @@
           {{template "admin-event_time_constraints" .Config}}
         {{else if eq .ID "backup_relay"}}
           {{template "admin-backup_relay" .Config}}
+        {{else if eq .ID "client"}}
+          {{template "admin-client" .Config}}
         {{else if eq .ID "rate_limit"}}
           {{template "admin-rate_limit" .Config}}
         {{else if eq .ID "resource_limits"}}

--- a/www/views/admin.html
+++ b/www/views/admin.html
@@ -29,6 +29,7 @@
       class="rounded-lg border border-border-strong bg-surface"
       data-section="{{.ID}}"
       data-method="{{.Method}}"
+      {{if eq .ID "ops"}}open{{end}}
     >
       <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer select-none">
         <span class="text-lg">{{.Icon}}</span>
@@ -70,6 +71,8 @@
           {{template "admin-blacklist" .Config}}
         {{else if eq .ID "ops"}}
           {{template "admin-ops" .Config}}
+        {{else if eq .ID "relay_info"}}
+          {{template "admin-relay_info" .Config}}
         {{else if .Config}}
         <!-- Stub until this section's partial lands. -->
         <pre

--- a/www/views/api-docs.html
+++ b/www/views/api-docs.html
@@ -5,8 +5,8 @@
      swagger-overrides.css file applies grain's design tokens on top
      of the default Swagger stylesheet — this is the seam where the
      embedded docs join the rest of the app's look. -->
-<link rel="stylesheet" href="/static/swagger/swagger-ui.css" />
-<link rel="stylesheet" href="/static/css/swagger-overrides.css" />
+<link rel="stylesheet" href="/static/swagger/swagger-ui.css?v={{assetVersion}}" />
+<link rel="stylesheet" href="/static/css/swagger-overrides.css?v={{assetVersion}}" />
 
 <main
   id="main-content"

--- a/www/views/api-docs.html
+++ b/www/views/api-docs.html
@@ -19,6 +19,55 @@
 <script src="/static/swagger/swagger-ui-bundle.js" charset="UTF-8"></script>
 <script src="/static/swagger/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
 <script>
+  // NIP-98 auth for "Try it out": the only protected operation is the NIP-86 RPC
+  // (POST /). Instead of pasting a base64 kind-27235 event by hand (which only
+  // authorizes one request, since NIP-98 binds the signature to the URL +
+  // payload), sign each protected request on the fly with the connected signer —
+  // the same flow as nip86-submit.js. preauthorizeApiKey arms the lock so
+  // SwaggerUI attaches the Authorization header; the interceptor swaps in a
+  // freshly-signed event.
+  async function sha256Hex(str) {
+    const bytes = new TextEncoder().encode(str);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest))
+      .map(function (b) {
+        return b.toString(16).padStart(2, "0");
+      })
+      .join("");
+  }
+
+  async function signNostrAuth(req) {
+    if (typeof window.restoreSigner === "function") {
+      try {
+        await window.restoreSigner();
+      } catch (e) {}
+    }
+    if (!window.grainSigner || typeof window.grainSigner.signEvent !== "function") {
+      return req; // no signer — the request will 401, the honest result
+    }
+    const u = /^https?:\/\//.test(req.url) ? req.url : window.location.origin + req.url;
+    const tags = [
+      ["u", u],
+      ["method", (req.method || "GET").toUpperCase()],
+    ];
+    if (req.body) {
+      const body = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+      tags.push(["payload", await sha256Hex(body)]);
+    }
+    try {
+      const signed = await window.grainSigner.signEvent({
+        kind: 27235,
+        created_at: Math.floor(Date.now() / 1000),
+        content: "",
+        tags: tags,
+      });
+      req.headers.Authorization = "Nostr " + btoa(JSON.stringify(signed));
+    } catch (e) {
+      console.warn("NIP-98 signing failed:", e);
+    }
+    return req;
+  }
+
   window.addEventListener("load", function () {
     window.ui = SwaggerUIBundle({
       url: "/api/docs/openapi.json",
@@ -36,6 +85,16 @@
       docExpansion: "list",
       defaultModelsExpandDepth: 1,
       tryItOutEnabled: true,
+      // Sign NIP-98-protected requests with the connected signer (the header is
+      // only present on protected operations, so others pass through untouched).
+      requestInterceptor: function (req) {
+        return req.headers && req.headers.Authorization ? signNostrAuth(req) : req;
+      },
+      onComplete: function () {
+        try {
+          window.ui.preauthorizeApiKey("NostrAuth", "signer");
+        } catch (e) {}
+      },
     });
   });
 </script>

--- a/www/views/components/profile-page.html
+++ b/www/views/components/profile-page.html
@@ -87,6 +87,18 @@
         </button>
       </div>
 
+      <!-- Edit button. Hidden by default; profile-page.js reveals it only when
+           the logged-in user is viewing their own profile. -->
+      <div class="mb-4">
+        <button
+          id="profile-edit-btn"
+          onclick="toggleProfileEdit()"
+          class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+        >
+          ✏️ Edit profile
+        </button>
+      </div>
+
       <!-- About Section -->
       <div class="max-w-2xl mx-auto mb-4">
         <div class="p-6 bg-surface rounded-lg">
@@ -131,6 +143,67 @@
           >
         </div>
       </div>
+      <!-- Edit panel. Own profile only; toggled by the Edit button. Fields map
+           1:1 to kind-0 content keys (the input id is edit-<key>). Save sends
+           only the changed fields to /build, signs client-side, and publishes
+           via the outbox; everything else in the existing kind-0 is preserved. -->
+      <div
+        id="profile-edit-panel"
+        class="hidden max-w-2xl p-6 mx-auto mb-8 text-left rounded-lg bg-surface"
+      >
+        <h3 class="mb-4 text-lg font-semibold text-text">Edit profile</h3>
+        <div class="space-y-3">
+          <label class="block">
+            <span class="text-sm text-text-secondary">Name</span>
+            <input id="edit-name" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">Display name</span>
+            <input id="edit-display_name" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">About</span>
+            <textarea id="edit-about" rows="3" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border"></textarea>
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">Picture URL</span>
+            <input id="edit-picture" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">Banner URL</span>
+            <input id="edit-banner" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">NIP-05</span>
+            <input id="edit-nip05" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">Lightning address (lud16)</span>
+            <input id="edit-lud16" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="block">
+            <span class="text-sm text-text-secondary">Website</span>
+            <input id="edit-website" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+        </div>
+        <div class="flex gap-2 mt-4">
+          <button
+            id="profile-save-btn"
+            onclick="saveProfile()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+          >
+            Save &amp; sign
+          </button>
+          <button
+            onclick="toggleProfileEdit()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+          >
+            Cancel
+          </button>
+        </div>
+        <p id="profile-save-status" class="mt-3 text-sm text-text-secondary"></p>
+      </div>
+
       <!-- Social Links Row (dynamically populated) -->
       <div class="flex justify-center gap-6 mb-8" id="social-links-container">
         <!-- External identity links will be added here dynamically -->

--- a/www/views/components/profile-page.html
+++ b/www/views/components/profile-page.html
@@ -87,15 +87,22 @@
         </button>
       </div>
 
-      <!-- Edit button. Hidden by default; profile-page.js reveals it only when
-           the logged-in user is viewing their own profile. -->
-      <div class="mb-4">
+      <!-- Edit buttons. Hidden by default; profile-page.js reveals them only
+           when the logged-in user is viewing their own profile. -->
+      <div class="flex justify-center gap-2 mb-4">
         <button
           id="profile-edit-btn"
           onclick="toggleProfileEdit()"
           class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
         >
           ✏️ Edit profile
+        </button>
+        <button
+          id="profile-advanced-btn"
+          onclick="toggleAdvancedEdit()"
+          class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+        >
+          ⚙️ Advanced
         </button>
       </div>
 
@@ -202,6 +209,45 @@
           </button>
         </div>
         <p id="profile-save-status" class="mt-3 text-sm text-text-secondary"></p>
+      </div>
+
+      <!-- Advanced editor. Own profile only; full control over content fields
+           and tags (drag the ⠿ handle to reorder tags). kind/pubkey are fixed
+           and created_at is stamped at sign time. Populated by profile-page.js. -->
+      <div
+        id="profile-advanced-panel"
+        class="hidden max-w-2xl p-6 mx-auto mb-8 text-left rounded-lg bg-surface"
+      >
+        <h3 class="mb-1 text-lg font-semibold text-text">Advanced editor</h3>
+        <p id="adv-meta" class="mb-4 font-mono text-xs break-all text-text-secondary"></p>
+
+        <h4 class="mb-2 text-sm font-medium text-text">Content</h4>
+        <div id="adv-content" class="space-y-2"></div>
+        <button onclick="advAddContent()" class="mt-2 text-sm text-accent hover:opacity-80">
+          + Add field
+        </button>
+
+        <h4 class="mt-5 mb-2 text-sm font-medium text-text">Tags</h4>
+        <div id="adv-tags" class="space-y-2"></div>
+        <button onclick="advAddTag()" class="mt-2 text-sm text-accent hover:opacity-80">
+          + Add tag
+        </button>
+
+        <div class="flex gap-2 mt-6">
+          <button
+            onclick="advSave()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+          >
+            Save &amp; sign
+          </button>
+          <button
+            onclick="toggleAdvancedEdit()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+          >
+            Cancel
+          </button>
+        </div>
+        <p id="adv-status" class="mt-3 text-sm text-text-secondary"></p>
       </div>
 
       <!-- Social Links Row (dynamically populated) -->

--- a/www/views/components/profile-page.html
+++ b/www/views/components/profile-page.html
@@ -245,4 +245,5 @@
     ></pre>
   </div>
 </div>
+<script src="/static/js/nostr-publish.js"></script>
 <script src="/static/js/profile-page.js"></script>

--- a/www/views/components/profile-page.html
+++ b/www/views/components/profile-page.html
@@ -136,10 +136,12 @@
             <label class="text-xs text-text-secondary">
               Picture URL
               <input id="edit-picture" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+              <button type="button" data-upload-target="#edit-picture" data-upload-accept="image/*" class="px-2 py-1 mt-1 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload</button>
             </label>
             <label class="text-xs text-text-secondary">
               Banner URL
               <input id="edit-banner" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+              <button type="button" data-upload-target="#edit-banner" data-upload-accept="image/*" class="px-2 py-1 mt-1 text-xs rounded bg-surface-elevated text-text border border-border hover:bg-surface-hover">⬆ Upload</button>
             </label>
           </div>
           <label class="block mt-3 text-xs text-text-secondary">

--- a/www/views/components/profile-page.html
+++ b/www/views/components/profile-page.html
@@ -1,23 +1,23 @@
-<!-- Profile Page Component - Matches sketch layout -->
-<div class="container max-w-4xl px-4 py-8 mx-auto">
+<!-- Profile Page Component. View ≈ edit: the same layout renders as text in
+     view mode and as in-place inputs in edit mode. Elements tagged .pf-view are
+     shown when viewing; .pf-edit when editing — profile-page.js flips them. -->
+<div class="container max-w-2xl px-4 py-8 mx-auto">
   <!-- Loading State -->
   <div id="loading" class="text-center">
     <div
-      class="inline-block w-8 h-8 border-2 border-white rounded-full animate-spin border-t-transparent"
+      class="inline-block w-8 h-8 border-2 rounded-full animate-spin border-text border-t-transparent"
     ></div>
     <p class="mt-2 text-text-secondary">Loading profile...</p>
   </div>
 
   <!-- Error State -->
   <div id="error" class="hidden text-center">
-    <div
-      class="max-w-md p-6 mx-auto bg-danger-dim border border-danger rounded-lg"
-    >
-      <h2 class="mb-2 text-xl font-bold text-danger">❌ Profile Error</h2>
+    <div class="max-w-md p-6 mx-auto border rounded-lg bg-danger-dim border-danger">
+      <h2 class="mb-2 text-xl font-bold text-danger">Profile error</h2>
       <p id="error-message" class="mb-4 text-danger">Failed to load profile</p>
       <button
         onclick="refreshProfile()"
-        class="px-4 py-2 text-text transition-colors bg-danger rounded hover:opacity-80"
+        class="px-4 py-2 transition-colors rounded text-text bg-danger hover:opacity-80"
       >
         Retry
       </button>
@@ -26,254 +26,223 @@
 
   <!-- Profile Content -->
   <div id="profile-content" class="hidden">
-    <!-- Banner Section -->
-    <div class="relative mb-20 overflow-visible bg-surface rounded-xl">
-      <!-- Banner placeholder/background -->
-      <div
-        class="flex items-center justify-center h-48 rounded-md bg-gradient-to-r from-accent to-accent-2"
-      ></div>
-
-      <!-- Banner image (hidden by default) -->
-      <div id="profile-banner" class="absolute inset-0 hidden">
+    <div class="overflow-hidden border rounded-xl bg-surface border-border">
+      <!-- Banner -->
+      <div class="relative h-32">
+        <div class="w-full h-full bg-gradient-to-r from-accent to-accent-2"></div>
         <img
           id="profile-banner-img"
-          class="object-cover w-full h-48 rounded-md"
+          class="absolute inset-0 hidden object-cover w-full h-full"
           alt="Profile Banner"
         />
+        <span
+          class="absolute items-center hidden gap-1 px-2 py-1 text-xs border rounded pf-edit top-2 right-2 bg-surface text-text-secondary border-border"
+        >
+          ✏️ editing
+        </span>
       </div>
 
-      <!-- Profile Picture Overlay (centered on bottom edge of banner) -->
-      <div class="absolute transform -translate-x-1/2 left-1/2 -bottom-16">
-        <div class="relative">
-          <!-- Picture placeholder - rounded square -->
+      <div class="px-6 pb-6 -mt-12 text-center">
+        <!-- Avatar -->
+        <div class="relative inline-block">
           <div
             id="profile-avatar-placeholder"
-            class="flex items-center justify-center w-32 h-32 bg-surface-overlay border-2 border-border-strong rounded-lg shadow-lg"
+            class="flex items-center justify-center w-24 h-24 border-2 rounded-lg shadow-lg bg-surface-overlay border-surface"
           ></div>
-          <!-- Actual picture - rounded square -->
           <img
             id="profile-avatar-img"
-            class="hidden object-cover w-32 h-32 border-2 border-border-strong rounded-lg shadow-lg"
+            class="hidden object-cover w-24 h-24 border-2 rounded-lg shadow-lg border-surface"
             alt="Profile Picture"
           />
-        </div>
-      </div>
-    </div>
-
-    <!-- Profile Info Section (starts below banner with space for visible profile pic) -->
-    <div class="text-center">
-      <!-- Display Name -->
-      <h1 id="profile-name" class="mb-2 text-3xl font-bold text-text">
-        display_name
-      </h1>
-
-      <!-- Display name alternate (if different from name) -->
-      <div
-        id="profile-display-name"
-        class="hidden mb-2 text-xl text-text-secondary"
-      ></div>
-
-      <!-- NPub with copy button -->
-      <div class="flex items-center justify-center gap-2 mb-6">
-        <span id="profile-identifier" class="font-mono text-sm text-text-secondary"
-          >npubxxx...</span
-        >
-        <button
-          onclick="copyIdentifier()"
-          class="text-text-secondary transition-colors hover:text-text"
-          title="Copy npub"
-        >
-          📋
-        </button>
-      </div>
-
-      <!-- Edit buttons. Hidden by default; profile-page.js reveals them only
-           when the logged-in user is viewing their own profile. -->
-      <div class="flex justify-center gap-2 mb-4">
-        <button
-          id="profile-edit-btn"
-          onclick="toggleProfileEdit()"
-          class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
-        >
-          ✏️ Edit profile
-        </button>
-        <button
-          id="profile-advanced-btn"
-          onclick="toggleAdvancedEdit()"
-          class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
-        >
-          ⚙️ Advanced
-        </button>
-      </div>
-
-      <!-- About Section -->
-      <div class="max-w-2xl mx-auto mb-4">
-        <div class="p-6 bg-surface rounded-lg">
-          <p id="profile-about" class="leading-relaxed text-text-secondary">
-            Loading bio...
-          </p>
-        </div>
-      </div>
-
-      <!-- Contact Information Grid -->
-      <div class="grid grid-cols-1 gap-4 mb-8 md:grid-cols-3">
-        <!-- NIP-05 Address -->
-        <div
-          id="profile-nip05-container"
-          class="hidden p-4 bg-surface rounded-lg"
-        >
-          <h4 class="mb-2 text-sm font-medium text-text-secondary">nip-05</h4>
-          <p id="profile-nip05" class="text-accent break-all">-</p>
-        </div>
-
-        <!-- Lightning Address -->
-        <div
-          id="profile-lightning-container"
-          class="hidden p-4 bg-surface rounded-lg"
-        >
-          <h4 class="mb-2 text-sm font-medium text-text-secondary">⚡</h4>
-          <p id="profile-lightning" class="text-warning break-all">-</p>
-        </div>
-
-        <!-- Website -->
-        <div
-          id="profile-website-container"
-          class="hidden p-4 bg-surface rounded-lg"
-        >
-          <h4 class="mb-2 text-sm font-medium text-text-secondary">🌐</h4>
-          <a
-            id="profile-website"
-            href="#"
-            target="_blank"
-            class="text-accent break-all hover:opacity-80"
-            >-</a
+          <button
+            onclick="focusPictureField()"
+            title="Change picture"
+            class="absolute items-center justify-center hidden border rounded-full pf-edit -right-1 -bottom-1 w-7 h-7 bg-surface border-border text-text-secondary hover:text-text"
           >
+            📷
+          </button>
         </div>
-      </div>
-      <!-- Edit panel. Own profile only; toggled by the Edit button. Fields map
-           1:1 to kind-0 content keys (the input id is edit-<key>). Save sends
-           only the changed fields to /build, signs client-side, and publishes
-           via the outbox; everything else in the existing kind-0 is preserved. -->
-      <div
-        id="profile-edit-panel"
-        class="hidden max-w-2xl p-6 mx-auto mb-8 text-left rounded-lg bg-surface"
-      >
-        <h3 class="mb-4 text-lg font-semibold text-text">Edit profile</h3>
-        <div class="space-y-3">
-          <label class="block">
-            <span class="text-sm text-text-secondary">Name</span>
-            <input id="edit-name" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">Display name</span>
-            <input id="edit-display_name" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">About</span>
-            <textarea id="edit-about" rows="3" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border"></textarea>
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">Picture URL</span>
-            <input id="edit-picture" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">Banner URL</span>
-            <input id="edit-banner" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">NIP-05</span>
-            <input id="edit-nip05" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">Lightning address (lud16)</span>
-            <input id="edit-lud16" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
-          <label class="block">
-            <span class="text-sm text-text-secondary">Website</span>
-            <input id="edit-website" type="text" class="w-full px-3 py-2 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
-          </label>
+
+        <!-- Name: view heading + inline input -->
+        <h1 id="profile-name" class="mt-3 text-2xl font-bold pf-view text-text">display_name</h1>
+        <input
+          id="edit-name"
+          placeholder="Name"
+          class="hidden w-full max-w-xs px-2 py-1 mx-auto mt-3 text-2xl font-bold text-center border rounded pf-edit bg-surface-elevated text-text border-border"
+        />
+        <div id="profile-display-name" class="hidden mt-1 text-lg pf-view text-text-secondary"></div>
+
+        <!-- NPub (shown in both modes) -->
+        <div class="flex items-center justify-center gap-2 mt-2">
+          <span id="profile-identifier" class="font-mono text-sm text-text-secondary">npubxxx...</span>
+          <button
+            onclick="copyIdentifier()"
+            class="transition-colors text-text-secondary hover:text-text"
+            title="Copy npub"
+          >
+            📋
+          </button>
         </div>
-        <div class="flex gap-2 mt-4">
+
+        <!-- Action buttons -->
+        <div class="flex flex-wrap justify-center gap-2 mt-4">
+          <button
+            id="profile-edit-btn"
+            onclick="toggleProfileEdit()"
+            class="hidden px-4 py-2 text-sm transition-colors rounded-lg pf-view text-text bg-surface-elevated hover:bg-surface-hover"
+          >
+            ✏️ Edit profile
+          </button>
           <button
             id="profile-save-btn"
             onclick="saveProfile()"
-            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+            class="hidden px-4 py-2 text-sm transition-colors rounded-lg pf-edit text-text-on-accent bg-accent hover:opacity-80"
           >
             Save &amp; sign
           </button>
           <button
             onclick="toggleProfileEdit()"
-            class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+            class="hidden px-4 py-2 text-sm transition-colors rounded-lg pf-edit text-text bg-surface-elevated hover:bg-surface-hover"
           >
             Cancel
           </button>
-        </div>
-        <p id="profile-save-status" class="mt-3 text-sm text-text-secondary"></p>
-      </div>
-
-      <!-- Advanced editor. Own profile only; full control over content fields
-           and tags (drag the ⠿ handle to reorder tags). kind/pubkey are fixed
-           and created_at is stamped at sign time. Populated by profile-page.js. -->
-      <div
-        id="profile-advanced-panel"
-        class="hidden max-w-2xl p-6 mx-auto mb-8 text-left rounded-lg bg-surface"
-      >
-        <h3 class="mb-1 text-lg font-semibold text-text">Advanced editor</h3>
-        <p id="adv-meta" class="mb-4 font-mono text-xs break-all text-text-secondary"></p>
-
-        <h4 class="mb-2 text-sm font-medium text-text">Content</h4>
-        <div id="adv-content" class="space-y-2"></div>
-        <button onclick="advAddContent()" class="mt-2 text-sm text-accent hover:opacity-80">
-          + Add field
-        </button>
-
-        <h4 class="mt-5 mb-2 text-sm font-medium text-text">Tags</h4>
-        <div id="adv-tags" class="space-y-2"></div>
-        <button onclick="advAddTag()" class="mt-2 text-sm text-accent hover:opacity-80">
-          + Add tag
-        </button>
-
-        <div class="flex gap-2 mt-6">
           <button
-            onclick="advSave()"
-            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
-          >
-            Save &amp; sign
-          </button>
-          <button
+            id="profile-advanced-btn"
             onclick="toggleAdvancedEdit()"
-            class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+            class="hidden px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
           >
-            Cancel
+            ⚙️ Advanced
           </button>
         </div>
-        <p id="adv-status" class="mt-3 text-sm text-text-secondary"></p>
-      </div>
+        <p id="profile-save-status" class="mt-2 text-sm text-text-secondary"></p>
 
-      <!-- Social Links Row (dynamically populated) -->
-      <div class="flex justify-center gap-6 mb-8" id="social-links-container">
-        <!-- External identity links will be added here dynamically -->
-      </div>
-      <!-- Debug Info (hidden elements for working JS) -->
-      <div class="hidden">
-        <span id="profile-pubkey"></span>
-      </div>
-
-      <!-- View Event JSON Button -->
-      <div class="text-center">
-        <button
-          id="event-json-btn"
-          onclick="toggleEventJson()"
-          class="px-6 py-3 text-text transition-colors bg-surface-elevated rounded-lg hover:bg-surface-hover"
+        <!-- About: view paragraph + inline textarea -->
+        <p
+          id="profile-about"
+          class="max-w-lg mx-auto mt-5 leading-relaxed pf-view text-text-secondary"
         >
-          view event json
+          Loading bio...
+        </p>
+        <textarea
+          id="edit-about"
+          rows="3"
+          placeholder="About"
+          class="hidden w-full max-w-lg px-3 py-2 mx-auto mt-5 text-sm border rounded pf-edit bg-surface-elevated text-text border-border"
+        ></textarea>
+
+        <!-- Picture / banner / display-name (edit mode only) -->
+        <div class="hidden max-w-lg mx-auto mt-3 text-left pf-edit">
+          <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <label class="text-xs text-text-secondary">
+              Picture URL
+              <input id="edit-picture" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+            </label>
+            <label class="text-xs text-text-secondary">
+              Banner URL
+              <input id="edit-banner" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+            </label>
+          </div>
+          <label class="block mt-3 text-xs text-text-secondary">
+            Display name
+            <input id="edit-display_name" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+        </div>
+
+        <!-- Contact info — view cards -->
+        <div
+          id="contact-view"
+          class="grid grid-cols-1 gap-3 mt-6 pf-view md:grid-cols-3"
+        >
+          <div id="profile-nip05-container" class="hidden p-3 text-left rounded-lg bg-surface-elevated">
+            <div class="mb-1 text-xs text-text-secondary">nip-05</div>
+            <p id="profile-nip05" class="text-sm break-all text-accent">-</p>
+          </div>
+          <div id="profile-lightning-container" class="hidden p-3 text-left rounded-lg bg-surface-elevated">
+            <div class="mb-1 text-xs text-text-secondary">⚡ lightning</div>
+            <p id="profile-lightning" class="text-sm break-all text-warning">-</p>
+          </div>
+          <div id="profile-website-container" class="hidden p-3 text-left rounded-lg bg-surface-elevated">
+            <div class="mb-1 text-xs text-text-secondary">🌐 website</div>
+            <a id="profile-website" href="#" target="_blank" class="text-sm break-all text-accent hover:opacity-80">-</a>
+          </div>
+        </div>
+
+        <!-- Contact info — edit inputs -->
+        <div class="hidden grid-cols-1 gap-3 mt-6 text-left pf-edit md:grid-cols-3">
+          <label class="text-xs text-text-secondary">
+            nip-05
+            <input id="edit-nip05" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="text-xs text-text-secondary">
+            ⚡ lightning
+            <input id="edit-lud16" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+          <label class="text-xs text-text-secondary">
+            🌐 website
+            <input id="edit-website" class="w-full px-2 py-1 mt-1 text-sm border rounded bg-surface-elevated text-text border-border" />
+          </label>
+        </div>
+
+        <!-- Social Links (view) -->
+        <div class="flex justify-center gap-6 mt-6 pf-view" id="social-links-container"></div>
+
+        <div class="hidden"><span id="profile-pubkey"></span></div>
+      </div>
+    </div>
+
+    <!-- Advanced editor. Own profile only; full control over content fields and
+         tags (drag the ⠿ grip to reorder). kind/pubkey fixed, created_at at
+         sign time. Populated by profile-page.js. -->
+    <div
+      id="profile-advanced-panel"
+      class="hidden p-6 mt-6 text-left border rounded-xl bg-surface border-border"
+    >
+      <h3 class="mb-1 text-lg font-semibold text-text">Advanced editor</h3>
+      <p id="adv-meta" class="mb-4 font-mono text-xs break-all text-text-secondary"></p>
+
+      <h4 class="mb-2 text-sm font-medium text-text">Content</h4>
+      <div id="adv-content" class="space-y-2"></div>
+      <button onclick="advAddContent()" class="mt-2 text-sm text-accent hover:opacity-80">
+        + Add field
+      </button>
+
+      <h4 class="mt-5 mb-2 text-sm font-medium text-text">Tags</h4>
+      <div id="adv-tags" class="space-y-2"></div>
+      <button onclick="advAddTag()" class="mt-2 text-sm text-accent hover:opacity-80">
+        + Add tag
+      </button>
+
+      <div class="flex gap-2 mt-6">
+        <button
+          onclick="advSave()"
+          class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+        >
+          Save &amp; sign
+        </button>
+        <button
+          onclick="toggleAdvancedEdit()"
+          class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+        >
+          Cancel
         </button>
       </div>
-      <pre
-        id="event-json"
-        class="hidden mt-4 p-4 overflow-x-auto text-xs text-left whitespace-pre-wrap break-all rounded-lg bg-surface-elevated text-text-secondary"
-      ></pre>
+      <p id="adv-status" class="mt-3 text-sm text-text-secondary"></p>
     </div>
+
+    <!-- View Event JSON -->
+    <div class="mt-6 text-center">
+      <button
+        id="event-json-btn"
+        onclick="toggleEventJson()"
+        class="px-4 py-2 text-sm transition-colors rounded-lg text-text-secondary bg-surface-elevated hover:bg-surface-hover"
+      >
+        view event json
+      </button>
+    </div>
+    <pre
+      id="event-json"
+      class="hidden p-4 mt-3 overflow-x-auto text-xs text-left break-all whitespace-pre-wrap rounded-lg bg-surface-elevated text-text-secondary"
+    ></pre>
   </div>
 </div>
 <script src="/static/js/profile-page.js"></script>

--- a/www/views/home.html
+++ b/www/views/home.html
@@ -23,6 +23,18 @@
     </div>
   </div>
 
+  <!-- Live Relay Stream: events hitting THIS relay, streamed live via a direct
+       WebSocket to grain's own relay. Rendered by feed.js. -->
+  <div class="mb-8 overflow-hidden bg-surface border border-border rounded-lg">
+    <div class="px-4 py-3 border-b border-border bg-surface-elevated">
+      <h2 class="text-lg font-semibold text-text">📡 Live Relay Stream</h2>
+      <p class="text-xs text-text-secondary">
+        Events hitting this relay, newest first — click an event to open it.
+      </p>
+    </div>
+    <div id="relay-stream-list" class="overflow-y-auto max-h-96"></div>
+  </div>
+
   <!-- 1. Relay Overview Section - MOVED ABOVE WHITELIST/BLACKLIST -->
   <div
     class="mb-8 overflow-hidden bg-surface border border-border rounded-lg"
@@ -271,6 +283,7 @@
   }
 </style>
 <script src="/static/js/dashboard.js"></script>
+<script src="/static/js/feed.js"></script>
 <script>
   // Safe initialization that waits for both DOM and script to be ready
   function safeInitializeDashboard() {

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -216,6 +216,122 @@
         </div>
       </div>
 
+      <!-- Media Servers (#83): where uploads go. The user's Blossom (kind
+           10063) + NIP-96 (kind 10096) lists, plus grain's recommended
+           quick-adds. Lists/rows are rendered by media-servers.js. -->
+      <div id="media-servers-section" class="p-6 mb-8 bg-surface rounded-lg">
+        <h2 class="mb-1 text-xl font-semibold text-text">🗂️ Media servers</h2>
+        <p class="mb-4 text-sm text-text-secondary">
+          Where grain uploads your pictures and files. Add a server to upload
+          from the app — or just paste image URLs without one.
+        </p>
+
+        <!-- Blossom explainer -->
+        <div class="flex gap-3 p-3 mb-5 text-sm rounded-lg bg-info-dim text-info">
+          <span aria-hidden="true">🌸</span>
+          <p>
+            <span class="font-semibold">Blossom</span> stores media as files
+            addressed by their hash. Upload once, mirror to several servers, and
+            any Blossom app can still find your media by hash — even if one
+            server drops it. <span class="font-semibold">Recommended.</span>
+          </p>
+        </div>
+
+        <!-- Your Blossom servers -->
+        <h3 class="text-sm font-medium text-text">Your Blossom servers</h3>
+        <p class="mb-2 text-xs text-text-muted">
+          First is your primary — uploads go here. The rest are mirrors. Drag
+          the ⠿ to reorder.
+        </p>
+        <div id="ms-blossom-list" class="space-y-2"></div>
+
+        <h4
+          class="mt-4 mb-2 text-xs font-medium tracking-wide uppercase text-text-secondary"
+        >
+          Recommended
+        </h4>
+        <div id="ms-blossom-suggested" class="space-y-2"></div>
+
+        <div class="flex gap-2 mt-3">
+          <input
+            id="ms-blossom-input"
+            type="text"
+            placeholder="Add a Blossom server by URL…"
+            class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"
+          />
+          <button
+            onclick="msAddBlossomFromInput()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+          >
+            + Add
+          </button>
+        </div>
+        <p class="mt-2 text-xs text-text-muted">
+          Want to pick your own? Browse
+          <a
+            href="https://blossomservers.com"
+            target="_blank"
+            rel="noopener"
+            class="text-accent"
+            >blossomservers.com ↗</a
+          >
+        </p>
+
+        <!-- Legacy NIP-96 -->
+        <details class="mt-6">
+          <summary
+            class="text-sm font-medium cursor-pointer text-text-secondary hover:text-text"
+          >
+            Legacy — HTTP servers (NIP-96)
+          </summary>
+          <p class="mt-2 mb-3 text-xs text-text-muted">
+            Traditional HTTP file storage, authed with NIP-98. Works, but has no
+            mirroring and isn't hash-addressed.
+            <span class="font-semibold text-text-secondary">Prefer Blossom</span>
+            unless you specifically need an existing NIP-96 host.
+          </p>
+          <div id="ms-nip96-list" class="space-y-2"></div>
+          <h4
+            class="mt-3 mb-2 text-xs font-medium tracking-wide uppercase text-text-secondary"
+          >
+            Recommended
+          </h4>
+          <div id="ms-nip96-suggested" class="space-y-2"></div>
+          <div class="flex gap-2 mt-3">
+            <input
+              id="ms-nip96-input"
+              type="text"
+              placeholder="Add a NIP-96 server by URL…"
+              class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"
+            />
+            <button
+              onclick="msAddNip96FromInput()"
+              class="px-4 py-2 text-sm transition-colors rounded-lg text-text bg-surface-elevated hover:bg-surface-hover"
+            >
+              + Add
+            </button>
+          </div>
+        </details>
+
+        <!-- Save -->
+        <div
+          class="flex items-center justify-between gap-3 pt-4 mt-6 border-t border-border"
+        >
+          <p class="text-xs text-text-muted">
+            Saving publishes your <code>kind 10063</code> + <code>10096</code>
+            lists.
+          </p>
+          <button
+            id="ms-save-btn"
+            onclick="msSave()"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+          >
+            Save &amp; sign
+          </button>
+        </div>
+        <p id="ms-status" class="mt-2 text-sm text-right text-text-secondary"></p>
+      </div>
+
       <!-- Key Information -->
       <div class="p-6 mb-8 bg-surface rounded-lg">
         <h2 class="mb-4 text-xl font-semibold text-text">
@@ -275,6 +391,11 @@
   </div>
 
   <script src="/static/js/settings.js"></script>
+  <!-- Shared publish helper + media-servers section (#83). nostr-publish.js
+       must load first; media-servers.js self-initialises when its section is in
+       the DOM. -->
+  <script src="/static/js/nostr-publish.js"></script>
+  <script src="/static/js/media-servers.js"></script>
   <script>
     // Safe initialization that waits for both DOM and script to be ready
     function safeInitializeSettings() {

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -77,7 +77,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">Where you publish. Others fetch your notes here.</p>
           <div id="rm-outbox-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-outbox-input" type="text" placeholder="Add an outbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-outbox-input" type="text" placeholder="Add an outbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAddOutbox()" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
         </div>
@@ -90,7 +90,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">Where replies, mentions, and zaps reach you.</p>
           <div id="rm-inbox-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-inbox-input" type="text" placeholder="Add an inbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-inbox-input" type="text" placeholder="Add an inbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAddInbox()" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
         </div>
@@ -109,7 +109,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">Where your private (gift-wrapped) direct messages are delivered.</p>
           <div id="rm-dm-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-dm-input" type="text" placeholder="Add a DM relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-dm-input" type="text" placeholder="Add a DM relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAdd('dm')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
           <div class="flex items-center justify-between gap-3 mt-2">
@@ -134,7 +134,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">Relays grain queries when you search.</p>
           <div id="rm-search-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-search-input" type="text" placeholder="Add a search relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-search-input" type="text" placeholder="Add a search relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAdd('search')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
           <div class="flex items-center justify-between gap-3 mt-2">
@@ -152,7 +152,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">Relays you've starred to browse.</p>
           <div id="rm-favorites-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-favorites-input" type="text" placeholder="Add a favorite relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-favorites-input" type="text" placeholder="Add a favorite relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAdd('favorites')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
           <div class="flex items-center justify-between gap-3 mt-2">
@@ -170,7 +170,7 @@
           <p class="mt-0.5 mb-2 text-xs text-text-muted">grain never connects to these.</p>
           <div id="rm-blocked-list" class="space-y-1.5"></div>
           <div class="flex gap-2 mt-2">
-            <input id="rm-blocked-input" type="text" placeholder="Add a blocked relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <input id="rm-blocked-input" type="text" placeholder="Add a blocked relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" list="rm-known-options" />
             <button onclick="rmAdd('blocked')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
           </div>
           <div class="flex items-center justify-between gap-3 mt-2">
@@ -197,6 +197,10 @@
           App relays · grain's plumbing
         </h3>
         <div id="rm-app-relays" class="space-y-3"></div>
+
+        <!-- Shared autocomplete source for every "add a relay" input above —
+             populated from the known set by relay-manager.js. -->
+        <datalist id="rm-known-options"></datalist>
 
         <!-- ── Known relays (browse + add) — accent card so it stands apart ── -->
         <div class="p-4 mt-6 border rounded-xl border-accent bg-accent-dim">

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -198,6 +198,25 @@
         </h3>
         <div id="rm-app-relays" class="space-y-3"></div>
 
+        <!-- ── Known relays (browse + add) ── -->
+        <h3
+          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
+        >
+          Known relays · browse + add
+        </h3>
+        <p class="mb-2 text-xs text-text-muted">
+          Every relay grain has seen — defaults, your mailboxes, and ones it's
+          connected to. Expand a row for its NIP-11 info; add any to your lists.
+        </p>
+        <input
+          id="rm-known-search"
+          type="text"
+          placeholder="Filter known relays…"
+          oninput="rmKnownSearch(this.value)"
+          class="w-full px-3 py-2 mb-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"
+        />
+        <div id="rm-known-list" class="space-y-1.5 overflow-y-auto max-h-96"></div>
+
         <!-- Fixed-relay override -->
         <div class="p-4 mt-6 border rounded-lg border-warning bg-warning-dim">
           <label class="flex items-center justify-between gap-3 cursor-pointer">

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -198,6 +198,20 @@
         </h3>
         <div id="rm-app-relays" class="space-y-3"></div>
 
+        <!-- ── NIP-42 AUTH requests (was "Trusted") ── -->
+        <h3
+          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
+        >
+          Relays requesting AUTH · NIP-42
+        </h3>
+        <p class="mb-2 text-xs text-text-muted">
+          Relays that asked grain to authenticate this session. Authenticate with
+          your signer to use them — each stays trusted until you remove it or your
+          session ends. If a relay re-challenges, your signer prompts you again.
+        </p>
+        <div id="rm-auth-list" class="space-y-1.5"></div>
+        <p id="rm-auth-status" class="mt-1 text-xs text-text-secondary"></p>
+
         <!-- Shared autocomplete source for every "add a relay" input above —
              populated from the known set by relay-manager.js. -->
         <datalist id="rm-known-options"></datalist>

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -180,13 +180,14 @@
           <p id="rm-blocked-status" class="mt-1 text-xs text-right text-text-secondary"></p>
         </div>
 
-        <div class="mt-5 opacity-60">
+        <div class="mt-5">
           <div class="flex items-center gap-2">
             <span class="text-sm font-medium text-text">🔒 Private</span>
             <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10013 · NIP-37</span>
-            <span class="px-2 py-0.5 ml-auto text-xs rounded bg-surface-inset text-text-muted">coming soon</span>
           </div>
-          <p class="mt-0.5 text-xs text-text-muted">Encrypted relay list — only you can read it (needs signer decryption).</p>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Encrypted relay list — only you can read it. Decrypt to reveal (read-only for now; editing comes with the encrypt side).</p>
+          <div id="rm-private-list" class="space-y-1.5"></div>
+          <p id="rm-private-status" class="mt-1 text-xs text-right text-text-secondary"></p>
         </div>
 
         <!-- ── App relays (local config) ── -->

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -455,6 +455,9 @@
         console.warn("Settings: cache fetch stalled — revealing content via watchdog");
         loadingEl.classList.add("hidden");
         if (contentEl) contentEl.classList.remove("hidden");
+        if (typeof window.scrollToSettingsTarget === "function") {
+          window.scrollToSettingsTarget();
+        }
       }
     }, 8000);
   </script>

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -405,6 +405,25 @@
         </details>
       </div>
 
+      <!-- Client tag (#99) -->
+      <div class="p-6 mb-8 text-left bg-surface rounded-lg">
+        <h2 class="mb-1 text-xl font-semibold text-text">🏷️ Client tag</h2>
+        <p class="mb-3 text-sm text-text-muted">
+          When on, grain stamps a <code>client:grain</code> tag on events you
+          publish (profile, relay &amp; media lists, notes) so others can see they
+          came from grain. grain always removes other apps' client tags. Turn this
+          off to publish without any client tag.
+        </p>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <input
+            id="client-tag-toggle"
+            type="checkbox"
+            onchange="window.grainClientTag && window.grainClientTag.set(this.checked)"
+          />
+          <span class="text-sm text-text">Stamp grain's client tag on my events</span>
+        </label>
+      </div>
+
       <!-- Key Information -->
       <div class="p-6 mb-8 bg-surface rounded-lg">
         <h2 class="mb-4 text-xl font-semibold text-text">
@@ -495,6 +514,16 @@
       // Give the script tag time to load
       setTimeout(safeInitializeSettings, 10);
     }
+
+    // Reflect the stored client-tag preference into its toggle (#99).
+    (function initClientTagToggle() {
+      var cb = document.getElementById("client-tag-toggle");
+      if (cb && window.grainClientTag) {
+        cb.checked = window.grainClientTag.enabled();
+      } else {
+        setTimeout(initClientTagToggle, 50);
+      }
+    })();
 
     // Watchdog: the relay-manager and media-servers sections load themselves,
     // independently of the cache fetch that hides this spinner. If that fetch

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -443,5 +443,19 @@
       // Give the script tag time to load
       setTimeout(safeInitializeSettings, 10);
     }
+
+    // Watchdog: the relay-manager and media-servers sections load themselves,
+    // independently of the cache fetch that hides this spinner. If that fetch
+    // stalls, don't hold the whole page hostage — reveal the content anyway so
+    // those sections are usable. (Session/key fields just stay "Loading…".)
+    setTimeout(function () {
+      var loadingEl = document.getElementById("loading");
+      var contentEl = document.getElementById("settings-content");
+      if (loadingEl && !loadingEl.classList.contains("hidden")) {
+        console.warn("Settings: cache fetch stalled — revealing content via watchdog");
+        loadingEl.classList.add("hidden");
+        if (contentEl) contentEl.classList.remove("hidden");
+      }
+    }, 8000);
   </script>
 </div>

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -219,7 +219,7 @@
       <!-- Media Servers (#83): where uploads go. The user's Blossom (kind
            10063) + NIP-96 (kind 10096) lists, plus grain's recommended
            quick-adds. Lists/rows are rendered by media-servers.js. -->
-      <div id="media-servers-section" class="p-6 mb-8 bg-surface rounded-lg">
+      <div id="media-servers-section" class="p-6 mb-8 text-left bg-surface rounded-lg">
         <h2 class="mb-1 text-xl font-semibold text-text">🗂️ Media servers</h2>
         <p class="mb-4 text-sm text-text-secondary">
           Where grain uploads your pictures and files. Add a server to upload
@@ -277,6 +277,26 @@
           >
         </p>
 
+        <!-- Save the Blossom (kind 10063) list on its own -->
+        <div
+          class="flex items-center justify-between gap-3 pt-3 mt-4 border-t border-border"
+        >
+          <p class="text-xs text-text-muted">
+            Publishes your <code>kind 10063</code> Blossom list.
+          </p>
+          <button
+            id="ms-blossom-save"
+            onclick="msSave('blossom')"
+            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+          >
+            Save &amp; sign
+          </button>
+        </div>
+        <p
+          id="ms-blossom-status"
+          class="mt-1 text-sm text-right text-text-secondary"
+        ></p>
+
         <!-- Legacy NIP-96 -->
         <details class="mt-6">
           <summary
@@ -311,25 +331,27 @@
               + Add
             </button>
           </div>
-        </details>
 
-        <!-- Save -->
-        <div
-          class="flex items-center justify-between gap-3 pt-4 mt-6 border-t border-border"
-        >
-          <p class="text-xs text-text-muted">
-            Saving publishes your <code>kind 10063</code> + <code>10096</code>
-            lists.
-          </p>
-          <button
-            id="ms-save-btn"
-            onclick="msSave()"
-            class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+          <!-- Save the NIP-96 (kind 10096) list on its own -->
+          <div
+            class="flex items-center justify-between gap-3 pt-3 mt-4 border-t border-border"
           >
-            Save &amp; sign
-          </button>
-        </div>
-        <p id="ms-status" class="mt-2 text-sm text-right text-text-secondary"></p>
+            <p class="text-xs text-text-muted">
+              Publishes your <code>kind 10096</code> NIP-96 list.
+            </p>
+            <button
+              id="ms-nip96-save"
+              onclick="msSave('nip96')"
+              class="px-4 py-2 text-sm transition-colors rounded-lg text-text-on-accent bg-accent hover:opacity-80"
+            >
+              Save &amp; sign
+            </button>
+          </div>
+          <p
+            id="ms-nip96-status"
+            class="mt-1 text-sm text-right text-text-secondary"
+          ></p>
+        </details>
       </div>
 
       <!-- Key Information -->

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -41,178 +41,177 @@
         </div>
       </div>
 
-      <!-- Relay Management -->
-      <div class="p-6 mb-8 bg-surface rounded-lg">
-        <h2 class="mb-4 text-xl font-semibold text-text">
-          📡 Relay Management
-        </h2>
+      <!-- Relay Manager (#98). The full role model; lists are rendered + edited
+           by relay-manager.js from /api/v1/user/relay-lists, published via the
+           relay-list build + streaming publish endpoints. -->
+      <div
+        id="relay-manager-section"
+        class="p-6 mb-8 text-left bg-surface rounded-lg"
+      >
+        <h2 class="mb-1 text-xl font-semibold text-text">📡 Relays</h2>
+        <p class="mb-4 text-sm text-text-secondary">
+          grain connects on demand under the outbox model — your mailboxes say
+          where you publish and where others reach you.
+        </p>
 
-        <!-- Tab Navigation -->
-        <div class="flex mb-6 border-b border-border-strong">
-          <button
-            id="client-relays-tab"
-            class="px-4 py-2 text-sm font-medium text-accent transition-colors border-b-2 border-blue-500"
-            onclick="switchRelayTab('client-relays')"
-          >
-            Client Relays
-          </button>
-          <button
-            id="mailboxes-tab"
-            class="px-4 py-2 text-sm font-medium text-text-secondary transition-colors border-b-2 border-transparent hover:text-text"
-            onclick="switchRelayTab('mailboxes')"
-          >
-            Mailboxes
-          </button>
-        </div>
-
-        <!-- Client Relays Tab Content -->
-        <div id="client-relays-content" class="relay-tab-content">
-          <div class="flex items-center justify-between mb-4">
-            <p class="text-sm text-text-secondary">Your configured client relays</p>
-            <div id="client-relay-buttons" class="space-x-2">
-              <button
-                id="edit-relays-btn"
-                onclick="toggleEditMode()"
-                class="px-4 py-2 text-sm text-text transition-colors bg-blue-600 rounded-lg hover:bg-accent-hover"
-              >
-                Edit
-              </button>
-              <button
-                id="save-relays-btn"
-                onclick="saveRelayChanges()"
-                class="hidden px-4 py-2 text-sm text-text transition-colors bg-green-600 rounded-lg hover:opacity-80"
-              >
-                Save
-              </button>
-              <button
-                id="import-mailboxes-btn"
-                onclick="importFromMailboxes()"
-                class="hidden px-4 py-2 text-sm text-text transition-colors bg-accent rounded-lg hover:bg-accent-hover"
-              >
-                Import from Mailboxes
-              </button>
-              <button
-                id="cancel-edit-btn"
-                onclick="cancelEdit()"
-                class="hidden px-4 py-2 text-sm text-text transition-colors bg-surface-overlay rounded-lg hover:bg-surface-hover"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-
-          <!-- View Mode: Client Relays Table -->
-          <div id="client-relays-view" class="overflow-x-auto">
-            <table class="w-full text-sm">
-              <thead>
-                <tr class="border-b border-border-strong">
-                  <th class="px-2 py-3 font-medium text-left text-text-secondary">
-                    Relay
-                  </th>
-                  <th
-                    class="w-20 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Status
-                  </th>
-                  <th
-                    class="w-20 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Ping
-                  </th>
-                  <th
-                    class="w-16 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Read
-                  </th>
-                  <th
-                    class="w-16 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Write
-                  </th>
-                </tr>
-              </thead>
-              <tbody id="client-relays-table">
-                <tr>
-                  <td colspan="5" class="py-8 text-center text-text-secondary">
-                    <div
-                      class="inline-block w-4 h-4 mr-2 border-2 border-white rounded-full animate-spin border-t-transparent"
-                    ></div>
-                    Loading relays...
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Edit Mode: Client Relays Form -->
-          <div id="client-relays-edit" class="hidden space-y-4">
-            <div class="p-4 bg-surface-elevated rounded-lg">
-              <h3 class="mb-4 text-lg font-medium text-text">
-                Edit Client Relays
-              </h3>
-              <div id="relay-form-list" class="space-y-3">
-                <!-- Dynamic relay form entries will be inserted here -->
-              </div>
-              <button
-                onclick="addNewRelayInput()"
-                class="px-4 py-2 mt-4 text-sm text-text transition-colors bg-blue-600 rounded-lg hover:bg-accent-hover"
-              >
-                + Add Relay
-              </button>
-            </div>
+        <!-- Connection overview (filled by relay-manager.js from client/status) -->
+        <div id="rm-overview" class="grid grid-cols-2 gap-2 mb-2 sm:grid-cols-4">
+          <div class="px-3 py-2 rounded-lg bg-surface-elevated">
+            <div class="text-xs text-text-secondary">Known</div>
+            <div class="text-xl font-semibold text-text">—</div>
           </div>
         </div>
 
-        <!-- Mailboxes Tab Content -->
-        <div id="mailboxes-content" class="hidden relay-tab-content">
-          <div class="mb-4">
-            <p class="text-sm text-text-secondary">
-              Your configured mailbox relays (NIP-65)
-            </p>
-          </div>
+        <!-- ── Public (NIP-65 / NIP-17) ── -->
+        <h3
+          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
+        >
+          Public · others can read these
+        </h3>
 
-          <!-- Mailboxes Table -->
-          <div class="overflow-x-auto">
-            <table class="w-full text-sm">
-              <thead>
-                <tr class="border-b border-border-strong">
-                  <th class="px-2 py-3 font-medium text-left text-text-secondary">
-                    Mailbox
-                  </th>
-                  <th
-                    class="w-20 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Status
-                  </th>
-                  <th
-                    class="w-20 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Ping
-                  </th>
-                  <th
-                    class="w-16 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Read
-                  </th>
-                  <th
-                    class="w-16 px-2 py-3 font-medium text-center text-text-secondary"
-                  >
-                    Write
-                  </th>
-                </tr>
-              </thead>
-              <tbody id="mailboxes-table">
-                <tr>
-                  <td colspan="5" class="py-8 text-center text-text-secondary">
-                    <div
-                      class="inline-block w-4 h-4 mr-2 border-2 border-white rounded-full animate-spin border-t-transparent"
-                    ></div>
-                    Loading mailboxes...
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+        <div class="mt-3">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">↑ Outbox</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10002 · write</span>
           </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Where you publish. Others fetch your notes here.</p>
+          <div id="rm-outbox-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-outbox-input" type="text" placeholder="Add an outbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAddOutbox()" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">↓ Inbox</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10002 · read</span>
+          </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Where replies, mentions, and zaps reach you.</p>
+          <div id="rm-inbox-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-inbox-input" type="text" placeholder="Add an inbox relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAddInbox()" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between gap-3 pt-3 mt-3 border-t border-border">
+          <span class="text-xs text-text-muted">Outbox + Inbox publish together as <code>kind 10002</code>.</span>
+          <button id="rm-nip65-save" onclick="rmSaveNip65()" class="px-4 py-2 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save &amp; sign</button>
+        </div>
+        <p id="rm-nip65-status" class="mt-1 text-xs text-right text-text-secondary"></p>
+
+        <div class="mt-5">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">✉ DM inbox</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10050 · NIP-17</span>
+          </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Where your private (gift-wrapped) direct messages are delivered.</p>
+          <div id="rm-dm-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-dm-input" type="text" placeholder="Add a DM relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAdd('dm')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+          <div class="flex items-center justify-between gap-3 mt-2">
+            <span class="text-xs text-text-muted">Publishes <code>kind 10050</code>.</span>
+            <button onclick="rmSave('dm')" class="px-4 py-1.5 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save &amp; sign</button>
+          </div>
+          <p id="rm-dm-status" class="mt-1 text-xs text-right text-text-secondary"></p>
+        </div>
+
+        <!-- ── Your lists (NIP-51 / NIP-37) ── -->
+        <h3
+          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
+        >
+          Your lists
+        </h3>
+
+        <div class="mt-3">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">🔍 Search</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10007</span>
+          </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Relays grain queries when you search.</p>
+          <div id="rm-search-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-search-input" type="text" placeholder="Add a search relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAdd('search')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+          <div class="flex items-center justify-between gap-3 mt-2">
+            <span class="text-xs text-text-muted">Publishes <code>kind 10007</code>.</span>
+            <button onclick="rmSave('search')" class="px-4 py-1.5 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save &amp; sign</button>
+          </div>
+          <p id="rm-search-status" class="mt-1 text-xs text-right text-text-secondary"></p>
+        </div>
+
+        <div class="mt-5">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">★ Favorites</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10012</span>
+          </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">Relays you've starred to browse.</p>
+          <div id="rm-favorites-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-favorites-input" type="text" placeholder="Add a favorite relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAdd('favorites')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+          <div class="flex items-center justify-between gap-3 mt-2">
+            <span class="text-xs text-text-muted">Publishes <code>kind 10012</code>.</span>
+            <button onclick="rmSave('favorites')" class="px-4 py-1.5 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save &amp; sign</button>
+          </div>
+          <p id="rm-favorites-status" class="mt-1 text-xs text-right text-text-secondary"></p>
+        </div>
+
+        <div class="mt-5">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">⛔ Blocked</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10006</span>
+          </div>
+          <p class="mt-0.5 mb-2 text-xs text-text-muted">grain never connects to these.</p>
+          <div id="rm-blocked-list" class="space-y-1.5"></div>
+          <div class="flex gap-2 mt-2">
+            <input id="rm-blocked-input" type="text" placeholder="Add a blocked relay…" class="flex-1 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border" />
+            <button onclick="rmAdd('blocked')" class="px-3 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">+ Add</button>
+          </div>
+          <div class="flex items-center justify-between gap-3 mt-2">
+            <span class="text-xs text-text-muted">Publishes <code>kind 10006</code>.</span>
+            <button onclick="rmSave('blocked')" class="px-4 py-1.5 text-sm rounded-lg text-text-on-accent bg-accent hover:opacity-80">Save &amp; sign</button>
+          </div>
+          <p id="rm-blocked-status" class="mt-1 text-xs text-right text-text-secondary"></p>
+        </div>
+
+        <div class="mt-5 opacity-60">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-text">🔒 Private</span>
+            <span class="px-1.5 py-0.5 font-mono text-xs rounded bg-surface-inset-strong text-text-secondary">10013 · NIP-37</span>
+            <span class="px-2 py-0.5 ml-auto text-xs rounded bg-surface-inset text-text-muted">coming soon</span>
+          </div>
+          <p class="mt-0.5 text-xs text-text-muted">Encrypted relay list — only you can read it (needs signer decryption).</p>
+        </div>
+
+        <!-- ── App relays (local config) ── -->
+        <h3
+          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
+        >
+          App relays · grain's plumbing
+        </h3>
+        <div id="rm-app-relays" class="space-y-3"></div>
+
+        <!-- Fixed-relay override -->
+        <div class="p-4 mt-6 border rounded-lg border-warning bg-warning-dim">
+          <label class="flex items-center justify-between gap-3 cursor-pointer">
+            <span class="text-sm font-medium text-warning">⚠ Fixed relays (advanced)</span>
+            <input id="rm-fixed-toggle" type="checkbox" onchange="rmToggleFixed()" />
+          </label>
+          <p class="mt-1 text-xs text-warning">
+            Read from / write to one fixed set only. <span class="font-semibold">Turns off the outbox model</span> — your replies won't reach others' inboxes. Off by default; not recommended.
+          </p>
+          <div id="rm-fixed-inputs" class="hidden mt-3 space-y-2">
+            <textarea id="rm-fixed-read" rows="2" placeholder="Read relays — one per line" class="w-full px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"></textarea>
+            <textarea id="rm-fixed-write" rows="2" placeholder="Write relays — one per line" class="w-full px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"></textarea>
+            <button onclick="rmApplyFixed()" class="px-4 py-2 text-sm rounded-lg text-text bg-surface-elevated hover:bg-surface-hover">Apply fixed relays</button>
+          </div>
+          <p id="rm-fixed-status" class="mt-1 text-xs text-warning"></p>
         </div>
       </div>
 
@@ -417,6 +416,7 @@
        must load first; media-servers.js self-initialises when its section is in
        the DOM. -->
   <script src="/static/js/nostr-publish.js"></script>
+  <script src="/static/js/relay-manager.js"></script>
   <script src="/static/js/media-servers.js"></script>
   <script>
     // Safe initialization that waits for both DOM and script to be ready

--- a/www/views/settings.html
+++ b/www/views/settings.html
@@ -198,24 +198,38 @@
         </h3>
         <div id="rm-app-relays" class="space-y-3"></div>
 
-        <!-- ── Known relays (browse + add) ── -->
-        <h3
-          class="pb-1.5 mt-6 mb-2 text-xs font-medium tracking-wide uppercase border-b text-text-secondary border-border"
-        >
-          Known relays · browse + add
-        </h3>
-        <p class="mb-2 text-xs text-text-muted">
-          Every relay grain has seen — defaults, your mailboxes, and ones it's
-          connected to. Expand a row for its NIP-11 info; add any to your lists.
-        </p>
-        <input
-          id="rm-known-search"
-          type="text"
-          placeholder="Filter known relays…"
-          oninput="rmKnownSearch(this.value)"
-          class="w-full px-3 py-2 mb-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"
-        />
-        <div id="rm-known-list" class="space-y-1.5 overflow-y-auto max-h-96"></div>
+        <!-- ── Known relays (browse + add) — accent card so it stands apart ── -->
+        <div class="p-4 mt-6 border rounded-xl border-accent bg-accent-dim">
+          <div class="flex items-center gap-2">
+            <span class="text-lg leading-none">🌐</span>
+            <h3 class="text-sm font-semibold tracking-wide uppercase text-accent">
+              Known relays · browse &amp; add
+            </h3>
+          </div>
+          <p class="mt-1 mb-3 text-xs text-text-secondary">
+            Every relay grain has seen — defaults, your mailboxes, and ones it's
+            connected to. Expand a row for its NIP-11 info; add any to your lists.
+          </p>
+          <div class="flex gap-2 mb-2">
+            <input
+              id="rm-known-search"
+              type="text"
+              placeholder="Filter known relays…"
+              oninput="rmKnownSearch(this.value)"
+              class="flex-1 min-w-0 px-3 py-2 text-sm border rounded-lg bg-surface-elevated text-text border-border"
+            />
+            <select
+              id="rm-known-sort"
+              onchange="rmKnownSort(this.value)"
+              title="How to order the list"
+              class="px-2 py-2 text-sm border rounded-lg shrink-0 bg-surface-elevated text-text border-border"
+            >
+              <option value="relevance">Sort: relevant</option>
+              <option value="ping">Sort: fastest</option>
+            </select>
+          </div>
+          <div id="rm-known-list" class="space-y-1.5 overflow-y-auto max-h-96"></div>
+        </div>
 
         <!-- Fixed-relay override -->
         <div class="p-4 mt-6 border rounded-lg border-warning bg-warning-dim">

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -13,6 +13,22 @@
   before someone else does.
 </div>
 
+<!-- No-relay-list nudge for a logged-in user who hasn't published a NIP-65
+     relay list yet (new identity). Revealed by navigation.js. -->
+<div
+  id="no-relays-banner"
+  class="hidden px-4 py-2 text-sm font-medium text-center bg-warning-dim text-warning"
+>
+  ⚠ You haven't set up your relays —
+  <a
+    href="/settings"
+    class="underline"
+    onclick="if(window.openRelaySettings){event.preventDefault();window.openRelaySettings();}"
+    >set up relays</a
+  >
+  so your notes and lists reach the right places.
+</div>
+
 <header
   class="relative flex items-center gap-3 px-4 mt-6 mb-6"
   hx-boost="true"

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -204,23 +204,59 @@
       </svg>
     </button>
 
-    <!-- Relay-pool indicator: how many relays the outbox pool has connected
-         out of the total it's tracking. Updated by the poller in the script
-         block below from /api/v1/client/status. Hidden on the narrowest
-         screens to keep the header uncluttered. -->
-    <div
-      id="relay-pool-status"
-      class="items-center hidden gap-1 px-2 py-1 font-mono text-xs rounded sm:flex text-text-secondary bg-surface-elevated"
-      title="Relays connected / total tracked by the outbox pool"
-    >
-      <span id="relay-pool-dot" class="text-text-secondary">●</span>
-      <span id="relay-pool-count">—/—</span>
-      <span class="hidden md:inline">relays</span>
-    </div>
-
     <!-- Login / profile button. Always present; content updated by
          navigation.js. -->
     <div id="profile-nav">{{template "login-button"}}</div>
+
+    <!-- Relay-pool indicator: connected / known relays, between the login
+         button and the theme swapper. Clicking toggles a breakdown panel; the
+         full relay manager lands in a later slice. Updated by the poller below
+         from /api/v1/client/status. -->
+    <div class="relative">
+      <button
+        id="relay-pool-button"
+        type="button"
+        title="Relay pool — connected / known relays"
+        class="flex items-center gap-1 px-2 py-1 text-xs rounded text-text-secondary hover:text-text hover:bg-surface-hover"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"
+          ></path>
+        </svg>
+        <span id="relay-pool-count" class="font-mono">—/—</span>
+      </button>
+      <div
+        id="relay-pool-panel"
+        class="absolute right-0 z-50 hidden p-3 mt-2 text-xs border rounded-lg shadow w-52 bg-surface border-border top-full"
+      >
+        <div class="mb-2 font-semibold text-text">Relay pool</div>
+        <div class="space-y-1">
+          <div class="flex justify-between">
+            <span class="text-text-secondary">Known</span>
+            <span id="rp-known" class="font-mono text-text">—</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-text-secondary">Connected</span>
+            <span id="rp-connected" class="font-mono text-text">—</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-text-secondary">In use</span>
+            <span id="rp-leased" class="font-mono text-text">—</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-text-secondary">Pinned (index)</span>
+            <span id="rp-pinned" class="font-mono text-text">—</span>
+          </div>
+        </div>
+        <div class="pt-2 mt-2 border-t text-text-secondary border-border">
+          Full relay manager coming soon.
+        </div>
+      </div>
+    </div>
 
     <!-- Theme swapper. Icon-only trigger + dropdown panel populated
          by theme.js. Sits to the right of the login button per the
@@ -269,26 +305,45 @@
   };
 
   // Relay-pool indicator. Polls /api/v1/client/status and shows
-  // connected/total relays the outbox pool is tracking. Best-effort: if the
-  // relay is unreachable the indicator just keeps its last value.
+  // connected/known relays; the button toggles a breakdown panel. Best-effort:
+  // if the relay is unreachable the indicator keeps its last value.
   (function () {
+    var btn = document.getElementById("relay-pool-button");
+    var panel = document.getElementById("relay-pool-panel");
     var count = document.getElementById("relay-pool-count");
-    var dot = document.getElementById("relay-pool-dot");
     if (!count) return;
+
+    function set(id, v) {
+      var el = document.getElementById(id);
+      if (el) el.textContent = v;
+    }
+
     function refresh() {
       fetch("/api/v1/client/status")
         .then(function (r) { return r.ok ? r.json() : null; })
         .then(function (s) {
           if (!s || !s.initialized) return;
-          var connected = s.pool_connected || 0;
-          var total = s.pool_total || 0;
-          count.textContent = connected + "/" + total;
-          if (dot) dot.className = connected > 0 ? "text-success" : "text-text-secondary";
+          count.textContent = (s.pool_connected || 0) + "/" + (s.pool_known || 0);
+          set("rp-known", s.pool_known || 0);
+          set("rp-connected", s.pool_connected || 0);
+          set("rp-leased", s.pool_leased || 0);
+          set("rp-pinned", s.pool_pinned || 0);
         })
         .catch(function () {});
     }
+
+    if (btn && panel) {
+      btn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        panel.classList.toggle("hidden");
+      });
+      document.addEventListener("click", function () {
+        panel.classList.add("hidden");
+      });
+    }
+
     refresh();
-    setInterval(refresh, 10000);
+    setInterval(refresh, 4000);
   })();
 </script>
 

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -339,11 +339,18 @@
     if (btn && panel) {
       btn.addEventListener("click", function (e) {
         e.stopPropagation();
-        // Opening: close any other header dropdown (profile, theme) first.
+        // Opening: close any other header dropdown (profile, theme) first, and
+        // warm the relay-list + media-server caches (once) so "Manage relays"
+        // lands on already-resolved data instead of a cold ~5s relay fetch.
         if (panel.classList.contains("hidden")) {
           window.dispatchEvent(
             new CustomEvent("grain:dropdown-open", { detail: "relay-pool" })
           );
+          if (!window.__relayCachesWarmed) {
+            window.__relayCachesWarmed = true;
+            fetch("/api/v1/user/relay-lists").catch(function () {});
+            fetch("/api/v1/user/media-servers").catch(function () {});
+          }
         }
         panel.classList.toggle("hidden");
       });
@@ -369,25 +376,15 @@
   window.openRelaySettings = function () {
     var panel = document.getElementById("relay-pool-panel");
     if (panel) panel.classList.add("hidden");
+    // settings.js scrolls here once the content is visible (handles both the
+    // normal load and the watchdog-reveal path deterministically).
+    window.__grainScrollTarget = "relay-manager-section";
     if (typeof htmx === "undefined") {
       window.location.href = "/settings";
       return;
     }
     window.history.pushState({}, "", "/settings");
-    htmx
-      .ajax("GET", "/views/settings.html", { target: "#main-content" })
-      .then(function () {
-        var tries = 0;
-        (function scrollWhenReady() {
-          var sec = document.getElementById("relay-manager-section");
-          // offsetParent is null while #settings-content is still hidden.
-          if (sec && sec.offsetParent !== null) {
-            sec.scrollIntoView({ behavior: "smooth", block: "start" });
-            return;
-          }
-          if (tries++ < 120) setTimeout(scrollWhenReady, 100); // up to ~12s
-        })();
-      });
+    htmx.ajax("GET", "/views/settings.html", { target: "#main-content" });
   };
 </script>
 

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -204,6 +204,20 @@
       </svg>
     </button>
 
+    <!-- Relay-pool indicator: how many relays the outbox pool has connected
+         out of the total it's tracking. Updated by the poller in the script
+         block below from /api/v1/client/status. Hidden on the narrowest
+         screens to keep the header uncluttered. -->
+    <div
+      id="relay-pool-status"
+      class="items-center hidden gap-1 px-2 py-1 font-mono text-xs rounded sm:flex text-text-secondary bg-surface-elevated"
+      title="Relays connected / total tracked by the outbox pool"
+    >
+      <span id="relay-pool-dot" class="text-text-secondary">●</span>
+      <span id="relay-pool-count">—/—</span>
+      <span class="hidden md:inline">relays</span>
+    </div>
+
     <!-- Login / profile button. Always present; content updated by
          navigation.js. -->
     <div id="profile-nav">{{template "login-button"}}</div>
@@ -253,6 +267,29 @@
       if (input) setTimeout(function () { input.focus(); }, 50);
     }
   };
+
+  // Relay-pool indicator. Polls /api/v1/client/status and shows
+  // connected/total relays the outbox pool is tracking. Best-effort: if the
+  // relay is unreachable the indicator just keeps its last value.
+  (function () {
+    var count = document.getElementById("relay-pool-count");
+    var dot = document.getElementById("relay-pool-dot");
+    if (!count) return;
+    function refresh() {
+      fetch("/api/v1/client/status")
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (s) {
+          if (!s || !s.initialized) return;
+          var connected = s.pool_connected || 0;
+          var total = s.pool_total || 0;
+          count.textContent = connected + "/" + total;
+          if (dot) dot.className = connected > 0 ? "text-success" : "text-text-secondary";
+        })
+        .catch(function () {});
+    }
+    refresh();
+    setInterval(refresh, 10000);
+  })();
 </script>
 
 <!-- Hidden template for navigation.js to swap the logged-out

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -339,10 +339,20 @@
     if (btn && panel) {
       btn.addEventListener("click", function (e) {
         e.stopPropagation();
+        // Opening: close any other header dropdown (profile, theme) first.
+        if (panel.classList.contains("hidden")) {
+          window.dispatchEvent(
+            new CustomEvent("grain:dropdown-open", { detail: "relay-pool" })
+          );
+        }
         panel.classList.toggle("hidden");
       });
       document.addEventListener("click", function () {
         panel.classList.add("hidden");
+      });
+      // When another header dropdown opens, close this one.
+      window.addEventListener("grain:dropdown-open", function (e) {
+        if (e.detail !== "relay-pool") panel.classList.add("hidden");
       });
     }
 

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -252,9 +252,13 @@
             <span id="rp-pinned" class="font-mono text-text">—</span>
           </div>
         </div>
-        <div class="pt-2 mt-2 border-t text-text-secondary border-border">
-          Full relay manager coming soon.
-        </div>
+        <button
+          hx-get="/views/settings.html"
+          hx-target="#main-content"
+          class="flex items-center w-full gap-2 px-2 py-1.5 mt-2 text-xs text-left transition-colors border-t rounded text-text-secondary hover:text-text hover:bg-surface-hover border-border"
+        >
+          ⚙️ Manage relays
+        </button>
       </div>
     </div>
 

--- a/www/views/templates/header.html
+++ b/www/views/templates/header.html
@@ -253,8 +253,8 @@
           </div>
         </div>
         <button
-          hx-get="/views/settings.html"
-          hx-target="#main-content"
+          type="button"
+          onclick="openRelaySettings()"
           class="flex items-center w-full gap-2 px-2 py-1.5 mt-2 text-xs text-left transition-colors border-t rounded text-text-secondary hover:text-text hover:bg-surface-hover border-border"
         >
           ⚙️ Manage relays
@@ -359,6 +359,36 @@
     refresh();
     setInterval(refresh, 4000);
   })();
+
+  // "Manage relays" → open Settings and jump straight to the relay section.
+  // Done in JS rather than hx-get on the button: the button lives inside the
+  // relay-pool panel, which the document-click handler hides on the same click
+  // — that stranded the htmx request and left it spinning. Mirror routing.js's
+  // settings swap, then scroll to #relay-manager-section once the settings
+  // content becomes visible (it loads behind its own spinner / watchdog).
+  window.openRelaySettings = function () {
+    var panel = document.getElementById("relay-pool-panel");
+    if (panel) panel.classList.add("hidden");
+    if (typeof htmx === "undefined") {
+      window.location.href = "/settings";
+      return;
+    }
+    window.history.pushState({}, "", "/settings");
+    htmx
+      .ajax("GET", "/views/settings.html", { target: "#main-content" })
+      .then(function () {
+        var tries = 0;
+        (function scrollWhenReady() {
+          var sec = document.getElementById("relay-manager-section");
+          // offsetParent is null while #settings-content is still hidden.
+          if (sec && sec.offsetParent !== null) {
+            sec.scrollIntoView({ behavior: "smooth", block: "start" });
+            return;
+          }
+          if (tries++ < 120) setTimeout(scrollWhenReady, 100); // up to ~12s
+        })();
+      });
+  };
 </script>
 
 <!-- Hidden template for navigation.js to swap the logged-out

--- a/www/views/templates/layout.html
+++ b/www/views/templates/layout.html
@@ -72,6 +72,9 @@
          grain's session API loads right after. -->
     <script src="/static/mill/mill.umd.min.js?v={{assetVersion}}"></script>
     <script src="/static/js/mill-bridge.js?v={{assetVersion}}" defer></script>
+    <!-- Live update channel (SSE): opens one EventSource when logged in and
+         re-broadcasts pushes as `grain:stream` events. -->
+    <script src="/static/js/grain-stream.js?v={{assetVersion}}" defer></script>
 
     <title>{{.Title}}</title>
     <style>

--- a/www/views/templates/layout.html
+++ b/www/views/templates/layout.html
@@ -57,6 +57,9 @@
     <script src="/static/js/theme.js?v={{assetVersion}}"></script>
     <!-- Per-user client-tag preference (#99); read by the build-request callers. -->
     <script src="/static/js/client-tag.js?v={{assetVersion}}"></script>
+    <!-- Reusable media upload (#83): the pre-upload modal + Blossom/NIP-96 flow,
+         and declarative [data-upload-target] button wiring. -->
+    <script src="/static/js/blossom-upload.js?v={{assetVersion}}" defer></script>
 
     <!-- Load external libraries first. These will be replaced on build with local minified
      versions and the build step will replace the tailwind cdn and compile the full minified css -->

--- a/www/views/templates/layout.html
+++ b/www/views/templates/layout.html
@@ -55,6 +55,8 @@
          doesn't flash the wrong palette during paint. theme.js
          exposes window.GrainTheme for the header swapper. -->
     <script src="/static/js/theme.js?v={{assetVersion}}"></script>
+    <!-- Per-user client-tag preference (#99); read by the build-request callers. -->
+    <script src="/static/js/client-tag.js?v={{assetVersion}}"></script>
 
     <!-- Load external libraries first. These will be replaced on build with local minified
      versions and the build step will replace the tailwind cdn and compile the full minified css -->


### PR DESCRIPTION
The accumulated **v0.8** work, held off `main` under the RC hold and opened as a PR so CI validates the whole batch (build + integration tests, including the cgo-dependent suites) before it lands. **85 commits** on the v0.8 theme: the importable client library plus the frontend that exposes it as the implementation reference.

## Highlights

**Client library (`client/core`) — outbox-model engine (#56)**
- Leased additive relay pool, `Role` vocabulary + routing, `UserContext` facade, multi-relay streaming-fetch primitive.
- `context.Context` threaded through the read **and** publish paths.
- Pluggable seams — `Signer`, `Logger` (`SetLogger`), `RelayListStore` — each with compile-checked examples.

**Protocol**
- NIP-44 v2 + v3 encryption, validated against the official test vectors (#100).
- NIP-42 session AUTH — per-relay authenticate UI (#101).
- NIP-65 / NIP-17 / NIP-51 / NIP-37 relay-list resolve + publish; NIP-89 client tag (strip-foreign + stamp, user opt-out) (#99).

**Frontend reference**
- Relay manager + known-relays browser — NIP-11 on expand, ping sort, stage-into-list (#98).
- Media-server lists + Blossom / NIP-96 uploads with a pre-upload modal (#83).
- Profile inline editor + new-user onboarding (empty editable profile, set-up-relays banner).
- Live homepage relay-stream feed (#77); live-sync own-event channel (#87).
- Dashboard polish (author names, newest-first feed, expandable NIPs, AUTH "Required"); admin reorg + client-config + repaired OpenAPI docs (#80).

**Docs**
- Comprehensive client-library guide covering the full 0.8.0 surface, with compile-checked examples in `client/core/example_test.go`.

## CI
This PR runs the `CI / Integration tests` workflow (docker-compose integration suite + host-side nostrdb build + `go test ./...`). Merging to `main` is the 0.8 RC.

> Heads-up for the run: per #78, the NIP-86 fixture bind-mounts have a few known pre-existing failures, and `TagFilterE` is known-flaky — worth distinguishing those from anything new.
